### PR TITLE
Implement OAuth2 per client credentials flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
+# app secrets ######
+
+/src/config/secrets.js
+
+
 # expo ######
 
 .expo/*

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Currently used colors in the mobile app:
 
 https://coolors.co/08743c-bbbe64-222222-26798e-ffffff
 
+## Documentation
+
+For detailed documentation see the [docs](./docs/INDEX.md).
+
 ## Tech Stack
 
 Information about currently used packages and their versions:

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -1,0 +1,12 @@
+# Smart Village App Auth Documentation
+
+You can find the documentation of the app's auth implementation here.
+
+## Secrets
+
+You need to provide necessary credentials per secrets-File in
+[/src/config](../src/config) to be able to fetch data from the server.
+
+You can use the [example file](../src/config/secrets.temp) with the keys needed.
+Change the file extension from `.temp` to `.js`, remove the comment and enter your data.
+The js-file needs to be listed in the [.gitignore](../.gitignore) file.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,23 @@
+# Smart Village App Documentation
+
+Detailed documentation of the app's code will grow here.
+
+## Run the app
+
+To start the app simply use one of the following commands.
+
+* only packager and Expo dev tools: `npm start` or `yarn start`
+* iOS: `npm run ios` or `yarn ios`
+* Android: `npm run android` or `yarn android`
+
+## Test the app
+
+For executing tests run `npm run test` or `yarn test`.
+
+## Lint the app
+
+For executing linters run `npm run lint` or `yarn lint`.
+
+## Auth
+
+For detailed documentation see [the auth docs](./AUTH.md).

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "apollo-cache-inmemory": "^1.6.0",
     "apollo-cache-persist": "^0.1.1",
     "apollo-client": "^2.6.0",
+    "apollo-link-context": "^1.0.17",
     "apollo-link-http": "^1.5.14",
     "expo": "^32.0.0",
     "graphql": "^14.3.0",

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,25 @@
+import { SecureStore } from 'expo';
+
+import { secrets } from './config';
+
+export const auth = (callback) => {
+  const fetchObj = {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      client_id: secrets.oAuthClientId,
+      client_secret: secrets.oAuthClientSecret,
+      grant_type: secrets.oAuthGrantType
+    })
+  };
+
+  fetch(`${secrets.serverUrl}${secrets.oAuthTokenEndpoint}`, fetchObj)
+    .then((res) => res.json())
+    .then((json) => {
+      SecureStore.setItemAsync('ACCESS_TOKEN', json.access_token);
+    })
+    .then(() => callback && callback());
+};

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,5 +1,6 @@
 export * from './colors';
 export * from './device';
 export * from './normalize';
+export * from './secrets';
 export * from './styles';
 export * from './texts';

--- a/src/config/secrets.temp
+++ b/src/config/secrets.temp
@@ -1,0 +1,11 @@
+// you need to provide these data and rename this file to .js instead of .temp
+// in order to fetch data from the server
+export const secrets = {
+  serverUrl: '',
+  graphqlEndpoint: '',
+
+  oAuthTokenEndpoint: '',
+  oAuthClientId: '',
+  oAuthClientSecret: '',
+  oAuthGrantType: ''
+};

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,12 +1,8 @@
-import {
-  GET_EVENT_RECORD,
-  GET_EVENT_RECORDS,
-  GET_NEWS_ITEM,
-  GET_NEWS_ITEMS,
-  GET_POINT_OF_INTEREST,
-  GET_POINTS_OF_INTEREST,
-  GET_PUBLIC_JSON_FILE
-} from '../queries';
+import { GET_EVENT_RECORD, GET_EVENT_RECORDS } from './eventRecords';
+import { GET_NEWS_ITEM, GET_NEWS_ITEMS } from './newsItems';
+import { GET_POINT_OF_INTEREST, GET_POINTS_OF_INTEREST } from './pointsOfInterest';
+import { GET_PUBLIC_HTML_FILE } from './publicHtmlFiles';
+import { GET_PUBLIC_JSON_FILE } from './publicJsonFiles';
 
 export const getQuery = (query) => {
   switch (query) {
@@ -22,13 +18,9 @@ export const getQuery = (query) => {
     return GET_POINT_OF_INTEREST;
   case 'pointsOfInterest':
     return GET_POINTS_OF_INTEREST;
+  case 'publicHtmlFile':
+    return GET_PUBLIC_HTML_FILE;
   case 'publicJsonFile':
     return GET_PUBLIC_JSON_FILE;
   }
 };
-
-export * from './eventRecords';
-export * from './newsItems';
-export * from './pointsOfInterest';
-export * from './publicHtmlFiles';
-export * from './publicJsonFiles';

--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Query } from 'react-apollo';
 
+import { auth } from '../auth';
 import { colors, normalize } from '../config';
 import {
   HtmlView,
@@ -19,7 +20,7 @@ import { getQuery } from '../queries';
 import { arrowLeft, drawerMenu, share } from '../icons';
 import { momentFormat, openShare, trimNewLines } from '../helpers';
 
-export class DetailScreen extends React.Component {
+export class DetailScreen extends React.PureComponent {
   static navigationOptions = ({ navigation }) => {
     const shareContent = navigation.getParam('shareContent', '');
 
@@ -43,6 +44,10 @@ export class DetailScreen extends React.Component {
       )
     };
   };
+
+  componentDidMount() {
+    auth();
+  }
 
   render() {
     const { navigation } = this.props;

--- a/src/screens/HtmlScreen.js
+++ b/src/screens/HtmlScreen.js
@@ -3,13 +3,14 @@ import React from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Query } from 'react-apollo';
 
+import { auth } from '../auth';
 import { colors, normalize } from '../config';
 import { Button, HtmlView, Icon, Wrapper } from '../components';
 import { trimNewLines } from '../helpers';
-import { GET_PUBLIC_HTML_FILE } from '../queries';
+import { getQuery } from '../queries';
 import { arrowLeft } from '../icons';
 
-export class HtmlScreen extends React.Component {
+export class HtmlScreen extends React.PureComponent {
   static navigationOptions = ({ navigation }) => {
     return {
       headerLeft: (
@@ -22,6 +23,10 @@ export class HtmlScreen extends React.Component {
     };
   };
 
+  componentDidMount() {
+    auth();
+  }
+
   render() {
     const { navigation } = this.props;
     const queryVariables = navigation.getParam('queryVariables', '');
@@ -32,7 +37,7 @@ export class HtmlScreen extends React.Component {
 
     return (
       <Query
-        query={GET_PUBLIC_HTML_FILE}
+        query={getQuery('publicHtmlFile')}
         variables={{ name: queryVariables.name }}
         fetchPolicy="cache-and-network"
       >

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -3,13 +3,14 @@ import React from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Query } from 'react-apollo';
 
+import { auth } from '../auth';
 import { colors, normalize } from '../config';
 import { CardList, Icon, TextList } from '../components';
 import { getQuery } from '../queries';
 import { arrowLeft } from '../icons';
 import { momentFormat, shareMessage } from '../helpers';
 
-export class IndexScreen extends React.Component {
+export class IndexScreen extends React.PureComponent {
   static navigationOptions = ({ navigation }) => {
     return {
       headerLeft: (
@@ -21,6 +22,10 @@ export class IndexScreen extends React.Component {
       )
     };
   };
+
+  componentDidMount() {
+    auth();
+  }
 
   render() {
     const { navigation } = this.props;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1326,6 +1326,14 @@ apollo-client@^2.6.0:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
+apollo-link-context@^1.0.17:
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/apollo-link-context/-/apollo-link-context-1.0.17.tgz#439272cfb43ec1891506dd175ed907845b7de36c"
+  integrity sha512-W5UUfHcrrlP5uqJs5X1zbf84AMXhPZGAqX/7AQDgR6wY/7//sMGfJvm36KDkpIeSOElztGtM9z6zdPN1NbT41Q==
+  dependencies:
+    apollo-link "^1.2.11"
+    tslib "^1.9.3"
+
 apollo-link-http-common@^0.2.13:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.13.tgz#c688f6baaffdc7b269b2db7ae89dae7c58b5b350"


### PR DESCRIPTION
- https://github.com/doorkeeper-gem/doorkeeper/wiki/Client-Credentials-flow
- using .gitignore secrets file with credentials
  - info in /docs/AUTH.md
- added authentication on startup before creating the apollo client
  - the access token is needed for creating it
  - save it in SecureStore https://docs.expo.io/versions/v32.0.0/sdk/securestore/
- added authentication refresh on screen component mounts
- changed Component to PureComponent in screens because they are stateless
- updated usage of `getQuery` where missing
- added more docs