### PR TITLE
refactor(upcoming events): remove js logics

### DIFF
--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -2,8 +2,6 @@ import PropTypes from 'prop-types';
 import React, { useContext, useEffect } from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Query } from 'react-apollo';
-import _filter from 'lodash/filter';
-import _take from 'lodash/take';
 import _shuffle from 'lodash/shuffle';
 
 import { NetworkContext } from '../NetworkProvider';
@@ -33,7 +31,6 @@ import { getQuery } from '../queries';
 import {
   eventDate,
   graphqlFetchPolicy,
-  isUpcomingEvent,
   mainImageOfMediaContents,
   momentFormat,
   shareMessage
@@ -303,7 +300,7 @@ export const HomeScreen = ({ navigation }) => {
         {showEvents && (
           <Query
             query={getQuery('eventRecords')}
-            variables={{ order: 'listDate_ASC' }}
+            variables={{ limit: 3, order: 'listDate_ASC' }}
             fetchPolicy={fetchPolicy}
           >
             {({ data, loading }) => {
@@ -315,37 +312,31 @@ export const HomeScreen = ({ navigation }) => {
                 );
               }
 
-              let upcomingEventRecords =
+              const eventRecords =
                 data &&
                 data.eventRecords &&
-                _filter(data.eventRecords, (eventRecord) => isUpcomingEvent(eventRecord.listDate));
-
-              if (!upcomingEventRecords || !upcomingEventRecords.length) return null;
-
-              upcomingEventRecords = _take(upcomingEventRecords, 3);
-
-              const eventRecords = upcomingEventRecords.map((eventRecord, index) => ({
-                id: eventRecord.id,
-                subtitle: `${eventDate(eventRecord.listDate)} | ${
-                  !!eventRecord.addresses &&
-                  !!eventRecord.addresses.length &&
-                  (eventRecord.addresses[0].addition || eventRecord.addresses[0].city)
-                }`,
-                title: eventRecord.title,
-                routeName: 'Detail',
-                params: {
-                  title: 'Veranstaltung',
-                  query: 'eventRecord',
-                  queryVariables: { id: `${eventRecord.id}` },
-                  rootRouteName: 'EventRecords',
-                  shareContent: {
-                    message: shareMessage(eventRecord, 'eventRecord')
+                data.eventRecords.map((eventRecord, index) => ({
+                  id: eventRecord.id,
+                  subtitle: `${eventDate(eventRecord.listDate)} | ${
+                    !!eventRecord.addresses &&
+                    !!eventRecord.addresses.length &&
+                    (eventRecord.addresses[0].addition || eventRecord.addresses[0].city)
+                  }`,
+                  title: eventRecord.title,
+                  routeName: 'Detail',
+                  params: {
+                    title: 'Veranstaltung',
+                    query: 'eventRecord',
+                    queryVariables: { id: `${eventRecord.id}` },
+                    rootRouteName: 'EventRecords',
+                    shareContent: {
+                      message: shareMessage(eventRecord, 'eventRecord')
+                    },
+                    details: eventRecord
                   },
-                  details: eventRecord
-                },
-                bottomDivider: index !== upcomingEventRecords.length - 1,
-                __typename: eventRecord.__typename
-              }));
+                  bottomDivider: index !== data.eventRecords.length - 1,
+                  __typename: eventRecord.__typename
+                }));
 
               if (!eventRecords || !eventRecords.length) return null;
 

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { ActivityIndicator, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Query } from 'react-apollo';
-import _filter from 'lodash/filter';
 
 import { NetworkContext } from '../NetworkProvider';
 import { auth } from '../auth';
@@ -20,7 +19,6 @@ import { arrowLeft } from '../icons';
 import {
   eventDate,
   graphqlFetchPolicy,
-  isUpcomingEvent,
   mainImageOfMediaContents,
   momentFormat,
   shareMessage
@@ -55,28 +53,26 @@ export class IndexScreen extends React.PureComponent {
         return (
           data &&
           data[query] &&
-          _filter(data[query], (eventRecord) => isUpcomingEvent(eventRecord.listDate)).map(
-            (eventRecord) => ({
-              id: eventRecord.id,
-              subtitle: `${eventDate(eventRecord.listDate)} | ${
-                !!eventRecord.addresses &&
-                !!eventRecord.addresses.length &&
-                (eventRecord.addresses[0].addition || eventRecord.addresses[0].city)
-              }`,
-              title: eventRecord.title,
-              routeName: 'Detail',
-              params: {
-                title: 'Veranstaltung',
-                query: 'eventRecord',
-                queryVariables: { id: `${eventRecord.id}` },
-                rootRouteName: 'EventRecords',
-                shareContent: {
-                  message: shareMessage(eventRecord, 'eventRecord')
-                },
-                details: eventRecord
-              }
-            })
-          )
+          data[query].map((eventRecord) => ({
+            id: eventRecord.id,
+            subtitle: `${eventDate(eventRecord.listDate)} | ${
+              !!eventRecord.addresses &&
+              !!eventRecord.addresses.length &&
+              (eventRecord.addresses[0].addition || eventRecord.addresses[0].city)
+            }`,
+            title: eventRecord.title,
+            routeName: 'Detail',
+            params: {
+              title: 'Veranstaltung',
+              query: 'eventRecord',
+              queryVariables: { id: `${eventRecord.id}` },
+              rootRouteName: 'EventRecords',
+              shareContent: {
+                message: shareMessage(eventRecord, 'eventRecord')
+              },
+              details: eventRecord
+            }
+          }))
         );
       case 'newsItems':
         return (


### PR DESCRIPTION
- the mainserver returns only upcoming event records now
  so the additional logic for filtering to upcoming events
  in the app is not necessary anymore
- we can use the `limit: 3` variable directly like for news on
  the home screen, which returns exactly the next three upcoming
  events as wanted
- also for the list of event records in index screen the js logic
  in the app is not needed anymore

Resolves #75