### PR TITLE
Update on title header in webView news

### DIFF
--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -30,19 +30,17 @@ const INJECTED_JAVASCRIPT_FOR_IFRAME_WEBVIEW = `
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const NewsItem = ({ data, navigation }) => {
-  const { dataProvider, mainTitle, contentBlocks, publishedAt, sourceUrl, settings } = data;
+  const { dataProvider, contentBlocks, publishedAt, sourceUrl, settings } = data;
 
   const logo = dataProvider && dataProvider.logo && dataProvider.logo.url;
   const link = sourceUrl && sourceUrl.url;
   const subtitle = `${momentFormat(publishedAt)} | ${dataProvider && dataProvider.name}`;
-  // the title of a news item is either a given main title or the title from the first content block
-  const title = mainTitle || (!!contentBlocks && !!contentBlocks.length && contentBlocks[0].title);
   // action to open source urls
   const openWebScreen = () =>
     navigation.navigate({
       routeName: 'Web',
       params: {
-        title,
+        title: 'Nachrichte',
         webUrl: link,
         rootRouteName: 'NewsItems'
       }

--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -42,7 +42,7 @@ export const NewsItem = ({ data, navigation }) => {
     navigation.navigate({
       routeName: 'Web',
       params: {
-        title: 'Nachrichte',
+        title: 'Nachricht',
         webUrl: link,
         rootRouteName: 'NewsItems'
       }

--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -30,11 +30,13 @@ const INJECTED_JAVASCRIPT_FOR_IFRAME_WEBVIEW = `
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const NewsItem = ({ data, navigation }) => {
-  const { dataProvider, contentBlocks, publishedAt, sourceUrl, settings } = data;
+  const { dataProvider, mainTitle, contentBlocks, publishedAt, sourceUrl, settings } = data;
 
   const logo = dataProvider && dataProvider.logo && dataProvider.logo.url;
   const link = sourceUrl && sourceUrl.url;
   const subtitle = `${momentFormat(publishedAt)} | ${dataProvider && dataProvider.name}`;
+  // the title of a news item is either a given main title or the title from the first content block
+  const title = mainTitle || (!!contentBlocks && !!contentBlocks.length && contentBlocks[0].title);
   // action to open source urls
   const openWebScreen = () =>
     navigation.navigate({

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -235,7 +235,7 @@ export const HomeScreen = ({ navigation }) => {
                   image: mainImageOfMediaContents(tour.mediaContents),
                   routeName: 'Detail',
                   params: {
-                    title: 'Touren',
+                    title: 'Tour',
                     query: 'tour',
                     queryVariables: { id: `${tour.id}` },
                     rootRouteName: 'Tours',


### PR DESCRIPTION
- just 'Nachrichte' will be visible now on header of webView news article
  - hardcoded in title params instead of previeus condition
-const title is in use in this file in several places , should not be deleted
- this change have been not tested because of network issues 