### PR TITLE
Fix and update share messages

### DIFF
--- a/src/helpers/shareHelper.js
+++ b/src/helpers/shareHelper.js
@@ -32,20 +32,27 @@ export const openShare = async ({ message, title, url }) => {
   }
 };
 
+/* eslint-disable complexity */
+/* NOTE: we need to check a lot for presence, so this is that complex */
 export const shareMessage = (data, query) => {
   const buildMessage = (query) => {
     switch (query) {
     case 'eventRecord':
-      return `${momentFormat(data.createdAt)} | ${data.dataProvider && data.dataProvider.name}: ${
-        data.title
-      }`;
+      return `${momentFormat(data.listDate)} | ${data.addresses &&
+          data.addresses.length &&
+          data.addresses[0].city}: ${data.title}`;
     case 'newsItem':
       return `${momentFormat(data.publishedAt)} | ${data.dataProvider &&
-          data.dataProvider.name}: ${data.contentBlocks[0].title}`;
+          data.dataProvider.name}: ${data.contentBlocks &&
+          data.contentBlocks.length &&
+          data.contentBlocks[0].title}`;
     case 'pointOfInterest':
-      return `${data.name}\n\n${data.description}`;
+      return `${data.category && data.category.name}: ${data.name}`;
+    case 'tour':
+      return `${data.category && data.category.name}: ${data.name}`;
     }
   };
 
   return `${buildMessage(query)}\n\nQuelle: ${appJson.expo.name}`;
 };
+/* eslint-enable complexity */

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -67,7 +67,7 @@ export class IndexScreen extends React.PureComponent {
                 queryVariables: { id: `${eventRecord.id}` },
                 rootRouteName: 'EventRecords',
                 shareContent: {
-                  message: shareMessage(eventRecord, query)
+                  message: shareMessage(eventRecord, 'eventRecord')
                 },
                 details: eventRecord
               }
@@ -90,7 +90,7 @@ export class IndexScreen extends React.PureComponent {
               queryVariables: { id: `${newsItem.id}` },
               rootRouteName: 'NewsItems',
               shareContent: {
-                message: shareMessage(newsItem, query)
+                message: shareMessage(newsItem, 'newsItem')
               },
               details: newsItem
             }
@@ -116,7 +116,7 @@ export class IndexScreen extends React.PureComponent {
               queryVariables: { id: `${pointOfInterest.id}` },
               rootRouteName: 'PointsOfInterest',
               shareContent: {
-                message: shareMessage(pointOfInterest, query)
+                message: shareMessage(pointOfInterest, 'pointOfInterest')
               },
               details: pointOfInterest
             }
@@ -142,7 +142,7 @@ export class IndexScreen extends React.PureComponent {
               queryVariables: { id: `${tour.id}` },
               rootRouteName: 'Tours',
               shareContent: {
-                message: shareMessage(tour, query)
+                message: shareMessage(tour, 'tour')
               },
               details: tour
             }


### PR DESCRIPTION
- fixed query parameter in IndexScreen for share messages
  - needs to be singular for a certain item and not the `query` variable
    available, because that is plural
- updated contents of share messages
  - we cannot use the description for pois and tours anymore, because
    they are HTML and not plain text