### PR TITLE
Add processing of a new button key in subQuery at HtmlScreen

### DIFF
--- a/src/screens/HtmlScreen.js
+++ b/src/screens/HtmlScreen.js
@@ -45,19 +45,34 @@ export const HtmlScreen = ({ navigation }) => {
   const rootRouteName = navigation.getParam('rootRouteName', '');
   const subQuery = navigation.getParam('subQuery', '');
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp, refreshTime });
+
   // action to open source urls
-  const openWebScreen = (webUrl) => {
-    if (!!webUrl && typeof webUrl === 'string') {
+  const openWebScreen = (param) => {
+    // if the `param` is a string, it is directly the web url to call
+    if (!!param && typeof param === 'string') {
       return navigation.navigate({
         routeName: 'Web',
         params: {
           title,
-          webUrl,
+          webUrl: param,
           rootRouteName
         }
       });
     }
 
+    // if the `param` is an object, it contains a `routeName` and a `webUrl`
+    if (!!param && typeof param === 'object') {
+      return navigation.navigate({
+        routeName: param.routeName,
+        params: {
+          title,
+          webUrl: param.webUrl,
+          rootRouteName
+        }
+      });
+    }
+
+    // if there is no `param`, use the main `subQuery` values for `routeName` and a `webUrl`
     return navigation.navigate({
       routeName: subQuery.routeName,
       params: {
@@ -94,12 +109,23 @@ export const HtmlScreen = ({ navigation }) => {
                   openWebScreen={openWebScreen}
                   navigation={navigation}
                 />
-                {!!subQuery && !!subQuery.routeName && (
+                {!!subQuery && !!subQuery.routeName && !!subQuery.webUrl && (
                   <Button
                     title={subQuery.buttonTitle || `${title} öffnen`}
-                    onPress={openWebScreen}
+                    onPress={() => openWebScreen()}
                   />
                 )}
+                {!!subQuery &&
+                  !!subQuery.buttons &&
+                  subQuery.buttons.map((button, index) => (
+                    <Button
+                      key={`${index}-${button.webUrl}`}
+                      title={button.buttonTitle || `${title} öffnen`}
+                      onPress={() =>
+                        openWebScreen({ routeName: button.routeName, webUrl: button.webUrl })
+                      }
+                    />
+                  ))}
               </Wrapper>
             </ScrollView>
           </SafeAreaViewFlex>


### PR DESCRIPTION
- there can be new data in `subQuery` at a `buttons` key with an array of objects, that contain information for navigation to web links
- extended logic in `openWebScreen` to determine which data to use for navigation
- adjusted existing button to call `openWebScreen` without params, so that always the fallback will be used from the method
  - with just passing `openWebScreen` instead of `() => openWebScreen()` there would be automatically bound some params from `onPress`

JSON | Screen
-------|-------
![Bildschirmfoto 2020-09-18 um 18.19.37](https://user-images.githubusercontent.com/1942953/93622707-e0090e80-f9dd-11ea-9e2d-8f6bc7a56783.png) | ![Simulator Screen Shot - iPhone 8 Plus - 2020-09-18 at 18 18 21](https://user-images.githubusercontent.com/1942953/93622716-e4cdc280-f9dd-11ea-87b0-b535c07242d1.png)

