### PR TITLE
Add check for validity of access token

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -3,9 +3,28 @@ import * as SecureStore from 'expo-secure-store';
 import appJson from '../app.json';
 import { secrets } from './config';
 
-export const auth = (callback) => {
-  const namespace = appJson.expo.slug;
+/**
+ * Check if a auth token is expired or still valid.
+ * The expire time is saved as seconds from 01.01.1970 00:00:00 UTC, so
+ * we need to divide Date.now() by 1000, which otherwise would return miliseconds.
+ */
+const isTokenValid = async () => {
+  const accessTokenExpireTime = await SecureStore.getItemAsync('ACCESS_TOKEN_EXPIRE_TIME');
 
+  if (!accessTokenExpireTime) return false;
+
+  const now = parseInt(Date.now() / 1000, 10); // in seconds from 01.01.1970 00:00:00 UTC
+  const expires = parseInt(accessTokenExpireTime, 10); // in seconds from 01.01.1970 00:00:00 UTC
+
+  return now < expires;
+};
+
+export const auth = async (callback) => {
+  // if the token is still valid, just run the callback, if one exists
+  if (await isTokenValid()) return callback && callback();
+
+  // otherwise fetch a new access token and expire time
+  const namespace = appJson.expo.slug;
   const fetchObj = {
     method: 'POST',
     headers: {
@@ -23,6 +42,9 @@ export const auth = (callback) => {
     .then((res) => res.json())
     .then((json) => {
       SecureStore.setItemAsync('ACCESS_TOKEN', json.access_token);
+      // save the time when the token will expire, calculated from the creation time in seconds
+      // added by the expire duration in seconds
+      SecureStore.setItemAsync('ACCESS_TOKEN_EXPIRE_TIME', `${json.created_at + json.expires_in}`);
     })
     .finally(() => callback && callback());
 };

--- a/src/index.js
+++ b/src/index.js
@@ -89,12 +89,19 @@ const MainAppWithApolloProvider = () => {
     });
 
     const fetchPolicy = await netInfoForGraphqlFetchPolicy();
+    let data;
 
-    const { data } = await client.query({
-      query: getQuery('publicJsonFile'),
-      variables: { name: 'navigation' },
-      fetchPolicy
-    });
+    try {
+      const response = await client.query({
+        query: getQuery('publicJsonFile'),
+        variables: { name: 'navigation' },
+        fetchPolicy
+      });
+
+      data = response.data;
+    } catch (errors) {
+      console.warn('errors', errors);
+    }
 
     let publicJsonFileContent =
       data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -7,6 +7,7 @@ import _take from 'lodash/take';
 import _shuffle from 'lodash/shuffle';
 
 import { NetworkContext } from '../NetworkProvider';
+import { auth } from '../auth';
 import { colors, device, normalize, texts } from '../config';
 import {
   BoldText,
@@ -39,6 +40,12 @@ import {
 
 export class HomeScreen extends React.PureComponent {
   static contextType = NetworkContext;
+
+  componentDidMount() {
+    const isConnected = this.context.isConnected;
+
+    isConnected && auth();
+  }
 
   render() {
     const { navigation } = this.props;


### PR DESCRIPTION
- currently the `auth()` method for retrieving a new
  access token is called when components did mount
  with requesting the server without condition
- this results in a unnecessary amount of request
- fetching an access token also returns the information
  about the time when a token expires
-- this is saved now to the SecureStore in addition to the token
- added a method for checking the validity of the
  access token with the expire date, so that new tokens
  will be requested only if the old one has expired

Call auth method on did mount of HomeScreen
- we call the method in every component that uses queries,
  but it was missing in HomeScreen

Add error catching on first query
- when loading the app, the first query can make
  the app crash if something went wrong or if
  the acces token for the server is not valid
- this is catched now, which results in empty screens,
  instead of endless loading indicator