### PR TITLE
Update news item rendering to consider stories

### DIFF
--- a/src/components/Logo.js
+++ b/src/components/Logo.js
@@ -13,7 +13,6 @@ Logo.propTypes = {
 Logo.defaultProps = {
   style: {
     height: 80,
-    marginBottom: 10,
     resizeMode: 'contain',
     width: 'auto'
   }

--- a/src/components/Wrapper.js
+++ b/src/components/Wrapper.js
@@ -6,6 +6,11 @@ export const Wrapper = styled.View`
   padding: ${normalize(14)}px;
 `;
 
+export const WrapperHorizontal = styled.View`
+  padding-left: ${normalize(14)}px;
+  padding-right: ${normalize(14)}px;
+`;
+
 export const WrapperRow = styled.View`
   flex-direction: row;
 `;

--- a/src/components/screens/EventRecord.js
+++ b/src/components/screens/EventRecord.js
@@ -1,19 +1,31 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { View } from 'react-native';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { WebView } from 'react-native-webview';
 import _filter from 'lodash/filter';
 
-import { device, texts } from '../../config';
+import { device, normalize, texts } from '../../config';
 import { HtmlView } from '../HtmlView';
 import { Image } from '../Image';
 import { Logo } from '../Logo';
 import { Title, TitleContainer, TitleShadow } from '../Title';
-import { Wrapper } from '../Wrapper';
+import { Wrapper, WrapperHorizontal } from '../Wrapper';
 import { PriceCard } from './PriceCard';
 import { InfoCard } from './InfoCard';
 import { OperatingCompanyInfo } from './OperatingCompanyInfo';
 import { OpeningTimesCard } from './OpeningTimesCard';
 import { ImagesCarousel } from '../ImagesCarousel';
+import { trimNewLines } from '../../helpers';
+
+// necessary hacky way of implementing iframe in webview with correct zoom level
+// thx to: https://stackoverflow.com/a/55780430
+const INJECTED_JAVASCRIPT_FOR_IFRAME_WEBVIEW = `
+  const meta = document.createElement('meta');
+  meta.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=0.99, user-scalable=0');
+  meta.setAttribute('name', 'viewport');
+  document.getElementsByTagName('head')[0].appendChild(meta);
+  true;
+`;
 
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
@@ -34,6 +46,7 @@ export const EventRecord = ({ data }) => {
 
   const logo = dataProvider && dataProvider.logo && dataProvider.logo.url;
   let images = [];
+  let media = [];
 
   !!mediaContents &&
     !!mediaContents.length &&
@@ -41,10 +54,37 @@ export const EventRecord = ({ data }) => {
       mediaContents,
       (mediaContent) =>
         mediaContent.contentType === 'image' || mediaContent.contentType === 'thumbnail'
-    ).map((item) => {
-      !!item.sourceUrl &&
-        !!item.sourceUrl.url &&
-        images.push({ picture: { uri: item.sourceUrl.url } });
+    ).map((mediaContent) => {
+      !!mediaContent.sourceUrl &&
+        !!mediaContent.sourceUrl.url &&
+        images.push({ picture: { uri: mediaContent.sourceUrl.url } });
+    });
+
+  !!mediaContents &&
+    !!mediaContents.length &&
+    _filter(
+      mediaContents,
+      (mediaContent) => mediaContent.contentType === 'video' || mediaContent.contentType === 'audio'
+    ).map((mediaContent) => {
+      !!mediaContent.sourceUrl &&
+        !!mediaContent.sourceUrl.url &&
+        media.push(
+          <WrapperHorizontal key={`mediaContent${mediaContent.id}`}>
+            <WebView
+              source={{ html: trimNewLines(mediaContent.sourceUrl.url) }}
+              style={styles.iframeWebView}
+              scrollEnabled={false}
+              bounces={false}
+              injectedJavaScript={INJECTED_JAVASCRIPT_FOR_IFRAME_WEBVIEW}
+              startInLoadingState
+              renderLoading={() => (
+                <View style={styles.loadingContainer}>
+                  <ActivityIndicator />
+                </View>
+              )}
+            />
+          </WrapperHorizontal>
+        );
     });
 
   return (
@@ -100,6 +140,8 @@ export const EventRecord = ({ data }) => {
         </View>
       )}
 
+      {!!media.length && media}
+
       {!!operatingCompany && (
         <View>
           <TitleContainer>
@@ -118,6 +160,19 @@ export const EventRecord = ({ data }) => {
   );
 };
 /* eslint-enable complexity */
+
+const styles = StyleSheet.create({
+  iframeWebView: {
+    height: normalize(210),
+    width: '100%'
+  },
+  loadingContainer: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+    padding: normalize(14)
+  }
+});
 
 EventRecord.propTypes = {
   data: PropTypes.object.isRequired

--- a/src/helpers/imageHelper.js
+++ b/src/helpers/imageHelper.js
@@ -1,3 +1,5 @@
+import _filter from 'lodash/filter';
+
 import { device } from '../config/device';
 
 // for horizontal CardList the cards are only 70% of the screen width
@@ -9,4 +11,22 @@ export const imageHeight = (horizontal = false) => {
   const factor = imageWidth(horizontal) / 360;
 
   return 180 * factor;
+};
+
+export const mainImageOfMediaContents = (mediaContents) => {
+  if (!mediaContents || !mediaContents.length) return null;
+
+  let images = _filter(
+    mediaContents,
+    (mediaContent) =>
+      mediaContent.contentType === 'image' || mediaContent.contentType === 'thumbnail'
+  );
+
+  if (!images || !images.length) return null;
+
+  images = _filter(images, (image) => image.sourceUrl && image.sourceUrl.url);
+
+  if (!images || !images.length) return null;
+
+  return images[0].sourceUrl.url;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ const MainAppWithApolloProvider = () => {
     let publicJsonFileContent =
       data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
 
-    if (publicJsonFileContent) {
+    if (publicJsonFileContent && publicJsonFileContent.length) {
       setDrawerRoutes(
         _reduce(
           publicJsonFileContent,

--- a/src/queries/eventRecords.js
+++ b/src/queries/eventRecords.js
@@ -19,6 +19,7 @@ export const GET_EVENT_RECORDS = gql`
       title
       description
       mediaContents {
+        id
         contentType
         sourceUrl {
           url
@@ -58,6 +59,7 @@ export const GET_EVENT_RECORD = gql`
       title
       description
       mediaContents {
+        id
         contentType
         sourceUrl {
           url

--- a/src/queries/newsItems.js
+++ b/src/queries/newsItems.js
@@ -4,11 +4,15 @@ export const GET_NEWS_ITEMS = gql`
   query NewsItems($limit: Int) {
     newsItems(limit: $limit) {
       id
+      mainTitle: title
       publishedAt
       contentBlocks {
+        id
         title
+        intro
         body
         mediaContents {
+          id
           contentType
           sourceUrl {
             url
@@ -32,11 +36,15 @@ export const GET_NEWS_ITEM = gql`
   query NewsItem($id: ID!) {
     newsItem(id: $id) {
       id
+      mainTitle: title
       publishedAt
       contentBlocks {
+        id
         title
+        intro
         body
         mediaContents {
+          id
           contentType
           sourceUrl {
             url

--- a/src/queries/pointsOfInterestAndTours.js
+++ b/src/queries/pointsOfInterestAndTours.js
@@ -43,6 +43,7 @@ export const GET_POINTS_OF_INTEREST_AND_TOURS = gql`
       }
       description
       mediaContents {
+        contentType
         sourceUrl {
           url
         }

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -353,86 +353,76 @@ export class HomeScreen extends React.PureComponent {
               );
             }}
           </Query>
-          <TitleContainer>
-            <Title>{texts.homeTitles.service}</Title>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
           <Query
             query={getQuery('publicJsonFile')}
             variables={{ name: 'homeService' }}
             fetchPolicy={fetchPolicy}
           >
-            {({ data, loading }) => {
-              if (loading) {
-                return (
-                  <View style={styles.loadingContainer}>
-                    <ActivityIndicator />
-                  </View>
-                );
-              }
-
+            {({ data }) => {
               let publicJsonFileContent =
                 data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
 
-              if (!publicJsonFileContent) return null;
+              if (!publicJsonFileContent || !publicJsonFileContent.length) return null;
 
               return (
-                <DiagonalGradient style={{ padding: normalize(14) }}>
-                  <WrapperWrap>
-                    {publicJsonFileContent.map((item, index) => {
-                      return (
-                        <ServiceBox key={index + item.title}>
-                          <TouchableOpacity
-                            onPress={() =>
-                              navigation.navigate({
-                                routeName: item.routeName,
-                                params: item.params
-                              })
-                            }
-                          >
-                            <View>
-                              <Image
-                                source={{ uri: item.icon }}
-                                style={styles.serviceImage}
-                                PlaceholderContent={null}
-                              />
-                              <BoldText small light>
-                                {item.title}
-                              </BoldText>
-                            </View>
-                          </TouchableOpacity>
-                        </ServiceBox>
-                      );
-                    })}
-                  </WrapperWrap>
-                </DiagonalGradient>
+                <View>
+                  <TitleContainer>
+                    <Title>{texts.homeTitles.service}</Title>
+                  </TitleContainer>
+                  {device.platform === 'ios' && <TitleShadow />}
+                  <DiagonalGradient style={{ padding: normalize(14) }}>
+                    <WrapperWrap>
+                      {publicJsonFileContent.map((item, index) => {
+                        return (
+                          <ServiceBox key={index + item.title}>
+                            <TouchableOpacity
+                              onPress={() =>
+                                navigation.navigate({
+                                  routeName: item.routeName,
+                                  params: item.params
+                                })
+                              }
+                            >
+                              <View>
+                                <Image
+                                  source={{ uri: item.icon }}
+                                  style={styles.serviceImage}
+                                  PlaceholderContent={null}
+                                />
+                                <BoldText small light>
+                                  {item.title}
+                                </BoldText>
+                              </View>
+                            </TouchableOpacity>
+                          </ServiceBox>
+                        );
+                      })}
+                    </WrapperWrap>
+                  </DiagonalGradient>
+                </View>
               );
             }}
           </Query>
-          <TitleContainer>
-            <Title>{texts.homeTitles.about}</Title>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
           <Query
             query={getQuery('publicJsonFile')}
             variables={{ name: 'homeAbout' }}
             fetchPolicy={fetchPolicy}
           >
-            {({ data, loading }) => {
-              if (loading) {
-                return (
-                  <View style={styles.loadingContainer}>
-                    <ActivityIndicator />
-                  </View>
-                );
-              }
-
+            {({ data }) => {
               let publicJsonFileContent =
                 data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
 
-              if (!publicJsonFileContent) return null;
+              if (!publicJsonFileContent || !publicJsonFileContent.length) return null;
 
-              return <TextList navigation={navigation} data={publicJsonFileContent} noSubtitle />;
+              return (
+                <View>
+                  <TitleContainer>
+                    <Title>{texts.homeTitles.about}</Title>
+                  </TitleContainer>
+                  {device.platform === 'ios' && <TitleShadow />}
+                  <TextList navigation={navigation} data={publicJsonFileContent} noSubtitle />
+                </View>
+              );
             }}
           </Query>
           <VersionNumber />

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -37,6 +37,7 @@ import {
   eventDate,
   graphqlFetchPolicy,
   isUpcomingEvent,
+  mainImageOfMediaContents,
   momentFormat,
   shareMessage
 } from '../helpers';
@@ -194,11 +195,7 @@ export class HomeScreen extends React.PureComponent {
                   id: pointOfInterest.id,
                   name: pointOfInterest.name,
                   category: !!pointOfInterest.category && pointOfInterest.category.name,
-                  image:
-                    !!pointOfInterest.mediaContents &&
-                    !!pointOfInterest.mediaContents.length &&
-                    !!pointOfInterest.mediaContents[0].sourceUrl &&
-                    pointOfInterest.mediaContents[0].sourceUrl.url, // TODO: some logic to get the first image/thumbnail
+                  image: mainImageOfMediaContents(pointOfInterest.mediaContents),
                   routeName: 'Detail',
                   params: {
                     title: 'Ort',
@@ -220,11 +217,7 @@ export class HomeScreen extends React.PureComponent {
                   id: tour.id,
                   name: tour.name,
                   category: !!tour.category && tour.category.name,
-                  image:
-                    !!tour.mediaContents &&
-                    !!tour.mediaContents.length &&
-                    !!tour.mediaContents[0].sourceUrl &&
-                    tour.mediaContents[0].sourceUrl.url, // TODO: some logic to get the first image/thumbnail
+                  image: mainImageOfMediaContents(tour.mediaContents),
                   routeName: 'Detail',
                   params: {
                     title: 'Touren',

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -14,6 +14,7 @@ import {
   eventDate,
   graphqlFetchPolicy,
   isUpcomingEvent,
+  mainImageOfMediaContents,
   momentFormat,
   shareMessage
 } from '../helpers';
@@ -101,11 +102,7 @@ export class IndexScreen extends React.PureComponent {
             id: pointOfInterest.id,
             name: pointOfInterest.name,
             category: !!pointOfInterest.category && pointOfInterest.category.name,
-            image:
-              !!pointOfInterest.mediaContents &&
-              !!pointOfInterest.mediaContents.length &&
-              !!pointOfInterest.mediaContents[0].sourceUrl &&
-              pointOfInterest.mediaContents[0].sourceUrl.url, // TODO: some logic to get the first image/thumbnail
+            image: mainImageOfMediaContents(pointOfInterest.mediaContents),
             routeName: 'Detail',
             params: {
               title: 'Ort',
@@ -127,11 +124,7 @@ export class IndexScreen extends React.PureComponent {
             id: tour.id,
             name: tour.name,
             category: !!tour.category && tour.category.name,
-            image:
-              !!tour.mediaContents &&
-              !!tour.mediaContents.length &&
-              !!tour.mediaContents[0].sourceUrl &&
-              tour.mediaContents[0].sourceUrl.url, // TODO: some logic to get the first image/thumbnail
+            image: mainImageOfMediaContents(tour.mediaContents),
             routeName: 'Detail',
             params: {
               title: 'Tour',


### PR DESCRIPTION
- data for news item can have multiple content blocks forming a longer story
- each content block is now a different section in a whole story
- a news item renders a main image(carousel) and a main title from the first content block
  - that is why that data is ignored inside of the story sections for the first index in the iteration
- the order of elements inside of a sections in the story is:
  - title
  - intro
  - image(carousel)
  - text
  - audio/video
- added a new wrapper with only horizontal padding to separate each section from the other without vertical space
- removed bottom margin from the logo as the body text now comes inside of the story sections
- added necessary keys in the news items queries

Render audio and video as html contents (iframe) in a WebView

- there were problems playing sound of SoundCloud iframes in the HTML renderer
- with WebView the sound plays correctly
- for correct display with zoomlevel, a hacky javascript include is necessary

Render audio and video also in EventRecord