### PR TITLE
Update mobile app to restrict news if desired and setup per main server

### DIFF
--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -14,6 +14,7 @@ import { Wrapper, WrapperHorizontal } from '../Wrapper';
 import { ImagesCarousel } from '../ImagesCarousel';
 import { momentFormat, openLink, trimNewLines } from '../../helpers';
 import { BoldText, RegularText } from '../Text';
+import { Button } from '../Button';
 
 // necessary hacky way of implementing iframe in webview with correct zoom level
 // thx to: https://stackoverflow.com/a/55780430
@@ -28,7 +29,7 @@ const INJECTED_JAVASCRIPT_FOR_IFRAME_WEBVIEW = `
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const NewsItem = ({ data }) => {
-  const { dataProvider, mainTitle, contentBlocks, publishedAt, sourceUrl } = data;
+  const { dataProvider, mainTitle, contentBlocks, publishedAt, sourceUrl, settings } = data;
 
   const logo = dataProvider && dataProvider.logo && dataProvider.logo.url;
   const link = sourceUrl && sourceUrl.url;
@@ -106,7 +107,10 @@ export const NewsItem = ({ data }) => {
           <Image source={sectionImages[0].picture} key={`${index}-${contentBlock.id}-image`} />
         );
 
-      !!contentBlock.body &&
+      !!settings &&
+        !!settings.displayOnlySummary &&
+        settings.displayOnlySummary == 'false' &&
+        !!contentBlock.body &&
         section.push(
           <WrapperHorizontal key={`${index}-${contentBlock.id}-body`}>
             <HtmlView html={trimNewLines(contentBlock.body)} />
@@ -140,6 +144,16 @@ export const NewsItem = ({ data }) => {
               </WrapperHorizontal>
             );
         });
+
+      !!settings &&
+        !!settings.displayOnlySummary &&
+        settings.displayOnlySummary == 'true' &&
+        !!settings.onlySummaryLinkText &&
+        section.push(
+          <WrapperHorizontal key={`${index}-${contentBlock.id}-onlySummaryLinkText`}>
+            <Button title={settings.onlySummaryLinkText} onPress={() => openLink(link)} />
+          </WrapperHorizontal>
+        );
 
       story.push(<View key={`${index}-${contentBlock.id}`}>{section}</View>);
     });

--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -12,7 +12,7 @@ import { Title, TitleContainer, TitleShadow } from '../Title';
 import { Touchable } from '../Touchable';
 import { Wrapper, WrapperHorizontal } from '../Wrapper';
 import { ImagesCarousel } from '../ImagesCarousel';
-import { momentFormat, openLink, trimNewLines } from '../../helpers';
+import { momentFormat, trimNewLines } from '../../helpers';
 import { BoldText, RegularText } from '../Text';
 import { Button } from '../Button';
 
@@ -28,7 +28,7 @@ const INJECTED_JAVASCRIPT_FOR_IFRAME_WEBVIEW = `
 
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
-export const NewsItem = ({ data }) => {
+export const NewsItem = ({ data, navigation }) => {
   const { dataProvider, mainTitle, contentBlocks, publishedAt, sourceUrl, settings } = data;
 
   const logo = dataProvider && dataProvider.logo && dataProvider.logo.url;
@@ -151,7 +151,19 @@ export const NewsItem = ({ data }) => {
         !!settings.onlySummaryLinkText &&
         section.push(
           <WrapperHorizontal key={`${index}-${contentBlock.id}-onlySummaryLinkText`}>
-            <Button title={settings.onlySummaryLinkText} onPress={() => openLink(link)} />
+            <Button
+              title={settings.onlySummaryLinkText}
+              onPress={() =>
+                navigation.navigate({
+                  routeName: 'Web',
+                  params: {
+                    title,
+                    webUrl: link,
+                    rootRouteName: 'NewsItems'
+                  }
+                })
+              }
+            />
           </WrapperHorizontal>
         );
 
@@ -166,7 +178,18 @@ export const NewsItem = ({ data }) => {
 
       {!!title && !!link ? (
         <TitleContainer>
-          <Touchable onPress={() => openLink(link)}>
+          <Touchable
+            onPress={() =>
+              navigation.navigate({
+                routeName: 'Web',
+                params: {
+                  title,
+                  webUrl: link,
+                  rootRouteName: 'NewsItems'
+                }
+              })
+            }
+          >
             <Title>{title}</Title>
           </Touchable>
         </TitleContainer>
@@ -203,5 +226,6 @@ const styles = StyleSheet.create({
 });
 
 NewsItem.propTypes = {
-  data: PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  navigation: PropTypes.object.isRequired
 };

--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -117,9 +117,8 @@ export const NewsItem = ({ data, navigation }) => {
           <Image source={sectionImages[0].picture} key={`${index}-${contentBlock.id}-image`} />
         );
 
-      !!settings &&
-        !!settings.displayOnlySummary &&
-        settings.displayOnlySummary == 'false' &&
+      (!settings ||
+        (!!settings && !!settings.displayOnlySummary && settings.displayOnlySummary == 'false')) &&
         !!contentBlock.body &&
         section.push(
           <WrapperHorizontal key={`${index}-${contentBlock.id}-body`}>

--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -36,6 +36,16 @@ export const NewsItem = ({ data, navigation }) => {
   const subtitle = `${momentFormat(publishedAt)} | ${dataProvider && dataProvider.name}`;
   // the title of a news item is either a given main title or the title from the first content block
   const title = mainTitle || (!!contentBlocks && !!contentBlocks.length && contentBlocks[0].title);
+  // action to open source urls
+  const openWebScreen = () =>
+    navigation.navigate({
+      routeName: 'Web',
+      params: {
+        title,
+        webUrl: link,
+        rootRouteName: 'NewsItems'
+      }
+    });
 
   // the images from the first content block will be present in the main image carousel
   let mainImages = [];
@@ -151,19 +161,7 @@ export const NewsItem = ({ data, navigation }) => {
         !!settings.onlySummaryLinkText &&
         section.push(
           <WrapperHorizontal key={`${index}-${contentBlock.id}-onlySummaryLinkText`}>
-            <Button
-              title={settings.onlySummaryLinkText}
-              onPress={() =>
-                navigation.navigate({
-                  routeName: 'Web',
-                  params: {
-                    title,
-                    webUrl: link,
-                    rootRouteName: 'NewsItems'
-                  }
-                })
-              }
-            />
+            <Button title={settings.onlySummaryLinkText} onPress={openWebScreen} />
           </WrapperHorizontal>
         );
 
@@ -178,18 +176,7 @@ export const NewsItem = ({ data, navigation }) => {
 
       {!!title && !!link ? (
         <TitleContainer>
-          <Touchable
-            onPress={() =>
-              navigation.navigate({
-                routeName: 'Web',
-                params: {
-                  title,
-                  webUrl: link,
-                  rootRouteName: 'NewsItems'
-                }
-              })
-            }
-          >
+          <Touchable onPress={openWebScreen}>
             <Title>{title}</Title>
           </Touchable>
         </TitleContainer>

--- a/src/queries/newsItems.js
+++ b/src/queries/newsItems.js
@@ -28,6 +28,10 @@ export const GET_NEWS_ITEMS = gql`
         }
         name
       }
+      settings {
+        displayOnlySummary
+        onlySummaryLinkText
+      }
     }
   }
 `;
@@ -59,6 +63,10 @@ export const GET_NEWS_ITEM = gql`
           url
         }
         name
+      }
+      settings {
+        displayOnlySummary
+        onlySummaryLinkText
       }
     }
   }

--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -97,7 +97,7 @@ export class DetailScreen extends React.PureComponent {
           return (
             <SafeAreaView>
               <ScrollView>
-                <Component data={(data && data[query]) || details} />
+                <Component data={(data && data[query]) || details} navigation={navigation} />
               </ScrollView>
             </SafeAreaView>
           );

--- a/src/screens/WebScreen.js
+++ b/src/screens/WebScreen.js
@@ -31,6 +31,7 @@ export class WebScreen extends React.PureComponent {
         <WebView
           source={{ uri: webUrl }}
           startInLoadingState
+          mediaPlaybackRequiresUserAction
           renderLoading={() => (
             <View style={styles.loadingContainer}>
               <ActivityIndicator />


### PR DESCRIPTION
Add ability to restrict news according to settings

  - added new settings to newsItems queries
  - added logics to display only intro and a button if settings say
    - otherwise still render the body content
    - button links to the source url

Open source of news in WebView instead of linking external

  - added navigation to WebScreen to open source url links in WebView
    instead of linking to external browser
  - added navigation prop to NewsItem
    - needed to navigate

Set mediaPlaybackRequiresUserAction prop for WebView

  - fixed problem with opening videos automatically after finished loading
    in WebView