### PR TITLE
feat(pull to refresh): add refetching in every screen

### DIFF
--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -14,7 +14,7 @@ export class CardList extends React.PureComponent {
 
   render() {
     const { listEndReached } = this.state;
-    const { data, navigation, horizontal } = this.props;
+    const { data, navigation, horizontal, refreshControl } = this.props;
 
     if (horizontal) {
       return (
@@ -44,6 +44,7 @@ export class CardList extends React.PureComponent {
           )
         }
         onEndReached={() => this.setState({ listEndReached: true })}
+        refreshControl={refreshControl}
       />
     );
   }
@@ -52,7 +53,8 @@ export class CardList extends React.PureComponent {
 CardList.propTypes = {
   navigation: PropTypes.object.isRequired,
   data: PropTypes.array.isRequired,
-  horizontal: PropTypes.bool
+  horizontal: PropTypes.bool,
+  refreshControl: PropTypes.object
 };
 
 CardList.defaultProps = {

--- a/src/components/CategoryList.js
+++ b/src/components/CategoryList.js
@@ -22,7 +22,7 @@ export class CategoryList extends React.PureComponent {
   );
 
   render() {
-    const { data, navigation, noSubtitle } = this.props;
+    const { data, navigation, noSubtitle, refreshControl } = this.props;
 
     const sectionedData = [
       {
@@ -56,6 +56,7 @@ export class CategoryList extends React.PureComponent {
           </Wrapper>
         }
         stickySectionHeadersEnabled
+        refreshControl={refreshControl}
       />
     );
   }
@@ -64,7 +65,8 @@ export class CategoryList extends React.PureComponent {
 CategoryList.propTypes = {
   navigation: PropTypes.object.isRequired,
   data: PropTypes.array.isRequired,
-  noSubtitle: PropTypes.bool
+  noSubtitle: PropTypes.bool,
+  refreshControl: PropTypes.object
 };
 
 CategoryList.defaultProps = {

--- a/src/components/TextList.js
+++ b/src/components/TextList.js
@@ -28,7 +28,7 @@ export class TextList extends React.PureComponent {
 
   render() {
     const { listEndReached } = this.state;
-    const { data, navigation, noSubtitle, ListHeaderComponent } = this.props;
+    const { data, navigation, noSubtitle, ListHeaderComponent, refreshControl } = this.props;
 
     return (
       <FlatList
@@ -46,6 +46,7 @@ export class TextList extends React.PureComponent {
         }
         onEndReachedThreshold={0.5}
         onEndReached={this.onEndReached}
+        refreshControl={refreshControl}
       />
     );
   }
@@ -57,7 +58,8 @@ TextList.propTypes = {
   noSubtitle: PropTypes.bool,
   query: PropTypes.string,
   fetchMoreData: PropTypes.func,
-  ListHeaderComponent: PropTypes.object
+  ListHeaderComponent: PropTypes.object,
+  refreshControl: PropTypes.object
 };
 
 TextList.defaultProps = {

--- a/src/components/screens/About.js
+++ b/src/components/screens/About.js
@@ -11,7 +11,7 @@ import { TextList } from '../TextList';
 import { getQuery } from '../../queries';
 import { graphqlFetchPolicy, refreshTimeFor } from '../../helpers';
 
-export const About = ({ navigation }) => {
+export const About = ({ navigation, refreshing }) => {
   const [refreshTime, setRefreshTime] = useState();
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const globalSettings = useContext(GlobalSettingsContext);
@@ -38,7 +38,10 @@ export const About = ({ navigation }) => {
       variables={{ name: 'homeAbout' }}
       fetchPolicy={fetchPolicy}
     >
-      {({ data, loading }) => {
+      {({ data, loading, refetch }) => {
+        // call the refetch method of Apollo after `refreshing` is given with `true`, which happens
+        // when pull to refresh is used in the parent component
+        if (refreshing) refetch();
         if (loading) return null;
 
         let publicJsonFileContent =
@@ -63,5 +66,10 @@ export const About = ({ navigation }) => {
 };
 
 About.propTypes = {
-  navigation: PropTypes.object.isRequired
+  navigation: PropTypes.object.isRequired,
+  refreshing: PropTypes.bool
+};
+
+About.defaultProps = {
+  refreshing: false
 };

--- a/src/components/screens/Carousel.js
+++ b/src/components/screens/Carousel.js
@@ -11,7 +11,7 @@ import { LoadingContainer } from '../LoadingContainer';
 import { getQuery } from '../../queries';
 import { graphqlFetchPolicy, refreshTimeFor } from '../../helpers';
 
-export const Carousel = ({ navigation }) => {
+export const Carousel = ({ navigation, refreshing }) => {
   const [refreshTime, setRefreshTime] = useState();
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
 
@@ -41,7 +41,10 @@ export const Carousel = ({ navigation }) => {
       variables={{ name: 'homeCarousel' }}
       fetchPolicy={fetchPolicy}
     >
-      {({ data, loading }) => {
+      {({ data, loading, refetch }) => {
+        // call the refetch method of Apollo after `refreshing` is given with `true`, which happens
+        // when pull to refresh is used in the parent component
+        if (refreshing) refetch();
         if (loading) {
           return (
             <LoadingContainer>
@@ -67,5 +70,10 @@ export const Carousel = ({ navigation }) => {
 };
 
 Carousel.propTypes = {
-  navigation: PropTypes.object.isRequired
+  navigation: PropTypes.object.isRequired,
+  refreshing: PropTypes.bool
+};
+
+Carousel.defaultProps = {
+  refreshing: false
 };

--- a/src/components/screens/Service.js
+++ b/src/components/screens/Service.js
@@ -16,7 +16,7 @@ import { getQuery } from '../../queries';
 import { graphqlFetchPolicy, refreshTimeFor } from '../../helpers';
 import TabBarIcon from '../TabBarIcon';
 
-export const Service = ({ navigation }) => {
+export const Service = ({ navigation, refreshing }) => {
   const [refreshTime, setRefreshTime] = useState();
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const globalSettings = useContext(GlobalSettingsContext);
@@ -43,7 +43,10 @@ export const Service = ({ navigation }) => {
       variables={{ name: 'homeService' }}
       fetchPolicy={fetchPolicy}
     >
-      {({ data, loading }) => {
+      {({ data, loading, refetch }) => {
+        // call the refetch method of Apollo after `refreshing` is given with `true`, which happens
+        // when pull to refresh is used in the parent component
+        if (refreshing) refetch();
         if (loading) return null;
 
         let publicJsonFileContent =
@@ -114,5 +117,10 @@ const styles = StyleSheet.create({
 });
 
 Service.propTypes = {
-  navigation: PropTypes.object.isRequired
+  navigation: PropTypes.object.isRequired,
+  refreshing: PropTypes.bool
+};
+
+Service.defaultProps = {
+  refreshing: false
 };

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
-import React, { useContext, useEffect } from 'react';
-import { ActivityIndicator, ScrollView, View } from 'react-native';
+import React, { useContext, useEffect, useState } from 'react';
+import { ActivityIndicator, RefreshControl, ScrollView, View } from 'react-native';
 import { Query } from 'react-apollo';
 import _shuffle from 'lodash/shuffle';
 
@@ -52,14 +52,36 @@ export const HomeScreen = ({ navigation }) => {
     headlineEvents = texts.homeTitles.events,
     buttonEvents = texts.homeButtons.events
   } = sections;
+  const [refreshing, setRefreshing] = useState(false);
 
   useEffect(() => {
     isConnected && auth();
   }, []);
 
+  const refresh = () => {
+    setRefreshing(true);
+    // for refetching data on the home screen we need to re-render the whole screen,
+    // in order to re-run every existing query.
+    // there is no solution to call the Apollo `refetch` for every `Query` component.
+    // we simulate state change of `refreshing` with setting it to `true` first and after
+    // a timeout to `false` again, which will result in a re-rendering of the screen.
+    setTimeout(() => {
+      setRefreshing(false);
+    }, 500);
+  };
+
   return (
     <SafeAreaViewFlex>
-      <ScrollView>
+      <ScrollView
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={refresh}
+            colors={[colors.accent]}
+            tintColor={colors.accent}
+          />
+        }
+      >
         <Carousel navigation={navigation} />
 
         {showNews && (
@@ -348,8 +370,8 @@ export const HomeScreen = ({ navigation }) => {
 
         {globalSettings.navigation === consts.DRAWER && (
           <>
-            <Service navigation={navigation} />
-            <About navigation={navigation} />
+            <Service navigation={navigation} refreshing={refreshing} />
+            <About navigation={navigation} refreshing={refreshing} />
             <VersionNumber />
           </>
         )}

--- a/src/screens/HtmlScreen.js
+++ b/src/screens/HtmlScreen.js
@@ -1,6 +1,13 @@
 import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
-import { ActivityIndicator, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import {
+  ActivityIndicator,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  View
+} from 'react-native';
 import { Query } from 'react-apollo';
 
 import { NetworkContext } from '../NetworkProvider';
@@ -16,6 +23,7 @@ export const HtmlScreen = ({ navigation }) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const query = navigation.getParam('query', '');
   const queryVariables = navigation.getParam('queryVariables', '');
+  const [refreshing, setRefreshing] = useState(false);
 
   if (!query || !queryVariables || !queryVariables.name) return null;
 
@@ -40,6 +48,12 @@ export const HtmlScreen = ({ navigation }) => {
       </LoadingContainer>
     );
   }
+
+  const refresh = async (refetch) => {
+    setRefreshing(true);
+    await refetch();
+    setRefreshing(false);
+  };
 
   const title = navigation.getParam('title', '');
   const rootRouteName = navigation.getParam('rootRouteName', '');
@@ -89,7 +103,7 @@ export const HtmlScreen = ({ navigation }) => {
       variables={{ name: queryVariables.name }}
       fetchPolicy={fetchPolicy}
     >
-      {({ data, loading }) => {
+      {({ data, loading, refetch }) => {
         if (loading) {
           return (
             <LoadingContainer>
@@ -102,7 +116,16 @@ export const HtmlScreen = ({ navigation }) => {
 
         return (
           <SafeAreaViewFlex>
-            <ScrollView>
+            <ScrollView
+              refreshControl={
+                <RefreshControl
+                  refreshing={refreshing}
+                  onRefresh={() => refresh(refetch)}
+                  colors={[colors.accent]}
+                  tintColor={colors.accent}
+                />
+              }
+            >
               <Wrapper>
                 <HtmlView
                   html={trimNewLines(data.publicHtmlFile.content)}

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -1,6 +1,12 @@
 import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
-import { ActivityIndicator, StyleSheet, TouchableOpacity, View } from 'react-native';
+import {
+  ActivityIndicator,
+  RefreshControl,
+  StyleSheet,
+  TouchableOpacity,
+  View
+} from 'react-native';
 import { Query } from 'react-apollo';
 
 import { NetworkContext } from '../NetworkProvider';
@@ -177,12 +183,19 @@ export const IndexScreen = ({ navigation }) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const query = navigation.getParam('query', '');
   const [queryVariables, setQueryVariables] = useState(navigation.getParam('queryVariables', {}));
+  const [refreshing, setRefreshing] = useState(false);
 
   if (!query) return null;
 
   useEffect(() => {
     isConnected && auth();
   }, []);
+
+  const refresh = async (refetch) => {
+    setRefreshing(true);
+    await refetch();
+    setRefreshing(false);
+  };
 
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
   const globalSettings = useContext(GlobalSettingsContext);
@@ -227,7 +240,7 @@ export const IndexScreen = ({ navigation }) => {
       variables={getQueryVariables()}
       fetchPolicy={fetchPolicy}
     >
-      {({ data, error, loading, fetchMore }) => {
+      {({ data, loading, fetchMore, refetch }) => {
         if (loading) {
           return (
             <LoadingContainer>
@@ -271,6 +284,14 @@ export const IndexScreen = ({ navigation }) => {
               query={query}
               fetchMoreData={isConnected ? fetchMoreData : null}
               ListHeaderComponent={ListHeaderComponent}
+              refreshControl={
+                <RefreshControl
+                  refreshing={refreshing}
+                  onRefresh={() => refresh(refetch)}
+                  colors={[colors.accent]}
+                  tintColor={colors.accent}
+                />
+              }
             />
           </SafeAreaViewFlex>
         );

--- a/src/screens/ServiceScreen.js
+++ b/src/screens/ServiceScreen.js
@@ -1,6 +1,13 @@
 import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
-import { ActivityIndicator, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import {
+  ActivityIndicator,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  View
+} from 'react-native';
 import { Query } from 'react-apollo';
 
 import { NetworkContext } from '../NetworkProvider';
@@ -25,6 +32,7 @@ export const ServiceScreen = ({ navigation }) => {
   const [refreshTime, setRefreshTime] = useState();
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const globalSettings = useContext(GlobalSettingsContext);
+  const [refreshing, setRefreshing] = useState(false);
 
   useEffect(() => {
     const getRefreshTime = async () => {
@@ -44,6 +52,12 @@ export const ServiceScreen = ({ navigation }) => {
     );
   }
 
+  const refresh = async (refetch) => {
+    setRefreshing(true);
+    await refetch();
+    setRefreshing(false);
+  };
+
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp, refreshTime });
   const { sections = {} } = globalSettings;
   const { headlineService = texts.homeTitles.service } = sections;
@@ -55,7 +69,7 @@ export const ServiceScreen = ({ navigation }) => {
         variables={{ name: 'homeService' }}
         fetchPolicy={fetchPolicy}
       >
-        {({ data, loading }) => {
+        {({ data, loading, refetch }) => {
           if (loading) {
             return (
               <LoadingContainer>
@@ -70,51 +84,62 @@ export const ServiceScreen = ({ navigation }) => {
           if (!publicJsonFileContent || !publicJsonFileContent.length) return null;
 
           return (
-            <ScrollView>
+            <>
               {!!headlineService && (
                 <TitleContainer>
                   <Title>{headlineService}</Title>
                 </TitleContainer>
               )}
               {!!headlineService && device.platform === 'ios' && <TitleShadow />}
-              <View style={{ padding: normalize(14) }}>
-                <WrapperWrap>
-                  {publicJsonFileContent.map((item, index) => {
-                    return (
-                      <ServiceBox key={index + item.title}>
-                        <TouchableOpacity
-                          onPress={() =>
-                            navigation.navigate({
-                              routeName: item.routeName,
-                              params: item.params
-                            })
-                          }
-                        >
-                          <View>
-                            {item.iconName ? (
-                              <TabBarIcon
-                                name={item.iconName}
-                                size={30}
-                                style={styles.serviceIcon}
-                              />
-                            ) : (
-                              <Image
-                                source={{ uri: item.icon }}
-                                style={styles.serviceImage}
-                                PlaceholderContent={null}
-                              />
-                            )}
-                            <BoldText small primary center>
-                              {item.title}
-                            </BoldText>
-                          </View>
-                        </TouchableOpacity>
-                      </ServiceBox>
-                    );
-                  })}
-                </WrapperWrap>
-              </View>
-            </ScrollView>
+              <ScrollView
+                refreshControl={
+                  <RefreshControl
+                    refreshing={refreshing}
+                    onRefresh={() => refresh(refetch)}
+                    colors={[colors.accent]}
+                    tintColor={colors.accent}
+                  />
+                }
+              >
+                <View style={{ padding: normalize(14) }}>
+                  <WrapperWrap>
+                    {publicJsonFileContent.map((item, index) => {
+                      return (
+                        <ServiceBox key={index + item.title}>
+                          <TouchableOpacity
+                            onPress={() =>
+                              navigation.navigate({
+                                routeName: item.routeName,
+                                params: item.params
+                              })
+                            }
+                          >
+                            <View>
+                              {item.iconName ? (
+                                <TabBarIcon
+                                  name={item.iconName}
+                                  size={30}
+                                  style={styles.serviceIcon}
+                                />
+                              ) : (
+                                <Image
+                                  source={{ uri: item.icon }}
+                                  style={styles.serviceImage}
+                                  PlaceholderContent={null}
+                                />
+                              )}
+                              <BoldText small primary center>
+                                {item.title}
+                              </BoldText>
+                            </View>
+                          </TouchableOpacity>
+                        </ServiceBox>
+                      );
+                    })}
+                  </WrapperWrap>
+                </View>
+              </ScrollView>
+            </>
           );
         }}
       </Query>


### PR DESCRIPTION
- it will be possible to pull to refresh in every screen to update
  data without respecting the refresh time logic
- the solution is a combination of https://reactnative.dev/docs/refreshcontrol
  with https://www.apollographql.com/docs/react/v2.6/data/queries/#refetching
- added `RefreshControl` in screens to trigger `refetch` of the existing query
  - in `IndexScreen` the `refreshControl` is passed down as prop to the actual
    component that gets rendered (`TextList`, `CardList`, `CategoryList`)
- in `HomeScreen` there are multiple queries. for refetching data on the home screen
  we need to re-render the whole screen, in order to re-run every existing query.
  there is no solution to call the Apollo `refetch` for every `Query` component.
  we simulate state change of `refreshing` with setting it to `true` first and after
  a timeout to `false` again, which will result in a re-rendering of the screen.
  - for `Carousel`, `Service` and `About`, the query is inside the component.
    a refetch is triggered with passing `refreshing` with `true`, which happens
    while pull to refresh in `HomeScreen`

Resolves #95 