### PR TITLE
Feature/poi detail screen

### DIFF
--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -7,6 +7,11 @@ export const RegularText = styled.Text`
   flex: 1;
   font-family: titillium-web-regular;
   font-size: ${normalize(16)};
+  ${(props) =>
+    props.linkText &&
+    css`
+      color: ${colors.primary};
+    `};
 `;
 
 export const BoldText = styled(RegularText)`

--- a/src/components/screens/InfoCard.js
+++ b/src/components/screens/InfoCard.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 
 import { colors, normalize } from '../../config';
 import { mail, location, phone as phoneIcon, url as urlIcon } from '../../icons';
-import { openLink } from '../../helpers';
+import { openLink, locationLink, locationString } from '../../helpers';
 import { RegularText } from '../Text';
 import { Icon } from '../Icon';
 import { Wrapper } from '../Wrapper';
@@ -16,6 +16,13 @@ const InfoBox = styled.View`
   flex-direction: row;
   margin-bottom: ${normalize(5)}px;
 `;
+
+const _onPress = (address) => {
+  const mapsString = locationString(address);
+  const mapsLink = locationLink(mapsString);
+
+  openLink(mapsLink);
+};
 
 export const InfoCard = ({ addresses, category, contact, webUrls }) => (
   <Wrapper>
@@ -52,7 +59,9 @@ export const InfoCard = ({ addresses, category, contact, webUrls }) => (
         return (
           <InfoBox key={index}>
             <Icon icon={location(colors.primary)} style={styles.margin} />
-            <RegularText>{address}</RegularText>
+            <TouchableOpacity onPress={() => _onPress(address)}>
+              <RegularText linkText>{address}</RegularText>
+            </TouchableOpacity>
           </InfoBox>
         );
       })}
@@ -73,14 +82,16 @@ export const InfoCard = ({ addresses, category, contact, webUrls }) => (
         {!!contact.phone && (
           <InfoBox>
             <Icon icon={phoneIcon(colors.primary)} style={styles.margin} />
-            <RegularText>{contact.phone}</RegularText>
+            <TouchableOpacity onPress={() => openLink(`tel:${contact.phone}`)}>
+              <RegularText linkText>{contact.phone}</RegularText>
+            </TouchableOpacity>
           </InfoBox>
         )}
         {!!contact.email && (
           <InfoBox>
             <Icon icon={mail(colors.primary)} style={styles.margin} />
             <TouchableOpacity onPress={() => openLink(`mailto:${contact.email}`)}>
-              <RegularText>{contact.email}</RegularText>
+              <RegularText linkText>{contact.email}</RegularText>
             </TouchableOpacity>
           </InfoBox>
         )}
@@ -97,7 +108,7 @@ export const InfoCard = ({ addresses, category, contact, webUrls }) => (
           <InfoBox key={index}>
             <Icon icon={urlIcon(colors.primary)} style={styles.margin} />
             <TouchableOpacity onPress={() => openLink(url)}>
-              <RegularText>{url}</RegularText>
+              <RegularText linkText>{url}</RegularText>
             </TouchableOpacity>
           </InfoBox>
         );

--- a/src/components/screens/PriceCard.js
+++ b/src/components/screens/PriceCard.js
@@ -5,9 +5,10 @@ import styled from 'styled-components/native';
 import { device, normalize } from '../../config';
 import { DiagonalGradient, WrapperPrice } from '../../components';
 import { PriceText } from '../Text';
+import { priceFormat } from '../../helpers';
 
 const PreiceBox = styled.View`
-  background-color: #3f745f;
+  background-color: rgba(15, 70, 24, 0.6);
   flex-direction: column;
   margin-bottom: ${normalize(14)};
   padding: ${normalize(7)}px;
@@ -37,11 +38,11 @@ export const PriceCard = ({ prices }) => (
           return (
             <PreiceBox key={index}>
               {!!category && <PriceText bold>{category}</PriceText>}
+              {!!amount && <PriceText bold>{priceFormat(amount)}</PriceText>}
+              {!!groupPrice && <PriceText bold>{priceFormat(groupPrice)}</PriceText>}
               {!!description && <PriceText>{description}</PriceText>}
               {!!maxAdultCount && <PriceText>{maxAdultCount} Erwachsene</PriceText>}
               {!!maxChildrenCount && <PriceText>{maxChildrenCount} Kinder</PriceText>}
-              {!!amount && <PriceText bold>EUR {amount}</PriceText>}
-              {!!groupPrice && <PriceText bold>EUR {groupPrice}</PriceText>}
             </PreiceBox>
           );
         })}

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,4 +1,5 @@
 export * from './htmlViewHelper';
 export * from './linkHelper';
 export * from './momentHelper';
+export * from './priceHelper';
 export * from './shareHelper';

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,5 +1,6 @@
 export * from './htmlViewHelper';
 export * from './linkHelper';
+export * from './mapHelper';
 export * from './momentHelper';
 export * from './priceHelper';
 export * from './shareHelper';

--- a/src/helpers/mapHelper.js
+++ b/src/helpers/mapHelper.js
@@ -1,0 +1,19 @@
+import { Platform } from 'react-native';
+
+export function locationString(address) {
+  if (!address) return '';
+
+  return encodeURIComponent(address);
+}
+
+// a maps link is different between the platforms
+export function locationLink(mapsString) {
+  switch (Platform.OS) {
+  case 'ios':
+    return `maps:0,0?q=${mapsString}`;
+  case 'android':
+    return `geo:0,0?q=${mapsString}`;
+  default:
+    return `https://maps.google.com/?q=${mapsString}`;
+  }
+}

--- a/src/helpers/priceHelper.js
+++ b/src/helpers/priceHelper.js
@@ -1,0 +1,13 @@
+/**
+ * Formatting floating-point numbers from data in to prices (1.2 => 1,20 EUR)
+ *
+ * @param {number} price the required number to format
+ *
+ * @return {string} a formatted string in the de-DE locale and with currency code
+ */
+export const priceFormat = (price) =>
+  new Intl.NumberFormat('de-DE', {
+    style: 'currency',
+    currency: 'EUR',
+    currencyDisplay: 'code'
+  }).format(price);


### PR DESCRIPTION
Completed priceCard and InfoCard:
**InfoCard**
- added a lot of checks for presence before rendering
  - we only want to render things if there is data
- refactored Text components to use them more globally
- transformed each info into a link using onPress navigates to correlated location
  - using mapHelper to link to maps
  - using tel from openLink/helpers to make a call phone
- passing a prop linkText that changes the color of taxt from black to green color of links

**priceCard**
- background color of each single priceBox is now with opacity (0.6)
- created and using a price helper able to format any number in to a price
 - as a guide : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString

