### PR TITLE
Add constants and conditions for rendering sections on HomeScreen

### DIFF
--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -51,6 +51,9 @@ export class HomeScreen extends React.PureComponent {
     const { navigation } = this.props;
     const isConnected = this.context.isConnected;
     const fetchPolicy = graphqlFetchPolicy(isConnected);
+    const showNews = true;
+    const showPointsOfInterestAndTours = true;
+    const showEvents = true;
 
     return (
       <SafeAreaViewFlex>
@@ -83,280 +86,297 @@ export class HomeScreen extends React.PureComponent {
               );
             }}
           </Query>
-          <TitleContainer>
-            <Touchable
-              onPress={() =>
-                navigation.navigate({
-                  routeName: 'Index',
-                  params: {
-                    title: 'Nachrichten',
-                    query: 'newsItems',
-                    queryVariables: {},
-                    rootRouteName: 'NewsItems'
-                  }
-                })
-              }
-            >
-              <Title>{texts.homeTitles.news}</Title>
-            </Touchable>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
-          <Query query={getQuery('newsItems')} variables={{ limit: 3 }} fetchPolicy={fetchPolicy}>
-            {({ data, loading }) => {
-              if (loading) {
-                return (
-                  <LoadingContainer>
-                    <ActivityIndicator color={colors.accent} />
-                  </LoadingContainer>
-                );
-              }
 
-              const newsItems =
-                data &&
-                data.newsItems &&
-                data.newsItems.map((newsItem, index) => ({
-                  id: newsItem.id,
-                  subtitle: `${momentFormat(newsItem.publishedAt)} | ${
-                    !!newsItem.dataProvider && newsItem.dataProvider.name
+          {showNews && (
+            <TitleContainer>
+              <Touchable
+                onPress={() =>
+                  navigation.navigate({
+                    routeName: 'Index',
+                    params: {
+                      title: 'Nachrichten',
+                      query: 'newsItems',
+                      queryVariables: {},
+                      rootRouteName: 'NewsItems'
+                    }
+                  })
+                }
+              >
+                <Title>{texts.homeTitles.news}</Title>
+              </Touchable>
+            </TitleContainer>
+          )}
+          {showNews && device.platform === 'ios' && <TitleShadow />}
+          {showNews && (
+            <Query query={getQuery('newsItems')} variables={{ limit: 3 }} fetchPolicy={fetchPolicy}>
+              {({ data, loading }) => {
+                if (loading) {
+                  return (
+                    <LoadingContainer>
+                      <ActivityIndicator color={colors.accent} />
+                    </LoadingContainer>
+                  );
+                }
+
+                const newsItems =
+                  data &&
+                  data.newsItems &&
+                  data.newsItems.map((newsItem, index) => ({
+                    id: newsItem.id,
+                    subtitle: `${momentFormat(newsItem.publishedAt)} | ${
+                      !!newsItem.dataProvider && newsItem.dataProvider.name
+                    }`,
+                    title:
+                      !!newsItem.contentBlocks &&
+                      !!newsItem.contentBlocks.length &&
+                      newsItem.contentBlocks[0].title,
+                    routeName: 'Detail',
+                    params: {
+                      title: 'Nachricht',
+                      query: 'newsItem',
+                      queryVariables: { id: `${newsItem.id}` },
+                      rootRouteName: 'NewsItems',
+                      shareContent: {
+                        message: shareMessage(newsItem, 'newsItem')
+                      },
+                      details: newsItem
+                    },
+                    bottomDivider: index !== data.newsItems.length - 1,
+                    __typename: newsItem.__typename
+                  }));
+
+                if (!newsItems || !newsItems.length) return null;
+
+                return (
+                  <View>
+                    <TextList navigation={navigation} data={newsItems} />
+
+                    <Wrapper>
+                      <Button
+                        title="Alle Nachrichten anzeigen"
+                        onPress={() =>
+                          navigation.navigate({
+                            routeName: 'Index',
+                            params: {
+                              title: 'Nachrichten',
+                              query: 'newsItems',
+                              queryVariables: {},
+                              rootRouteName: 'NewsItems'
+                            }
+                          })
+                        }
+                      />
+                    </Wrapper>
+                  </View>
+                );
+              }}
+            </Query>
+          )}
+
+          {showPointsOfInterestAndTours && (
+            <TitleContainer>
+              <Touchable
+                onPress={() =>
+                  navigation.navigate({
+                    routeName: 'Index',
+                    params: {
+                      title: 'Touren und Orte',
+                      query: 'categories',
+                      queryVariables: {},
+                      rootRouteName: 'PointsOfInterestAndTours'
+                    }
+                  })
+                }
+              >
+                <Title>{texts.homeTitles.pointsOfInterest}</Title>
+              </Touchable>
+            </TitleContainer>
+          )}
+          {showPointsOfInterestAndTours && device.platform === 'ios' && <TitleShadow />}
+          {showPointsOfInterestAndTours && (
+            <Query
+              query={getQuery('pointsOfInterestAndTours')}
+              variables={{ limit: 10, orderPoi: 'RAND', orderTour: 'RAND' }}
+              fetchPolicy={fetchPolicy}
+            >
+              {({ data, loading }) => {
+                if (loading) {
+                  return (
+                    <LoadingContainer>
+                      <ActivityIndicator color={colors.accent} />
+                    </LoadingContainer>
+                  );
+                }
+
+                const pointsOfInterest =
+                  data &&
+                  data.pointsOfInterest &&
+                  data.pointsOfInterest.map((pointOfInterest) => ({
+                    id: pointOfInterest.id,
+                    name: pointOfInterest.name,
+                    category: !!pointOfInterest.category && pointOfInterest.category.name,
+                    image: mainImageOfMediaContents(pointOfInterest.mediaContents),
+                    routeName: 'Detail',
+                    params: {
+                      title: 'Ort',
+                      query: 'pointOfInterest',
+                      queryVariables: { id: `${pointOfInterest.id}` },
+                      rootRouteName: 'PointsOfInterest',
+                      shareContent: {
+                        message: shareMessage(pointOfInterest, 'pointOfInterest')
+                      },
+                      details: pointOfInterest
+                    },
+                    __typename: pointOfInterest.__typename
+                  }));
+
+                const tours =
+                  data &&
+                  data.tours &&
+                  data.tours.map((tour) => ({
+                    id: tour.id,
+                    name: tour.name,
+                    category: !!tour.category && tour.category.name,
+                    image: mainImageOfMediaContents(tour.mediaContents),
+                    routeName: 'Detail',
+                    params: {
+                      title: 'Touren',
+                      query: 'tour',
+                      queryVariables: { id: `${tour.id}` },
+                      rootRouteName: 'Tours',
+                      shareContent: {
+                        message: shareMessage(tour, 'tour')
+                      },
+                      details: tour
+                    },
+                    __typename: tour.__typename
+                  }));
+
+                return (
+                  <View>
+                    <CardList
+                      navigation={navigation}
+                      data={_shuffle([...(pointsOfInterest || []), ...(tours || [])])}
+                      horizontal
+                    />
+
+                    <Wrapper>
+                      <Button
+                        title="Alle Touren und Orte anzeigen"
+                        onPress={() =>
+                          navigation.navigate({
+                            routeName: 'Index',
+                            params: {
+                              title: 'Touren und Orte',
+                              query: 'categories',
+                              queryVariables: {},
+                              rootRouteName: 'PointsOfInterestAndTours'
+                            }
+                          })
+                        }
+                      />
+                    </Wrapper>
+                  </View>
+                );
+              }}
+            </Query>
+          )}
+
+          {showEvents && (
+            <TitleContainer>
+              <Touchable
+                onPress={() =>
+                  navigation.navigate({
+                    routeName: 'Index',
+                    params: {
+                      title: 'Veranstaltungen',
+                      query: 'eventRecords',
+                      queryVariables: { order: 'listDate_ASC' },
+                      rootRouteName: 'EventRecords'
+                    }
+                  })
+                }
+              >
+                <Title>{texts.homeTitles.events}</Title>
+              </Touchable>
+            </TitleContainer>
+          )}
+          {showEvents && device.platform === 'ios' && <TitleShadow />}
+          {showEvents && (
+            <Query
+              query={getQuery('eventRecords')}
+              variables={{ order: 'listDate_ASC' }}
+              fetchPolicy={fetchPolicy}
+            >
+              {({ data, loading }) => {
+                if (loading) {
+                  return (
+                    <LoadingContainer>
+                      <ActivityIndicator color={colors.accent} />
+                    </LoadingContainer>
+                  );
+                }
+
+                const upcomingEventRecords =
+                  data &&
+                  data.eventRecords &&
+                  _filter(data.eventRecords, (eventRecord) =>
+                    isUpcomingEvent(eventRecord.listDate)
+                  );
+
+                if (!upcomingEventRecords || !upcomingEventRecords.length) return null;
+
+                const eventRecords = _take(upcomingEventRecords, 3).map((eventRecord, index) => ({
+                  id: eventRecord.id,
+                  subtitle: `${eventDate(eventRecord.listDate)} | ${
+                    !!eventRecord.addresses &&
+                    !!eventRecord.addresses.length &&
+                    (eventRecord.addresses[0].addition || eventRecord.addresses[0].city)
                   }`,
-                  title:
-                    !!newsItem.contentBlocks &&
-                    !!newsItem.contentBlocks.length &&
-                    newsItem.contentBlocks[0].title,
+                  title: eventRecord.title,
                   routeName: 'Detail',
                   params: {
-                    title: 'Nachricht',
-                    query: 'newsItem',
-                    queryVariables: { id: `${newsItem.id}` },
-                    rootRouteName: 'NewsItems',
+                    title: 'Veranstaltung',
+                    query: 'eventRecord',
+                    queryVariables: { id: `${eventRecord.id}` },
+                    rootRouteName: 'EventRecords',
                     shareContent: {
-                      message: shareMessage(newsItem, 'newsItem')
+                      message: shareMessage(eventRecord, 'eventRecord')
                     },
-                    details: newsItem
+                    details: eventRecord
                   },
-                  bottomDivider: index !== data.newsItems.length - 1,
-                  __typename: newsItem.__typename
+                  bottomDivider: index !== data.eventRecords.length - 1,
+                  __typename: eventRecord.__typename
                 }));
 
-              if (!newsItems || !newsItems.length) return null;
+                if (!eventRecords || !eventRecords.length) return null;
 
-              return (
-                <View>
-                  <TextList navigation={navigation} data={newsItems} />
-
-                  <Wrapper>
-                    <Button
-                      title="Alle Nachrichten anzeigen"
-                      onPress={() =>
-                        navigation.navigate({
-                          routeName: 'Index',
-                          params: {
-                            title: 'Nachrichten',
-                            query: 'newsItems',
-                            queryVariables: {},
-                            rootRouteName: 'NewsItems'
-                          }
-                        })
-                      }
-                    />
-                  </Wrapper>
-                </View>
-              );
-            }}
-          </Query>
-
-          <TitleContainer>
-            <Touchable
-              onPress={() =>
-                navigation.navigate({
-                  routeName: 'Index',
-                  params: {
-                    title: 'Touren und Orte',
-                    query: 'categories',
-                    queryVariables: {},
-                    rootRouteName: 'PointsOfInterestAndTours'
-                  }
-                })
-              }
-            >
-              <Title>{texts.homeTitles.pointsOfInterest}</Title>
-            </Touchable>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
-          <Query
-            query={getQuery('pointsOfInterestAndTours')}
-            variables={{ limit: 10, orderPoi: 'RAND', orderTour: 'RAND' }}
-            fetchPolicy={fetchPolicy}
-          >
-            {({ data, loading }) => {
-              if (loading) {
                 return (
-                  <LoadingContainer>
-                    <ActivityIndicator color={colors.accent} />
-                  </LoadingContainer>
+                  <View>
+                    <TextList navigation={navigation} data={eventRecords} />
+
+                    <Wrapper>
+                      <Button
+                        title="Alle Veranstaltungen anzeigen"
+                        onPress={() =>
+                          navigation.navigate({
+                            routeName: 'Index',
+                            params: {
+                              title: 'Veranstaltungen',
+                              query: 'eventRecords',
+                              queryVariables: { order: 'listDate_ASC' },
+                              rootRouteName: 'EventRecords'
+                            }
+                          })
+                        }
+                      />
+                    </Wrapper>
+                  </View>
                 );
-              }
+              }}
+            </Query>
+          )}
 
-              const pointsOfInterest =
-                data &&
-                data.pointsOfInterest &&
-                data.pointsOfInterest.map((pointOfInterest) => ({
-                  id: pointOfInterest.id,
-                  name: pointOfInterest.name,
-                  category: !!pointOfInterest.category && pointOfInterest.category.name,
-                  image: mainImageOfMediaContents(pointOfInterest.mediaContents),
-                  routeName: 'Detail',
-                  params: {
-                    title: 'Ort',
-                    query: 'pointOfInterest',
-                    queryVariables: { id: `${pointOfInterest.id}` },
-                    rootRouteName: 'PointsOfInterest',
-                    shareContent: {
-                      message: shareMessage(pointOfInterest, 'pointOfInterest')
-                    },
-                    details: pointOfInterest
-                  },
-                  __typename: pointOfInterest.__typename
-                }));
-
-              const tours =
-                data &&
-                data.tours &&
-                data.tours.map((tour) => ({
-                  id: tour.id,
-                  name: tour.name,
-                  category: !!tour.category && tour.category.name,
-                  image: mainImageOfMediaContents(tour.mediaContents),
-                  routeName: 'Detail',
-                  params: {
-                    title: 'Touren',
-                    query: 'tour',
-                    queryVariables: { id: `${tour.id}` },
-                    rootRouteName: 'Tours',
-                    shareContent: {
-                      message: shareMessage(tour, 'tour')
-                    },
-                    details: tour
-                  },
-                  __typename: tour.__typename
-                }));
-
-              return (
-                <View>
-                  <CardList
-                    navigation={navigation}
-                    data={_shuffle([...(pointsOfInterest || []), ...(tours || [])])}
-                    horizontal
-                  />
-
-                  <Wrapper>
-                    <Button
-                      title="Alle Touren und Orte anzeigen"
-                      onPress={() =>
-                        navigation.navigate({
-                          routeName: 'Index',
-                          params: {
-                            title: 'Touren und Orte',
-                            query: 'categories',
-                            queryVariables: {},
-                            rootRouteName: 'PointsOfInterestAndTours'
-                          }
-                        })
-                      }
-                    />
-                  </Wrapper>
-                </View>
-              );
-            }}
-          </Query>
-          <TitleContainer>
-            <Touchable
-              onPress={() =>
-                navigation.navigate({
-                  routeName: 'Index',
-                  params: {
-                    title: 'Veranstaltungen',
-                    query: 'eventRecords',
-                    queryVariables: { order: 'listDate_ASC' },
-                    rootRouteName: 'EventRecords'
-                  }
-                })
-              }
-            >
-              <Title>{texts.homeTitles.events}</Title>
-            </Touchable>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
-          <Query
-            query={getQuery('eventRecords')}
-            variables={{ order: 'listDate_ASC' }}
-            fetchPolicy={fetchPolicy}
-          >
-            {({ data, loading }) => {
-              if (loading) {
-                return (
-                  <LoadingContainer>
-                    <ActivityIndicator color={colors.accent} />
-                  </LoadingContainer>
-                );
-              }
-
-              const upcomingEventRecords =
-                data &&
-                data.eventRecords &&
-                _filter(data.eventRecords, (eventRecord) => isUpcomingEvent(eventRecord.listDate));
-
-              if (!upcomingEventRecords || !upcomingEventRecords.length) return null;
-
-              const eventRecords = _take(upcomingEventRecords, 3).map((eventRecord, index) => ({
-                id: eventRecord.id,
-                subtitle: `${eventDate(eventRecord.listDate)} | ${
-                  !!eventRecord.addresses &&
-                  !!eventRecord.addresses.length &&
-                  (eventRecord.addresses[0].addition || eventRecord.addresses[0].city)
-                }`,
-                title: eventRecord.title,
-                routeName: 'Detail',
-                params: {
-                  title: 'Veranstaltung',
-                  query: 'eventRecord',
-                  queryVariables: { id: `${eventRecord.id}` },
-                  rootRouteName: 'EventRecords',
-                  shareContent: {
-                    message: shareMessage(eventRecord, 'eventRecord')
-                  },
-                  details: eventRecord
-                },
-                bottomDivider: index !== data.eventRecords.length - 1,
-                __typename: eventRecord.__typename
-              }));
-
-              if (!eventRecords || !eventRecords.length) return null;
-
-              return (
-                <View>
-                  <TextList navigation={navigation} data={eventRecords} />
-
-                  <Wrapper>
-                    <Button
-                      title="Alle Veranstaltungen anzeigen"
-                      onPress={() =>
-                        navigation.navigate({
-                          routeName: 'Index',
-                          params: {
-                            title: 'Veranstaltungen',
-                            query: 'eventRecords',
-                            queryVariables: { order: 'listDate_ASC' },
-                            rootRouteName: 'EventRecords'
-                          }
-                        })
-                      }
-                    />
-                  </Wrapper>
-                </View>
-              );
-            }}
-          </Query>
           <Query
             query={getQuery('publicJsonFile')}
             variables={{ name: 'homeService' }}
@@ -407,6 +427,7 @@ export class HomeScreen extends React.PureComponent {
               );
             }}
           </Query>
+
           <Query
             query={getQuery('publicJsonFile')}
             variables={{ name: 'homeAbout' }}

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -382,7 +382,9 @@ export class HomeScreen extends React.PureComponent {
             variables={{ name: 'homeService' }}
             fetchPolicy={fetchPolicy}
           >
-            {({ data }) => {
+            {({ data, loading }) => {
+              if (loading) return null;
+
               let publicJsonFileContent =
                 data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
 
@@ -433,7 +435,9 @@ export class HomeScreen extends React.PureComponent {
             variables={{ name: 'homeAbout' }}
             fetchPolicy={fetchPolicy}
           >
-            {({ data }) => {
+            {({ data, loading }) => {
+              if (loading) return null;
+
               let publicJsonFileContent =
                 data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
 


### PR DESCRIPTION
- added fix boolean constants that decides rendering
  of the main sections on the HomeScreen
-- default: true
- later there can be more logic around that, with
  setting the constants dynamically from queries
  for example

 Avoid renderings for homeService and homeAbout if query is in loading state

- we do not need a loading indicator for that sections,
  because there is no headline pre-rendered as for
  the main sections
- the headline is rendered with the data after query
  has succeeded

