### PR TITLE
feat(android status bar): set explicit colors

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,6 +25,11 @@
     ],
     "ios": {
       "supportsTablet": true
+    },
+    "androidStatusBar": {
+      "barStyle": "dark-content",
+      "translucent": true,
+      "backgroundColor": "#00000000"
     }
   }
 }


### PR DESCRIPTION
- https://docs.expo.io/guides/configuring-statusbar/#configuring-the-status-bar-while-your-app
  - > On iOS, it is not possible in the Expo managed workflow to customize the status bar before the app has loaded, while the splash screen is presented.
- adding the config to app.json allows us to set
  the colors on android while splash screen is visible
  - available options: https://docs.expo.io/versions/latest/config/app/#androidstatusbar
- after the splash screen the status bar is configured with `<StatusBar>`