### PR TITLE
Feature/include html table renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-native-elements": "^1.1.0",
     "react-native-linear-gradient": "^2.5.4",
     "react-native-render-html": "^4.1.2",
+    "react-native-render-html-table-bridge": "^0.3.1",
     "react-native-svg-uri": "^1.2.3",
     "react-native-webview": "~5.8.1",
     "react-navigation": "^3.11.0",

--- a/src/components/HtmlView.js
+++ b/src/components/HtmlView.js
@@ -1,20 +1,31 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import HTML from 'react-native-render-html';
+import { IGNORED_TAGS, alterNode, makeTableRenderer } from 'react-native-render-html-table-bridge';
+import { WebView } from 'react-native-webview';
 
-import { colors, device, normalize, styles } from '../config';
+import { device, normalize, styles } from '../config';
 import { openLink } from '../helpers';
+
+const renderers = {
+  table: makeTableRenderer({
+    WebViewComponent: WebView
+  })
+};
+
+const htmlConfig = {
+  alterNode,
+  renderers,
+  ignoredTags: IGNORED_TAGS
+};
 
 export const HtmlView = (props) => (
   <HTML
     {...props}
+    {...htmlConfig}
     tagsStyles={{ ...styles.html, ...props.tagsStyles }}
     emSize={normalize(16)}
-    baseFontStyle={{
-      color: colors.darkText,
-      fontFamily: 'titillium-web-regular',
-      fontSize: normalize(16)
-    }}
+    baseFontStyle={styles.baseFontStyle}
     imagesMaxWidth={device.width}
     staticContentMaxWidth={device.width}
     onLinkPress={(evt, href) => openLink(href)}

--- a/src/components/HtmlView.js
+++ b/src/components/HtmlView.js
@@ -1,15 +1,49 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import HTML from 'react-native-render-html';
-import { IGNORED_TAGS, alterNode, makeTableRenderer } from 'react-native-render-html-table-bridge';
+import {
+  IGNORED_TAGS,
+  alterNode,
+  makeTableRenderer,
+  defaultTableStylesSpecs,
+  cssRulesFromSpecs
+} from 'react-native-render-html-table-bridge';
 import { WebView } from 'react-native-webview';
 
-import { device, normalize, styles } from '../config';
+import { colors, device, normalize, styles } from '../config';
 import { openLink } from '../helpers';
+
+const tableCssRules =
+  cssRulesFromSpecs({
+    ...defaultTableStylesSpecs,
+    linkColor: colors.primary,
+    // TODO: font family was not working at the moment with following implementation
+    //       https://github.com/jsamr/react-native-render-html-table-bridge/blob/master/readme.md#how-to-load-custom-fonts
+    // fontFamily: 'titillium-web-regular',
+    thColor: colors.lightestText,
+    trOddBackground: colors.lightestText,
+    trOddColor: colors.darkText,
+    trEvenBackground: colors.lightestText,
+    trEvenColor: colors.darkText
+  }) +
+  `
+:root {
+  font-size: ${normalize(13)}px;
+}
+th {
+  border-left: 0.25px solid ${'#3f5c7a'};
+  border-top: 0.25px solid ${'#3f5c7a'};
+}
+td {
+  border-left: 0.25px solid ${'#b5b5b5'};
+  border-top: 0.25px solid ${'#b5b5b5'};
+}
+`;
 
 const renderers = {
   table: makeTableRenderer({
-    WebViewComponent: WebView
+    WebViewComponent: WebView,
+    cssRules: tableCssRules
   })
 };
 

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -1,26 +1,29 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { StyleSheet, TouchableOpacity } from 'react-native';
 
-import { Linking, TouchableOpacity, View } from 'react-native';
-import styled from 'styled-components/native';
-
+import { colors, normalize } from '../config';
+import { openLink } from '../helpers';
 import { link } from '../icons';
-import { colors } from '../config';
 import { Icon } from './Icon';
-
-const LinkStyle = styled.Text`
-  color: ${colors.secondary};
-  font-family: titillium-web-bold;
-`;
+import { RegularText } from './Text';
+import { WrapperRowNoFlex } from './Wrapper';
 
 export const Link = ({ url, title }) => (
-  <TouchableOpacity onPress={() => Linking.openURL(url)}>
-    <View style={{ flexDirection: 'row' }}>
-      <LinkStyle>{title}</LinkStyle>
-      <Icon icon={link(colors.secondary)} style={{ marginLeft: 5 }} />
-    </View>
+  <TouchableOpacity onPress={() => openLink(url)}>
+    <WrapperRowNoFlex>
+      <Icon icon={link(colors.secondary)} style={styles.icon} />
+      <RegularText link>{title}</RegularText>
+    </WrapperRowNoFlex>
   </TouchableOpacity>
 );
+
+const styles = StyleSheet.create({
+  icon: {
+    marginRight: normalize(5),
+    marginTop: normalize(3)
+  }
+});
 
 Link.propTypes = {
   url: PropTypes.string.isRequired,

--- a/src/components/Wrapper.js
+++ b/src/components/Wrapper.js
@@ -22,3 +22,11 @@ export const WrapperWrap = styled.View`
   justify-content: space-between;
   width: 100%;
 `;
+
+export const WrapperNoFlex = styled.View`
+  padding: ${normalize(14)}px;
+`;
+
+export const WrapperRowNoFlex = styled.View`
+  flex-direction: row;
+`;

--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -6,7 +6,7 @@ import { device, texts } from '../../config';
 import { HtmlView } from '../HtmlView';
 import { Image } from '../Image';
 import { Title, TitleContainer, TitleShadow } from '../Title';
-import { Wrapper } from '../Wrapper';
+import { WrapperNoFlex } from '../Wrapper';
 import { PriceCard } from './PriceCard';
 import { TimeCard } from './TimeCard';
 import { InfoCard } from './InfoCard';
@@ -95,7 +95,7 @@ export const PointOfInterest = ({ data }) => {
             <Title>{texts.pointOfInterest.description}</Title>
           </TitleContainer>
           {device.platform === 'ios' && <TitleShadow />}
-          <Wrapper>{!!body && <HtmlView html={body} />}</Wrapper>
+          <WrapperNoFlex>{!!body && <HtmlView html={body} />}</WrapperNoFlex>
         </View>
       )}
     </ScrollView>

--- a/src/config/styles/baseFontStyle.js
+++ b/src/config/styles/baseFontStyle.js
@@ -1,0 +1,8 @@
+import { colors } from '../colors';
+import { normalize } from '../normalize';
+
+export const baseFontStyle = {
+  color: colors.darkText,
+  fontFamily: 'titillium-web-regular',
+  fontSize: normalize(16)
+};

--- a/src/config/styles/index.js
+++ b/src/config/styles/index.js
@@ -1,5 +1,7 @@
+import { baseFontStyle } from './baseFontStyle';
 import { html } from './html';
 
 export const styles = {
+  baseFontStyle,
   html
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,6 +1160,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.124.tgz#16fb067a8fc4be42f044c505d8b5316c6f54de93"
   integrity sha512-6bKEUVbHJ8z34jisA7lseJZD2g31SIvee3cGX2KEZCS4XXWNbjPZpmO1/2rGNR9BhGtaYr6iYXPl1EzRrDAFTA==
 
+"@types/prop-types@^15.7.1":
+  version "15.7.1"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
+  integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
+
 "@types/qs@^6.5.1":
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.5.3.tgz#1c3b71b091eaeaf5924538006b7f70603ce63d38"
@@ -2020,6 +2025,16 @@ change-emitter@^0.1.2:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
   integrity sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=
+
+character-entities-html4@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.3.tgz#5ce6e01618e47048ac22f34f7f39db5c6fd679ef"
+  integrity sha512-SwnyZ7jQBCRHELk9zf2CN5AnGEc2nA+uKMZLHvcqhpPprjkYhiLn0DywMHgN5ttFZuITMATbh68M6VIVKwJbcg==
+
+character-entities-legacy@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz#3c729991d9293da0ede6dddcaf1f2ce1009ee8b4"
+  integrity sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww==
 
 chardet@^0.4.0:
   version "0.4.2"
@@ -4021,6 +4036,19 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.3.tgz#eb04cc47219a8895d8450ace4715abff2258a1f8"
+  integrity sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz#57ae21c374277b3defe0274c640a5704b8f6657c"
+  integrity sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -4066,6 +4094,11 @@ is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
   integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
+
+is-decimal@^1.0.0, is-decimal@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.3.tgz#381068759b9dc807d8c0dc0bfbae2b68e1da48b7"
+  integrity sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -4142,6 +4175,11 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   integrity sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=
   dependencies:
     is-extglob "^1.0.0"
+
+is-hexadecimal@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz#e8a426a69b6d31470d3a33a47bb825cda02506ee"
+  integrity sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==
 
 is-number@^2.1.0:
   version "2.1.0"
@@ -6334,6 +6372,11 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
 
+ramda@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
+
 randomatic@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.1.1.tgz#b776efc59375984e36c537b2f51a1f0aff0da1ed"
@@ -6464,6 +6507,16 @@ react-native-reanimated@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-1.0.1.tgz#5ecb6a2f6dad0351077ac9b771ca943b7ad6feda"
   integrity sha512-RENoo6/sJc3FApP7vJ1Js7WyDuTVh97bbr5aMjJyw3kqpR2/JDHyL/dQFfOvSSAc+VjitpR9/CfPPad7tLRiIA==
+
+react-native-render-html-table-bridge@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-render-html-table-bridge/-/react-native-render-html-table-bridge-0.3.1.tgz#253bf29f7d9ea252d9a69a1f2e95318c77901dec"
+  integrity sha512-adKzoWiUF77GaFuUNGp5ZN6Vk96ZV6CzvTXEjS1SIJQPS9lDRs3H/Ph+30GBVF9sMYGRAN2OiiUcnOLeWAl/lQ==
+  dependencies:
+    "@types/prop-types" "^15.7.1"
+    prop-types "^15.7.2"
+    ramda "^0.26.1"
+    stringify-entities "^2.0.0"
 
 react-native-render-html@^4.1.2:
   version "4.1.2"
@@ -7448,6 +7501,17 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+stringify-entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-2.0.0.tgz#fa7ca6614b355fb6c28448140a20c4ede7462827"
+  integrity sha512-fqqhZzXyAM6pGD9lky/GOPq6V4X0SeTAFBl0iXb/BzOegl40gpf/bV3QQP7zULNYvjr6+Dx8SCaDULjVoOru0A==
+  dependencies:
+    character-entities-html4 "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.2"
+    is-hexadecimal "^1.0.0"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Add a table renderer for our HtmlView

- we need to render `<table>` html with an additional package
  - https://github.com/jsamr/react-native-render-html-table-bridge
- refactored base font styles to an own file, because we do not
  want to have inline style

Fix flex bug around html table renderer

- struggled a long time with a strange behavior while rendering
  html table with the package
- resolved with using no flex wrappers where necessary

Update Link component

- swapped the icon to the left of the text
  like on other places in the app, i. e. InfoCard
- refactored Link to use the openLink helper

Update html table render styles