### PR TITLE
feat(sections): variable title for sections

### DIFF
--- a/src/screens/CompanyScreen.js
+++ b/src/screens/CompanyScreen.js
@@ -1,9 +1,10 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useContext } from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Query } from 'react-apollo';
 
 import { NetworkContext } from '../NetworkProvider';
+import { GlobalSettingsContext } from '../GlobalSettingsProvider';
 import { colors, device, normalize, texts } from '../config';
 import {
   BoldText,
@@ -20,86 +21,86 @@ import { getQuery } from '../queries';
 import { graphqlFetchPolicy } from '../helpers';
 import TabBarIcon from '../components/TabBarIcon';
 
-export class CompanyScreen extends React.PureComponent {
-  static contextType = NetworkContext;
+export const CompanyScreen = ({ navigation }) => {
+  const { isConnected } = useContext(NetworkContext);
+  const fetchPolicy = graphqlFetchPolicy(isConnected);
+  const globalSettings = useContext(GlobalSettingsContext);
+  const { sections } = globalSettings;
+  const { headlineCompany = texts.homeTitles.company } = sections;
 
-  render() {
-    const { navigation } = this.props;
-    const isConnected = this.context.isConnected;
-    const fetchPolicy = graphqlFetchPolicy(isConnected);
-
-    return (
-      <SafeAreaViewFlex>
-        <Query
-          query={getQuery('publicJsonFile')}
-          variables={{ name: 'homeCompanies' }}
-          fetchPolicy={fetchPolicy}
-        >
-          {({ data, loading }) => {
-            if (loading) {
-              return (
-                <LoadingContainer>
-                  <ActivityIndicator color={colors.accent} />
-                </LoadingContainer>
-              );
-            }
-
-            let publicJsonFileContent =
-              data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
-
-            if (!publicJsonFileContent || !publicJsonFileContent.length) return null;
-
+  return (
+    <SafeAreaViewFlex>
+      <Query
+        query={getQuery('publicJsonFile')}
+        variables={{ name: 'homeCompanies' }}
+        fetchPolicy={fetchPolicy}
+      >
+        {({ data, loading }) => {
+          if (loading) {
             return (
-              <ScrollView>
-                <TitleContainer>
-                  <Title>{texts.homeTitles.company}</Title>
-                </TitleContainer>
-                {device.platform === 'ios' && <TitleShadow />}
-                <View style={{ padding: normalize(14) }}>
-                  <WrapperWrap>
-                    {publicJsonFileContent.map((item, index) => {
-                      return (
-                        <ServiceBox key={index + item.title}>
-                          <TouchableOpacity
-                            onPress={() =>
-                              navigation.navigate({
-                                routeName: item.routeName,
-                                params: item.params
-                              })
-                            }
-                          >
-                            <View>
-                              {item.iconName ? (
-                                <TabBarIcon
-                                  name={item.iconName}
-                                  size={30}
-                                  style={styles.serviceIcon}
-                                />
-                              ) : (
-                                <Image
-                                  source={{ uri: item.icon }}
-                                  style={styles.serviceImage}
-                                  PlaceholderContent={null}
-                                />
-                              )}
-                              <BoldText small primary>
-                                {item.title}
-                              </BoldText>
-                            </View>
-                          </TouchableOpacity>
-                        </ServiceBox>
-                      );
-                    })}
-                  </WrapperWrap>
-                </View>
-              </ScrollView>
+              <LoadingContainer>
+                <ActivityIndicator color={colors.accent} />
+              </LoadingContainer>
             );
-          }}
-        </Query>
-      </SafeAreaViewFlex>
-    );
-  }
-}
+          }
+
+          let publicJsonFileContent =
+            data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
+
+          if (!publicJsonFileContent || !publicJsonFileContent.length) return null;
+
+          return (
+            <ScrollView>
+              {!!headlineCompany && (
+                <TitleContainer>
+                  <Title>{headlineCompany}</Title>
+                </TitleContainer>
+              )}
+              {!!headlineCompany && device.platform === 'ios' && <TitleShadow />}
+              <View style={{ padding: normalize(14) }}>
+                <WrapperWrap>
+                  {publicJsonFileContent.map((item, index) => {
+                    return (
+                      <ServiceBox key={index + item.title}>
+                        <TouchableOpacity
+                          onPress={() =>
+                            navigation.navigate({
+                              routeName: item.routeName,
+                              params: item.params
+                            })
+                          }
+                        >
+                          <View>
+                            {item.iconName ? (
+                              <TabBarIcon
+                                name={item.iconName}
+                                size={30}
+                                style={styles.serviceIcon}
+                              />
+                            ) : (
+                              <Image
+                                source={{ uri: item.icon }}
+                                style={styles.serviceImage}
+                                PlaceholderContent={null}
+                              />
+                            )}
+                            <BoldText small primary>
+                              {item.title}
+                            </BoldText>
+                          </View>
+                        </TouchableOpacity>
+                      </ServiceBox>
+                    );
+                  })}
+                </WrapperWrap>
+              </View>
+            </ScrollView>
+          );
+        }}
+      </Query>
+    </SafeAreaViewFlex>
+  );
+};
 
 const styles = StyleSheet.create({
   serviceIcon: {

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -42,9 +42,17 @@ export const HomeScreen = ({ navigation }) => {
   const { isConnected } = useContext(NetworkContext);
   const fetchPolicy = graphqlFetchPolicy(isConnected);
   const globalSettings = useContext(GlobalSettingsContext);
-  const showNews = true;
-  const showPointsOfInterestAndTours = true;
-  const showEvents = true;
+  const { sections } = globalSettings;
+  const {
+    showNews = true,
+    showPointsOfInterestAndTours = true,
+    showEvents = true,
+    headlineNews = texts.homeTitles.news,
+    headlinePointsOfInterestAndTours = texts.homeTitles.pointsOfInterest,
+    headlineEvents = texts.homeTitles.events,
+    headlineService = texts.homeTitles.service,
+    headlineAbout = texts.homeTitles.about
+  } = sections;
 
   useEffect(() => {
     isConnected && auth();
@@ -97,7 +105,7 @@ export const HomeScreen = ({ navigation }) => {
                 })
               }
             >
-              <Title>{texts.homeTitles.news}</Title>
+              <Title>{headlineNews}</Title>
             </Touchable>
           </TitleContainer>
         )}
@@ -183,7 +191,7 @@ export const HomeScreen = ({ navigation }) => {
                 })
               }
             >
-              <Title>{texts.homeTitles.pointsOfInterest}</Title>
+              <Title>{headlinePointsOfInterestAndTours}</Title>
             </Touchable>
           </TitleContainer>
         )}
@@ -292,7 +300,7 @@ export const HomeScreen = ({ navigation }) => {
                 })
               }
             >
-              <Title>{texts.homeTitles.events}</Title>
+              <Title>{headlineEvents}</Title>
             </Touchable>
           </TitleContainer>
         )}
@@ -383,10 +391,12 @@ export const HomeScreen = ({ navigation }) => {
 
                 return (
                   <View>
-                    <TitleContainer>
-                      <Title>{texts.homeTitles.service}</Title>
-                    </TitleContainer>
-                    {device.platform === 'ios' && <TitleShadow />}
+                    {!!headlineService && (
+                      <TitleContainer>
+                        <Title>{headlineService}</Title>
+                      </TitleContainer>
+                    )}
+                    {!!headlineService && device.platform === 'ios' && <TitleShadow />}
                     <DiagonalGradient style={{ padding: normalize(14) }}>
                       <WrapperWrap>
                         {publicJsonFileContent.map((item, index) => {
@@ -436,9 +446,12 @@ export const HomeScreen = ({ navigation }) => {
 
                 return (
                   <View>
-                    <TitleContainer>
-                      <Title>{texts.homeTitles.about}</Title>
-                    </TitleContainer>
+                    {!!headlineAbout && (
+                      <TitleContainer>
+                        <Title>{headlineAbout}</Title>
+                      </TitleContainer>
+                    )}
+                    {!!headlineAbout && device.platform === 'ios' && <TitleShadow />}
                     {device.platform === 'ios' && <TitleShadow />}
                     <TextList navigation={navigation} data={publicJsonFileContent} noSubtitle />
                   </View>

--- a/src/screens/ServiceScreen.js
+++ b/src/screens/ServiceScreen.js
@@ -1,9 +1,10 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useContext } from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Query } from 'react-apollo';
 
 import { NetworkContext } from '../NetworkProvider';
+import { GlobalSettingsContext } from '../GlobalSettingsProvider';
 import { colors, device, normalize, texts } from '../config';
 import {
   BoldText,
@@ -20,86 +21,86 @@ import { getQuery } from '../queries';
 import { graphqlFetchPolicy } from '../helpers';
 import TabBarIcon from '../components/TabBarIcon';
 
-export class ServiceScreen extends React.PureComponent {
-  static contextType = NetworkContext;
+export const ServiceScreen = ({ navigation }) => {
+  const { isConnected } = useContext(NetworkContext);
+  const fetchPolicy = graphqlFetchPolicy(isConnected);
+  const globalSettings = useContext(GlobalSettingsContext);
+  const { sections } = globalSettings;
+  const { headlineService = texts.homeTitles.service } = sections;
 
-  render() {
-    const { navigation } = this.props;
-    const isConnected = this.context.isConnected;
-    const fetchPolicy = graphqlFetchPolicy(isConnected);
+  return (
+    <SafeAreaViewFlex>
+      <Query
+        query={getQuery('publicJsonFile')}
+        variables={{ name: 'homeService' }}
+        fetchPolicy={fetchPolicy}
+      >
+        {({ data, loading }) => {
+          if (loading) {
+            return (
+              <LoadingContainer>
+                <ActivityIndicator color={colors.accent} />
+              </LoadingContainer>
+            );
+          }
 
-    return (
-      <SafeAreaViewFlex>
-        <Query
-          query={getQuery('publicJsonFile')}
-          variables={{ name: 'homeService' }}
-          fetchPolicy={fetchPolicy}
-        >
-          {({ data, loading }) => {
-            if (loading) {
-              return (
-                <LoadingContainer>
-                  <ActivityIndicator color={colors.accent} />
-                </LoadingContainer>
-              );
-            }
-
-            let publicJsonFileContent =
+          let publicJsonFileContent =
               data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
 
-            if (!publicJsonFileContent || !publicJsonFileContent.length) return null;
+          if (!publicJsonFileContent || !publicJsonFileContent.length) return null;
 
-            return (
-              <ScrollView>
+          return (
+            <ScrollView>
+              {!!headlineService && (
                 <TitleContainer>
-                  <Title>{texts.homeTitles.service}</Title>
+                  <Title>{headlineService}</Title>
                 </TitleContainer>
-                {device.platform === 'ios' && <TitleShadow />}
-                <View style={{ padding: normalize(14) }}>
-                  <WrapperWrap>
-                    {publicJsonFileContent.map((item, index) => {
-                      return (
-                        <ServiceBox key={index + item.title}>
-                          <TouchableOpacity
-                            onPress={() =>
-                              navigation.navigate({
-                                routeName: item.routeName,
-                                params: item.params
-                              })
-                            }
-                          >
-                            <View>
-                              {item.iconName ? (
-                                <TabBarIcon
-                                  name={item.iconName}
-                                  size={30}
-                                  style={styles.serviceIcon}
-                                />
-                              ) : (
-                                <Image
-                                  source={{ uri: item.icon }}
-                                  style={styles.serviceImage}
-                                  PlaceholderContent={null}
-                                />
-                              )}
-                              <BoldText small primary>
-                                {item.title}
-                              </BoldText>
-                            </View>
-                          </TouchableOpacity>
-                        </ServiceBox>
-                      );
-                    })}
-                  </WrapperWrap>
-                </View>
-              </ScrollView>
-            );
-          }}
-        </Query>
-      </SafeAreaViewFlex>
-    );
-  }
-}
+              )}
+              {!!headlineService && device.platform === 'ios' && <TitleShadow />}
+              <View style={{ padding: normalize(14) }}>
+                <WrapperWrap>
+                  {publicJsonFileContent.map((item, index) => {
+                    return (
+                      <ServiceBox key={index + item.title}>
+                        <TouchableOpacity
+                          onPress={() =>
+                            navigation.navigate({
+                              routeName: item.routeName,
+                              params: item.params
+                            })
+                          }
+                        >
+                          <View>
+                            {item.iconName ? (
+                              <TabBarIcon
+                                name={item.iconName}
+                                size={30}
+                                style={styles.serviceIcon}
+                              />
+                            ) : (
+                              <Image
+                                source={{ uri: item.icon }}
+                                style={styles.serviceImage}
+                                PlaceholderContent={null}
+                              />
+                            )}
+                            <BoldText small primary>
+                              {item.title}
+                            </BoldText>
+                          </View>
+                        </TouchableOpacity>
+                      </ServiceBox>
+                    );
+                  })}
+                </WrapperWrap>
+              </View>
+            </ScrollView>
+          );
+        }}
+      </Query>
+    </SafeAreaViewFlex>
+  );
+};
 
 const styles = StyleSheet.create({
   serviceIcon: {


### PR DESCRIPTION
- added variables from global settings
  - depend renderings based on that variables so it is server side configured, which of the main sections are visible and what headline texts are set
    - news, points of interests and tours, events
  - for the sub sections the headlines can also be set per server config
    - if no headline is set, no headline container will be rendered
    - service, company, about

Screenshot of server json:
![grafik](https://user-images.githubusercontent.com/1942953/90426458-640b6600-e0c1-11ea-98dd-76798033dc1c.png)

Resolves #68