### PR TITLE
Show only upcoming events

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "expo-font": "~5.0.1",
     "expo-linear-gradient": "~5.0.1",
     "expo-secure-store": "~5.0.1",
-    "graphql": "^14.4.1",
+    "graphql": "^14.4.2",
     "graphql-tag": "^2.10.1",
     "lodash": "^4.17.11",
     "moment": "^2.24.0",

--- a/src/helpers/momentHelper.js
+++ b/src/helpers/momentHelper.js
@@ -15,3 +15,20 @@ export const momentFormat = (
   returnFormat = 'DD.MM.YYYY',
   dateTimeFormat = 'YYYY-MM-DD HH:mm:ss Z'
 ) => moment(dateTime, dateTimeFormat).format(returnFormat);
+
+/**
+ * Check if a given event date is today or in the future. We will check that with moment `isBefore`.
+ *  https://momentjs.com/docs/#/query/is-before/
+ *
+ * If a date is not before today, it is upcoming.
+ *
+ * @param {string} eventDate a date
+ *
+ * @return {bool} true if the eventDate is today or in the future, false if in the past
+ */
+export const isUpcomingEvent = (eventDate) => {
+  if (!eventDate) return false;
+
+  // "using day will check for year, month and day"
+  return !moment(eventDate).isBefore(moment(), 'day');
+};

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -9,6 +9,7 @@ import {
   View
 } from 'react-native';
 import { Query } from 'react-apollo';
+import _filter from 'lodash/filter';
 
 import { NetworkContext } from '../NetworkProvider';
 import { auth } from '../auth';
@@ -16,7 +17,13 @@ import { colors, normalize } from '../config';
 import { CardList, Icon, TextList } from '../components';
 import { getQuery } from '../queries';
 import { arrowLeft } from '../icons';
-import { eventDate, graphqlFetchPolicy, momentFormat, shareMessage } from '../helpers';
+import {
+  eventDate,
+  graphqlFetchPolicy,
+  isUpcomingEvent,
+  momentFormat,
+  shareMessage
+} from '../helpers';
 
 export class IndexScreen extends React.PureComponent {
   static navigationOptions = ({ navigation }) => {
@@ -44,23 +51,26 @@ export class IndexScreen extends React.PureComponent {
     case 'eventRecords':
       return (
         data &&
-          data[query].map((eventRecord) => ({
-            id: eventRecord.id,
-            subtitle: `${eventDate(eventRecord.listDate)} | ${eventRecord.dataProvider &&
-              eventRecord.dataProvider.name}`,
-            title: eventRecord.title,
-            routeName: 'Detail',
-            params: {
-              title: 'Veranstaltung',
-              query: 'eventRecord',
-              queryVariables: { id: `${eventRecord.id}` },
-              rootRouteName: 'EventRecords',
-              shareContent: {
-                message: shareMessage(eventRecord, query)
-              },
-              details: eventRecord
-            }
-          }))
+          data[query] &&
+          _filter(data[query], (eventRecord) => isUpcomingEvent(eventRecord.listDate)).map(
+            (eventRecord) => ({
+              id: eventRecord.id,
+              subtitle: `${eventDate(eventRecord.listDate)} | ${eventRecord.dataProvider &&
+                eventRecord.dataProvider.name}`,
+              title: eventRecord.title,
+              routeName: 'Detail',
+              params: {
+                title: 'Veranstaltung',
+                query: 'eventRecord',
+                queryVariables: { id: `${eventRecord.id}` },
+                rootRouteName: 'EventRecords',
+                shareContent: {
+                  message: shareMessage(eventRecord, query)
+                },
+                details: eventRecord
+              }
+            })
+          )
       );
     case 'newsItems':
       return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3780,10 +3780,10 @@ graphql-tag@^2.10.1:
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
   integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
 
-graphql@^14.4.1:
-  version "14.4.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.4.1.tgz#7a7818d3f63f66b9528ba5416b6c88460db62280"
-  integrity sha512-g4HUH26CohlMjaHneXMAtvG3QtO6peJIUTFxrPW4g5LNnXkUuFoBI6Bk1c14Q5kW8+FyjM/tTbePTgpiVB/2hQ==
+graphql@^14.4.2:
+  version "14.4.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.4.2.tgz#553a7d546d524663eda49ed6df77577be3203ae3"
+  integrity sha512-6uQadiRgnpnSS56hdZUSvFrVcQ6OF9y6wkxJfKquFtHlnl7+KSuWwSJsdwiK1vybm1HgcdbpGkCpvhvsVQ0UZQ==
   dependencies:
     iterall "^1.2.2"
 


### PR DESCRIPTION
Show only upcoming events

    - added check for upcoming event based on the `listDate` of a
      event record
    - used `moment` helper for determining, if an event is in the past
    - used lodash `filter` to filter data and reject past events on HomeScreen
      and IndexScreen
      - still render only the next 3 events on the HomeScreen
      - used lodash `take` for it
    - now we request always all events and filter afterwards
      - this could lead to worse performance than before

**Today: 09.07.2019**

![Simulator Screen Shot - iPhone XS Max - 2019-07-09 at 16 06 49-side](https://user-images.githubusercontent.com/1942953/60895282-a62e6b00-a264-11e9-88bb-008f90403711.png)
