### PR TITLE
feat(network error): retry authentication with forcing new token

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -19,9 +19,15 @@ const isTokenValid = async () => {
   return now < expires;
 };
 
-export const auth = async (callback) => {
+/**
+ * Requests the server to authenticate the mobile app with the main server.
+ *
+ * @param {requestCallback} callback the callback that needs authentication
+ * @param {boolean} forceNewToken trigger to force request for new token, default `false`
+ */
+export const auth = async (callback, forceNewToken = false) => {
   // if the token is still valid, just run the callback, if one exists
-  if (await isTokenValid()) return callback && callback();
+  if (!forceNewToken && await isTokenValid()) return callback && callback();
 
   // otherwise fetch a new access token and expire time
   const namespace = appJson.expo.slug;

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ const MainAppWithApolloProvider = () => {
       }
     }
   });
+  const [authRetried, setAuthRetried] = useState(false);
 
   /* eslint-disable complexity */
   /* NOTE: we need to check a lot for presence, so this is that complex */
@@ -114,8 +115,15 @@ const MainAppWithApolloProvider = () => {
       });
 
       globalSettingsData = response.data;
-    } catch (errors) {
-      console.warn('errors', errors);
+    } catch (error) {
+      console.warn('error', error);
+
+      if (error.message.includes('Network error')) {
+        // try once to authenticate with forcing a fresh token request
+        !authRetried && auth(setupApolloClient, true);
+        // set flag `true` to prevent endless loops
+        setAuthRetried(true);
+      }
     }
 
     const globalSettingsPublicJsonFileContent =


### PR DESCRIPTION
- added logic on network error while `auth()` on app
  start to retry the authentication with a forced fresh
  token request
  - if the app fails once with the default logic, the
    app tries the request again with requesting a new
    auth token
  - this can only be done once, otherwise we could
    crash in an endless loop of retries

---

This feature makes it possible to switch secrets and change the main server without problems. This was necessary for smooth development.