### PR TITLE
Add global setting to de-/activate for news filter

### DIFF
--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,6 +1,11 @@
 import { GET_CATEGORIES } from './categories';
 import { GET_EVENT_RECORD, GET_EVENT_RECORDS } from './eventRecords';
-import { GET_NEWS_ITEM, GET_NEWS_ITEMS, GET_NEWS_ITEMS_AND_DATA_PROVIDERS } from './newsItems';
+import {
+  GET_NEWS_ITEM,
+  GET_NEWS_ITEMS,
+  GET_FILTERED_NEWS_ITEMS,
+  GET_FILTERED_NEWS_ITEMS_AND_DATA_PROVIDERS
+} from './newsItems';
 import { GET_POINT_OF_INTEREST, GET_POINTS_OF_INTEREST } from './pointsOfInterest';
 import { GET_TOUR, GET_TOURS } from './tours';
 import { GET_POINTS_OF_INTEREST_AND_TOURS } from './pointsOfInterestAndTours';
@@ -9,7 +14,7 @@ import { GET_PUBLIC_JSON_FILE } from './publicJsonFiles';
 
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
-export const getQuery = (query) => {
+export const getQuery = (query, filterOptions = {}) => {
   switch (query) {
   case 'categories':
     return GET_CATEGORIES;
@@ -20,7 +25,9 @@ export const getQuery = (query) => {
   case 'newsItem':
     return GET_NEWS_ITEM;
   case 'newsItems':
-    return GET_NEWS_ITEMS_AND_DATA_PROVIDERS;
+    return filterOptions.showNewsFilter
+      ? GET_FILTERED_NEWS_ITEMS_AND_DATA_PROVIDERS
+      : GET_NEWS_ITEMS;
   case 'tour':
     return GET_TOUR;
   case 'tours':
@@ -39,11 +46,11 @@ export const getQuery = (query) => {
 };
 /* eslint-enable complexity */
 
-export const getFetchMoreQuery = (query) => {
+export const getFetchMoreQuery = (query, filterOptions = {}) => {
   switch (query) {
   case 'eventRecords':
     return GET_EVENT_RECORDS;
   case 'newsItems':
-    return GET_NEWS_ITEMS;
+    return filterOptions.showNewsFilter ? GET_FILTERED_NEWS_ITEMS : GET_NEWS_ITEMS;
   }
 };

--- a/src/queries/newsItems.js
+++ b/src/queries/newsItems.js
@@ -1,6 +1,43 @@
 import gql from 'graphql-tag';
 
 export const GET_NEWS_ITEMS = gql`
+  query NewsItems($limit: Int, $offset: Int) {
+    newsItems(limit: $limit, skip: $offset) {
+      id
+      mainTitle: title
+      publishedAt
+      contentBlocks {
+        id
+        title
+        intro
+        body
+        mediaContents {
+          id
+          contentType
+          copyright
+          sourceUrl {
+            url
+          }
+        }
+      }
+      sourceUrl {
+        url
+      }
+      dataProvider {
+        logo {
+          url
+        }
+        name
+      }
+      settings {
+        displayOnlySummary
+        onlySummaryLinkText
+      }
+    }
+  }
+`;
+
+export const GET_FILTERED_NEWS_ITEMS = gql`
   query NewsItems($limit: Int, $offset: Int, $dataProvider: String) {
     newsItems(limit: $limit, skip: $offset, dataProvider: $dataProvider) {
       id
@@ -37,7 +74,7 @@ export const GET_NEWS_ITEMS = gql`
   }
 `;
 
-export const GET_NEWS_ITEMS_AND_DATA_PROVIDERS = gql`
+export const GET_FILTERED_NEWS_ITEMS_AND_DATA_PROVIDERS = gql`
   query NewsItems($limit: Int, $offset: Int, $dataProvider: String) {
     newsItems(limit: $limit, skip: $offset, dataProvider: $dataProvider) {
       id

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { ActivityIndicator, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Query } from 'react-apollo';
 
@@ -25,272 +25,270 @@ import {
   shareMessage
 } from '../helpers';
 
-export class IndexScreen extends React.PureComponent {
-  static navigationOptions = ({ navigation }) => {
-    return {
-      headerLeft: (
-        <View>
-          <TouchableOpacity onPress={() => navigation.goBack()}>
-            <Icon icon={arrowLeft(colors.lightestText)} style={styles.icon} />
-          </TouchableOpacity>
-        </View>
-      )
-    };
-  };
-
-  static contextType = NetworkContext;
-
-  state = {
-    queryVariables: this.props.navigation.getParam('queryVariables', {})
-  };
-
-  componentDidMount() {
-    const isConnected = this.context.isConnected;
-
-    isConnected && auth();
-  }
-
-  /* eslint-disable complexity */
-  /* NOTE: we need to check a lot for presence, so this is that complex */
-  getListItems(query, data) {
-    switch (query) {
-    case 'eventRecords':
-      return (
-        data &&
-          data[query] &&
-          data[query].map((eventRecord) => ({
-            id: eventRecord.id,
-            subtitle: `${eventDate(eventRecord.listDate)} | ${
-              !!eventRecord.addresses &&
-              !!eventRecord.addresses.length &&
-              (eventRecord.addresses[0].addition || eventRecord.addresses[0].city)
-            }`,
-            title: eventRecord.title,
-            routeName: 'Detail',
-            params: {
-              title: 'Veranstaltung',
-              query: 'eventRecord',
-              queryVariables: { id: `${eventRecord.id}` },
-              rootRouteName: 'EventRecords',
-              shareContent: {
-                message: shareMessage(eventRecord, 'eventRecord')
-              },
-              details: eventRecord
-            }
-          }))
-      );
-    case 'newsItems':
-      return (
-        data &&
-          data[query] &&
-          data[query].map((newsItem) => ({
-            id: newsItem.id,
-            subtitle: `${momentFormat(newsItem.publishedAt)} | ${
-              !!newsItem.dataProvider && newsItem.dataProvider.name
-            }`,
-            title:
-              !!newsItem.contentBlocks &&
-              !!newsItem.contentBlocks.length &&
-              newsItem.contentBlocks[0].title,
-            routeName: 'Detail',
-            params: {
-              title: 'Nachricht',
-              query: 'newsItem',
-              queryVariables: { id: `${newsItem.id}` },
-              rootRouteName: 'NewsItems',
-              shareContent: {
-                message: shareMessage(newsItem, 'newsItem')
-              },
-              details: newsItem
-            }
-          }))
-      );
-    case 'pointsOfInterest':
-      return (
-        data &&
-          data[query] &&
-          data[query].map((pointOfInterest) => ({
-            id: pointOfInterest.id,
-            name: pointOfInterest.name,
-            category: !!pointOfInterest.category && pointOfInterest.category.name,
-            image: mainImageOfMediaContents(pointOfInterest.mediaContents),
-            routeName: 'Detail',
-            params: {
-              title: 'Ort',
-              query: 'pointOfInterest',
-              queryVariables: { id: `${pointOfInterest.id}` },
-              rootRouteName: 'PointsOfInterest',
-              shareContent: {
-                message: shareMessage(pointOfInterest, 'pointOfInterest')
-              },
-              details: pointOfInterest
-            }
-          }))
-      );
-    case 'tours':
-      return (
-        data &&
-          data[query] &&
-          data[query].map((tour) => ({
-            id: tour.id,
-            name: tour.name,
-            category: !!tour.category && tour.category.name,
-            image: mainImageOfMediaContents(tour.mediaContents),
-            routeName: 'Detail',
-            params: {
-              title: 'Tour',
-              query: 'tour',
-              queryVariables: { id: `${tour.id}` },
-              rootRouteName: 'Tours',
-              shareContent: {
-                message: shareMessage(tour, 'tour')
-              },
-              details: tour
-            }
-          }))
-      );
-
-    case 'categories': {
-      return (
-        data &&
-          data[query] &&
-          data[query].map((category) => ({
-            id: category.id,
-            title: category.name,
-            pointsOfInterestCount: category.pointsOfInterestCount,
-            toursCount: category.toursCount,
-            routeName: 'Index',
-            params: {
-              title: category.name,
-              query: category.pointsOfInterestCount > 0 ? 'pointsOfInterest' : 'tours',
-              queryVariables: { order: 'name_ASC', category: `${category.name}` },
-              rootRouteName: category.pointsOfInterestCount > 0 ? 'PointsOfInterest' : 'Tours'
-            }
-          }))
-      );
-    }
-    }
-  }
-  /* eslint-enable complexity */
-
-  getComponent(query) {
-    switch (query) {
-    case 'eventRecords':
-      return TextList;
-    case 'newsItems':
-      return TextList;
-    case 'pointsOfInterest':
-      return CardList;
-    case 'tours':
-      return CardList;
-    case 'categories':
-      return CategoryList;
-    }
-  }
-
-  getListHeaderComponent(query, queryVariables, data, updateListData) {
-    switch (query) {
-    case 'newsItems':
-      return (
-        <ListHeader queryVariables={queryVariables} data={data} updateListData={updateListData} />
-      );
-    }
-  }
-
-  render() {
-    let { queryVariables } = this.state;
-    const { navigation } = this.props;
-    const query = navigation.getParam('query', '');
-
-    if (!query) return null;
-
-    const { isConnected, isMainserverUp } = this.context;
-    const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
-
-    // if offline, pagination with partially fetching data is not possible, so we cannot pass
-    // a probably given `limit` variable. remove that `limit` with destructing, like in this
-    // example: https://stackoverflow.com/a/51478664/9956365
-    if (!isConnected) {
-      const { limit, ...queryVariablesWithoutLimit } = queryVariables;
-
-      queryVariables = queryVariablesWithoutLimit;
-    }
-
+/* eslint-disable complexity */
+/* NOTE: we need to check a lot for presence, so this is that complex */
+const getListItems = (query, data) => {
+  switch (query) {
+  case 'eventRecords':
     return (
-      <Query query={getQuery(query)} variables={queryVariables} fetchPolicy={fetchPolicy}>
-        {({ data, loading, fetchMore }) => {
-          if (loading) {
-            return (
-              <LoadingContainer>
-                <ActivityIndicator color={colors.accent} />
-              </LoadingContainer>
-            );
+      data &&
+        data[query] &&
+        data[query].map((eventRecord) => ({
+          id: eventRecord.id,
+          subtitle: `${eventDate(eventRecord.listDate)} | ${
+            !!eventRecord.addresses &&
+            !!eventRecord.addresses.length &&
+            (eventRecord.addresses[0].addition || eventRecord.addresses[0].city)
+          }`,
+          title: eventRecord.title,
+          routeName: 'Detail',
+          params: {
+            title: 'Veranstaltung',
+            query: 'eventRecord',
+            queryVariables: { id: `${eventRecord.id}` },
+            rootRouteName: 'EventRecords',
+            shareContent: {
+              message: shareMessage(eventRecord, 'eventRecord')
+            },
+            details: eventRecord
           }
+        }))
+    );
+  case 'newsItems':
+    return (
+      data &&
+        data[query] &&
+        data[query].map((newsItem) => ({
+          id: newsItem.id,
+          subtitle: `${momentFormat(newsItem.publishedAt)} | ${
+            !!newsItem.dataProvider && newsItem.dataProvider.name
+          }`,
+          title:
+            !!newsItem.contentBlocks &&
+            !!newsItem.contentBlocks.length &&
+            newsItem.contentBlocks[0].title,
+          routeName: 'Detail',
+          params: {
+            title: 'Nachricht',
+            query: 'newsItem',
+            queryVariables: { id: `${newsItem.id}` },
+            rootRouteName: 'NewsItems',
+            shareContent: {
+              message: shareMessage(newsItem, 'newsItem')
+            },
+            details: newsItem
+          }
+        }))
+    );
+  case 'pointsOfInterest':
+    return (
+      data &&
+        data[query] &&
+        data[query].map((pointOfInterest) => ({
+          id: pointOfInterest.id,
+          name: pointOfInterest.name,
+          category: !!pointOfInterest.category && pointOfInterest.category.name,
+          image: mainImageOfMediaContents(pointOfInterest.mediaContents),
+          routeName: 'Detail',
+          params: {
+            title: 'Ort',
+            query: 'pointOfInterest',
+            queryVariables: { id: `${pointOfInterest.id}` },
+            rootRouteName: 'PointsOfInterest',
+            shareContent: {
+              message: shareMessage(pointOfInterest, 'pointOfInterest')
+            },
+            details: pointOfInterest
+          }
+        }))
+    );
+  case 'tours':
+    return (
+      data &&
+        data[query] &&
+        data[query].map((tour) => ({
+          id: tour.id,
+          name: tour.name,
+          category: !!tour.category && tour.category.name,
+          image: mainImageOfMediaContents(tour.mediaContents),
+          routeName: 'Detail',
+          params: {
+            title: 'Tour',
+            query: 'tour',
+            queryVariables: { id: `${tour.id}` },
+            rootRouteName: 'Tours',
+            shareContent: {
+              message: shareMessage(tour, 'tour')
+            },
+            details: tour
+          }
+        }))
+    );
 
-          const listItems = this.getListItems(query, data);
-
-          if (!listItems || !listItems.length) return null;
-
-          const Component = this.getComponent(query);
-          const fetchMoreData = () =>
-            fetchMore({
-              query: getFetchMoreQuery(query),
-              variables: {
-                ...queryVariables,
-                offset: listItems.length
-              },
-              updateQuery: (prevResult, { fetchMoreResult }) => {
-                if (!fetchMoreResult || !fetchMoreResult[query].length) return prevResult;
-
-                return {
-                  ...prevResult,
-                  [query]: [...prevResult[query], ...fetchMoreResult[query]]
-                };
-              }
-            });
-
-          const updateListData = (selectedDataProvider) => {
-            const { dataProvider, ...queryVariablesWithoutDataProvider } = queryVariables;
-
-            this.setState({
-              queryVariables: selectedDataProvider
-                ? {
-                  ...queryVariables,
-                  dataProvider: selectedDataProvider
-                }
-                : queryVariablesWithoutDataProvider
-            });
-          };
-
-          const ListHeaderComponent = this.getListHeaderComponent(
-            query,
-            queryVariables,
-            data,
-            updateListData
-          );
-
-          return (
-            <SafeAreaViewFlex>
-              <Component
-                navigation={navigation}
-                data={listItems}
-                query={query}
-                fetchMoreData={isConnected ? fetchMoreData : null}
-                ListHeaderComponent={ListHeaderComponent}
-              />
-            </SafeAreaViewFlex>
-          );
-        }}
-      </Query>
+  case 'categories': {
+    return (
+      data &&
+        data[query] &&
+        data[query].map((category) => ({
+          id: category.id,
+          title: category.name,
+          pointsOfInterestCount: category.pointsOfInterestCount,
+          toursCount: category.toursCount,
+          routeName: 'Index',
+          params: {
+            title: category.name,
+            query: category.pointsOfInterestCount > 0 ? 'pointsOfInterest' : 'tours',
+            queryVariables: { order: 'name_ASC', category: `${category.name}` },
+            rootRouteName: category.pointsOfInterestCount > 0 ? 'PointsOfInterest' : 'Tours'
+          }
+        }))
     );
   }
-}
+  }
+};
+/* eslint-enable complexity */
+
+const getComponent = (query) => {
+  switch (query) {
+  case 'eventRecords':
+    return TextList;
+  case 'newsItems':
+    return TextList;
+  case 'pointsOfInterest':
+    return CardList;
+  case 'tours':
+    return CardList;
+  case 'categories':
+    return CategoryList;
+  }
+};
+
+const getListHeaderComponent = (query, queryVariables, data, updateListData) => {
+  switch (query) {
+  case 'newsItems':
+    return (
+      <ListHeader queryVariables={queryVariables} data={data} updateListData={updateListData} />
+    );
+  }
+};
+
+export const IndexScreen = ({ navigation }) => {
+  const { isConnected, isMainserverUp } = useContext(NetworkContext);
+  const query = navigation.getParam('query', '');
+  const [queryVariables, setQueryVariables] = useState(navigation.getParam('queryVariables', {}));
+
+  if (!query) return null;
+
+  useEffect(() => {
+    isConnected && auth();
+  }, []);
+
+  const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
+
+  // if offline, pagination with partially fetching data is not possible, so we cannot pass
+  // a probably given `limit` variable. remove that `limit` with destructing, like in this
+  // example: https://stackoverflow.com/a/51478664/9956365
+  const getQueryVariables = () => {
+    if (!isConnected) {
+      /* NOTE: remove `limit`, which is super easy with spread operator */
+      /* eslint-disable-next-line no-unused-vars */
+      const { limit, ...queryVariablesWithoutLimit } = queryVariables;
+
+      return queryVariablesWithoutLimit;
+    }
+
+    return queryVariables;
+  };
+
+  const Component = getComponent(query);
+
+  const updateListData = (selectedDataProvider) => {
+    if (selectedDataProvider) {
+      setQueryVariables({
+        ...queryVariables,
+        dataProvider: selectedDataProvider
+      });
+    } else {
+      /* NOTE: remove `dataProvider`, which is super easy with spread operator */
+      /* eslint-disable-next-line no-unused-vars */
+      const { dataProvider, ...queryVariablesWithoutDataProvider } = queryVariables;
+
+      setQueryVariables(queryVariablesWithoutDataProvider);
+    }
+  };
+
+  return (
+    <Query query={getQuery(query)} variables={getQueryVariables()} fetchPolicy={fetchPolicy}>
+      {({ data, loading, fetchMore }) => {
+        if (loading) {
+          return (
+            <LoadingContainer>
+              <ActivityIndicator color={colors.accent} />
+            </LoadingContainer>
+          );
+        }
+
+        const listItems = getListItems(query, data);
+
+        if (!listItems || !listItems.length) return null;
+
+        const fetchMoreData = () =>
+          fetchMore({
+            query: getFetchMoreQuery(query),
+            variables: {
+              ...queryVariables,
+              offset: listItems.length
+            },
+            updateQuery: (prevResult, { fetchMoreResult }) => {
+              if (!fetchMoreResult || !fetchMoreResult[query].length) return prevResult;
+
+              return {
+                ...prevResult,
+                [query]: [...prevResult[query], ...fetchMoreResult[query]]
+              };
+            }
+          });
+
+        const ListHeaderComponent = getListHeaderComponent(
+          query,
+          queryVariables,
+          data,
+          updateListData
+        );
+
+        return (
+          <SafeAreaViewFlex>
+            <Component
+              navigation={navigation}
+              data={listItems}
+              query={query}
+              fetchMoreData={isConnected ? fetchMoreData : null}
+              ListHeaderComponent={ListHeaderComponent}
+            />
+          </SafeAreaViewFlex>
+        );
+      }}
+    </Query>
+  );
+};
 
 const styles = StyleSheet.create({
   icon: {
     paddingHorizontal: normalize(14)
   }
 });
+
+IndexScreen.navigationOptions = ({ navigation }) => {
+  return {
+    headerLeft: (
+      <View>
+        <TouchableOpacity onPress={() => navigation.goBack()}>
+          <Icon icon={arrowLeft(colors.lightestText)} style={styles.icon} />
+        </TouchableOpacity>
+      </View>
+    )
+  };
+};
 
 IndexScreen.propTypes = {
   navigation: PropTypes.object.isRequired

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -222,8 +222,12 @@ export const IndexScreen = ({ navigation }) => {
   };
 
   return (
-    <Query query={getQuery(query)} variables={getQueryVariables()} fetchPolicy={fetchPolicy}>
-      {({ data, loading, fetchMore }) => {
+    <Query
+      query={getQuery(query, { showNewsFilter })}
+      variables={getQueryVariables()}
+      fetchPolicy={fetchPolicy}
+    >
+      {({ data, error, loading, fetchMore }) => {
         if (loading) {
           return (
             <LoadingContainer>
@@ -238,7 +242,7 @@ export const IndexScreen = ({ navigation }) => {
 
         const fetchMoreData = () =>
           fetchMore({
-            query: getFetchMoreQuery(query),
+            query: getFetchMoreQuery(query, { showNewsFilter }),
             variables: {
               ...queryVariables,
               offset: listItems.length
@@ -256,12 +260,7 @@ export const IndexScreen = ({ navigation }) => {
         let ListHeaderComponent = null;
 
         if (showNewsFilter) {
-          ListHeaderComponent = getListHeaderComponent(
-            query,
-            queryVariables,
-            data,
-            updateListData
-          );
+          ListHeaderComponent = getListHeaderComponent(query, queryVariables, data, updateListData);
         }
 
         return (

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -4,6 +4,7 @@ import { ActivityIndicator, StyleSheet, TouchableOpacity, View } from 'react-nat
 import { Query } from 'react-apollo';
 
 import { NetworkContext } from '../NetworkProvider';
+import { GlobalSettingsContext } from '../GlobalSettingsProvider';
 import { auth } from '../auth';
 import { colors, normalize } from '../config';
 import {
@@ -184,6 +185,9 @@ export const IndexScreen = ({ navigation }) => {
   }, []);
 
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
+  const globalSettings = useContext(GlobalSettingsContext);
+  const { filter = {} } = globalSettings;
+  const { news: showNewsFilter = false } = filter;
 
   // if offline, pagination with partially fetching data is not possible, so we cannot pass
   // a probably given `limit` variable. remove that `limit` with destructing, like in this
@@ -249,12 +253,16 @@ export const IndexScreen = ({ navigation }) => {
             }
           });
 
-        const ListHeaderComponent = getListHeaderComponent(
-          query,
-          queryVariables,
-          data,
-          updateListData
-        );
+        let ListHeaderComponent = null;
+
+        if (showNewsFilter) {
+          ListHeaderComponent = getListHeaderComponent(
+            query,
+            queryVariables,
+            data,
+            updateListData
+          );
+        }
 
         return (
           <SafeAreaViewFlex>


### PR DESCRIPTION
For better backwards compatibility and to avoid conflicts with server versions, a global setting is added for news filter, whether to show in the app or not.

To implement this, the `IndexScreen` needed an update to a functional component and the usage of hooks.

<img width="271" alt="Bildschirmfoto 2020-09-18 um 16 09 42" src="https://user-images.githubusercontent.com/1942953/93612390-bb0d9f00-f9cf-11ea-8d0a-776407d393a7.png">
