### PR TITLE
Accessibility hints and labels recognized by VoiceOver (iOS) and TalkBack (Android)

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -20,6 +20,7 @@ export const Button = ({ title, onPress }) => {
       containerStyle={[styles.containerStyle, needLandscapeStyle && styles.containerStyleLandscape]}
       ViewComponent={DiagonalGradient}
       useForeground
+      accessibilityLabel={`${title} (Taste)`}
     />
   );
 };

--- a/src/components/CardListItem.js
+++ b/src/components/CardListItem.js
@@ -12,6 +12,7 @@ import { Touchable } from './Touchable';
 export const CardListItem = memo(({ navigation, horizontal, item, orientation, dimensions }) => {
   const { routeName, params, image, category, name } = item;
 
+  // TODO: accessibility logic needs to be implemented
   return (
     <Touchable
       onPress={() =>

--- a/src/components/CardListItem.js
+++ b/src/components/CardListItem.js
@@ -12,9 +12,10 @@ import { Touchable } from './Touchable';
 export const CardListItem = memo(({ navigation, horizontal, item, orientation, dimensions }) => {
   const { routeName, params, image, category, name } = item;
 
-  // TODO: accessibility logic needs to be implemented
+  // TODO: count articles logic could to be implemented
   return (
     <Touchable
+      accessibilityLabel={`(${category}) ${name} (Taste)`}
       onPress={() =>
         navigation.navigate({
           routeName,

--- a/src/components/CategoryList.js
+++ b/src/components/CategoryList.js
@@ -15,7 +15,7 @@ export class CategoryList extends React.PureComponent {
   renderSectionHeader = ({ section: { title } }) => (
     <View>
       <TitleContainer>
-        <Title>{title}</Title>
+        <Title accessibilityLabel={`${title} (Überschrift)`}>{title}</Title>
       </TitleContainer>
       {device.platform === 'ios' && <TitleShadow />}
     </View>

--- a/src/components/CategoryListItem.js
+++ b/src/components/CategoryListItem.js
@@ -50,7 +50,7 @@ export class CategoryListItem extends React.PureComponent {
         }
         delayPressIn={0}
         Component={Touchable}
-        accessibilityLabel={`${title} (Anzahl verfügbarer Einträge ${count}) (Taste)`}
+        accessibilityLabel={`${title} (Anzahl verfügbarer Einträge: ${count}) (Taste)`}
       />
     );
   }

--- a/src/components/CategoryListItem.js
+++ b/src/components/CategoryListItem.js
@@ -32,8 +32,8 @@ export class CategoryListItem extends React.PureComponent {
           bottomDivider !== undefined
             ? bottomDivider
             : item.toursCount > 0
-            ? index < section.data.length - 1 // do not show a bottomDivider after last tours entry
-            : true
+              ? index < section.data.length - 1 // do not show a bottomDivider after last entry
+              : true
         }
         topDivider={topDivider !== undefined ? topDivider : false}
         containerStyle={{

--- a/src/components/CategoryListItem.js
+++ b/src/components/CategoryListItem.js
@@ -32,8 +32,8 @@ export class CategoryListItem extends React.PureComponent {
           bottomDivider !== undefined
             ? bottomDivider
             : item.toursCount > 0
-              ? index < section.data.length - 1 // do not show a bottomDivider after last tours entry
-              : true
+            ? index < section.data.length - 1 // do not show a bottomDivider after last tours entry
+            : true
         }
         topDivider={topDivider !== undefined ? topDivider : false}
         containerStyle={{
@@ -50,6 +50,7 @@ export class CategoryListItem extends React.PureComponent {
         }
         delayPressIn={0}
         Component={Touchable}
+        accessibilityLabel={`${title} (Anzahl verfügbarer Einträge ${count}) (Taste)`}
       />
     );
   }

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -34,24 +34,18 @@ export const Image = ({ source, style, PlaceholderContent }) => {
   }, []);
 
   if (!globalSettings.showImageRights || !source.copyright) {
-    // TODO: how to make an image accessible? is the accessibilityLabel working? maybe put it at the surrounding View?
     return (
       <RNEImage
         source={uri ? (source.uri ? { uri } : uri) : null}
         style={style}
         PlaceholderContent={PlaceholderContent}
         placeholderStyle={{ backgroundColor: colors.transparent }}
-        // TODO: is accessible needed?
-        accessible
-        // TODO: needs correct label. we want to ue a captionText here, which needs to come as a prop from outside
-        //       only apply that caption text to accessibilityLabel if there is one
-        // the captionText can be available per source.captionText
-        accessibilityLabel={`${PlaceholderContent}`}
+        accessible={!!source.captionText}
+        accessibilityLabel={source.captionText}
       />
     );
   }
 
-  // TODO: how to make an image accessible? is the accessibilityLabel working? maybe put it at the surrounding View?
   return (
     <View>
       <RNEImage
@@ -59,12 +53,8 @@ export const Image = ({ source, style, PlaceholderContent }) => {
         style={style}
         PlaceholderContent={PlaceholderContent}
         placeholderStyle={{ backgroundColor: colors.transparent }}
-        // TODO: is accessible needed?
-        accessible
-        // TODO: needs correct label. we want to ue a captionText here, which needs to come as a prop from outside
-        //       only apply that caption text to accessibilityLabel if there is one
-        // the captionText can be available per source.captionText
-        accessibilityLabel={`${PlaceholderContent}`}
+        accessible={!!source.captionText}
+        accessibilityLabel={source.captionText}
       />
       <ImageRights imageRights={source.copyright} />
     </View>

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -34,18 +34,24 @@ export const Image = ({ source, style, PlaceholderContent }) => {
   }, []);
 
   if (!globalSettings.showImageRights || !source.copyright) {
+    // TODO: how to make an image accessible? is the accessibilityLabel working? maybe put it at the surrounding View?
     return (
       <RNEImage
         source={uri ? (source.uri ? { uri } : uri) : null}
         style={style}
         PlaceholderContent={PlaceholderContent}
         placeholderStyle={{ backgroundColor: colors.transparent }}
+        // TODO: is accessible needed?
         accessible
+        // TODO: needs correct label. we want to ue a captionText here, which needs to come as a prop from outside
+        //       only apply that caption text to accessibilityLabel if there is one
+        // the captionText can be available per source.captionText
         accessibilityLabel={`${PlaceholderContent}`}
       />
     );
   }
-  // TODO Image is not accessible here, why ?
+
+  // TODO: how to make an image accessible? is the accessibilityLabel working? maybe put it at the surrounding View?
   return (
     <View>
       <RNEImage
@@ -53,7 +59,11 @@ export const Image = ({ source, style, PlaceholderContent }) => {
         style={style}
         PlaceholderContent={PlaceholderContent}
         placeholderStyle={{ backgroundColor: colors.transparent }}
+        // TODO: is accessible needed?
         accessible
+        // TODO: needs correct label. we want to ue a captionText here, which needs to come as a prop from outside
+        //       only apply that caption text to accessibilityLabel if there is one
+        // the captionText can be available per source.captionText
         accessibilityLabel={`${PlaceholderContent}`}
       />
       <ImageRights imageRights={source.copyright} />

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -40,7 +40,7 @@ export const Image = ({ source, style, PlaceholderContent }) => {
         style={style}
         PlaceholderContent={PlaceholderContent}
         placeholderStyle={{ backgroundColor: colors.transparent }}
-        accessible={true}
+        accessible
         accessibilityLabel={`${PlaceholderContent}`}
       />
     );
@@ -53,7 +53,7 @@ export const Image = ({ source, style, PlaceholderContent }) => {
         style={style}
         PlaceholderContent={PlaceholderContent}
         placeholderStyle={{ backgroundColor: colors.transparent }}
-        accessible={true}
+        accessible
         accessibilityLabel={`${PlaceholderContent}`}
       />
       <ImageRights imageRights={source.copyright} />

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -40,10 +40,12 @@ export const Image = ({ source, style, PlaceholderContent }) => {
         style={style}
         PlaceholderContent={PlaceholderContent}
         placeholderStyle={{ backgroundColor: colors.transparent }}
+        accessible={true}
+        accessibilityLabel={`${PlaceholderContent}`}
       />
     );
   }
-
+  // TODO Image is not accessible here, why ?
   return (
     <View>
       <RNEImage
@@ -51,6 +53,8 @@ export const Image = ({ source, style, PlaceholderContent }) => {
         style={style}
         PlaceholderContent={PlaceholderContent}
         placeholderStyle={{ backgroundColor: colors.transparent }}
+        accessible={true}
+        accessibilityLabel={`${PlaceholderContent}`}
       />
       <ImageRights imageRights={source.copyright} />
     </View>

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -10,7 +10,11 @@ import { RegularText } from './Text';
 import { WrapperRow } from './Wrapper';
 
 export const Link = ({ url, description, openWebScreen }) => (
-  <TouchableOpacity onPress={() => openLink(url, openWebScreen)}>
+  <TouchableOpacity
+    onPress={() => openLink(url, openWebScreen)}
+    accessibilityLabel="Link"
+    accessibilityHint="Navigieren zur Link"
+  >
     <WrapperRow>
       <Icon xml={link(colors.secondary)} style={styles.icon} />
       <RegularText primary>{description}</RegularText>

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -12,8 +12,7 @@ import { WrapperRow } from './Wrapper';
 export const Link = ({ url, description, openWebScreen }) => (
   <TouchableOpacity
     onPress={() => openLink(url, openWebScreen)}
-    accessibilityLabel="Link"
-    accessibilityHint="Navigieren zur Link"
+    accessibilityLabel={`${description} (Taste)`}
   >
     <WrapperRow>
       <Icon xml={link(colors.secondary)} style={styles.icon} />

--- a/src/components/TextListItem.js
+++ b/src/components/TextListItem.js
@@ -33,8 +33,7 @@ export class TextListItem extends React.PureComponent {
         }
         delayPressIn={0}
         Component={Touchable}
-        accessibilityLabel="Listeneintrag"
-        accessibilityHint="Navigiert zum Article"
+        accessibilityLabel={`${title} (Taste)`}
       />
     );
   }

--- a/src/components/TextListItem.js
+++ b/src/components/TextListItem.js
@@ -33,6 +33,8 @@ export class TextListItem extends React.PureComponent {
         }
         delayPressIn={0}
         Component={Touchable}
+        accessibilityLabel="Listeneintrag"
+        accessibilityHint="Navigiert zum Article"
       />
     );
   }

--- a/src/components/VersionNumber.js
+++ b/src/components/VersionNumber.js
@@ -9,7 +9,12 @@ import { Wrapper } from './Wrapper.js';
 export const VersionNumber = () => {
   return (
     <Wrapper>
-      <RegularText small style={styles.version}>
+      <RegularText
+        small
+        style={styles.version}
+        accessible={true}
+        accessibilityLabel={`(App version:) ${appJson.expo.version} `}
+      >
         Version: {appJson.expo.version}
       </RegularText>
     </Wrapper>

--- a/src/components/VersionNumber.js
+++ b/src/components/VersionNumber.js
@@ -12,8 +12,8 @@ export const VersionNumber = () => {
       <RegularText
         small
         style={styles.version}
-        accessible={true}
-        accessibilityLabel={`(App version:) ${appJson.expo.version} `}
+        accessible
+        accessibilityLabel={`App version: ${appJson.expo.version}`}
       >
         Version: {appJson.expo.version}
       </RegularText>

--- a/src/components/VersionNumber.js
+++ b/src/components/VersionNumber.js
@@ -12,8 +12,7 @@ export const VersionNumber = () => {
       <RegularText
         small
         style={styles.version}
-        accessible
-        accessibilityLabel={`App version: ${appJson.expo.version}`}
+        accessibilityLabel={`App-Version: ${appJson.expo.version}`}
       >
         Version: {appJson.expo.version}
       </RegularText>

--- a/src/components/screens/About.js
+++ b/src/components/screens/About.js
@@ -56,7 +56,7 @@ export const About = ({ navigation, refreshing }) => {
           <View>
             {!!headlineAbout && (
               <TitleContainer>
-                <Title>{headlineAbout}</Title>
+                <Title accessibilityLabel={`${headlineAbout} (Überschrift)`}>{headlineAbout}</Title>
               </TitleContainer>
             )}
             {!!headlineAbout && device.platform === 'ios' && <TitleShadow />}

--- a/src/components/screens/EventRecord.js
+++ b/src/components/screens/EventRecord.js
@@ -76,7 +76,8 @@ export const EventRecord = ({ data, navigation }) => {
         images.push({
           picture: {
             uri: mediaContent.sourceUrl.url,
-            copyright: mediaContent.copyright
+            copyright: mediaContent.copyright,
+            captionText: mediaContent.captionText
           }
         });
     });

--- a/src/components/screens/EventRecord.js
+++ b/src/components/screens/EventRecord.js
@@ -117,18 +117,14 @@ export const EventRecord = ({ data, navigation }) => {
 
         {!!title && !!link ? (
           <TitleContainer>
-            <Touchable
-              onPress={openWebScreen}
-              accessibilityLabel="Webseite"
-              accessibilityHint="Navigieren zur Webseite"
-            >
-              <Title>{title}</Title>
+            <Touchable onPress={openWebScreen}>
+              <Title accessibilityLabel={`${title} (Überschrift) (Taste)`}>{title}</Title>
             </Touchable>
           </TitleContainer>
         ) : (
           !!title && (
             <TitleContainer>
-              <Title>{title}</Title>
+              <Title accessibilityLabel={`${title} (Überschrift)`}>{title}</Title>
             </TitleContainer>
           )
         )}

--- a/src/components/screens/EventRecord.js
+++ b/src/components/screens/EventRecord.js
@@ -145,7 +145,9 @@ export const EventRecord = ({ data, navigation }) => {
         {!!dates && !!dates.length && (
           <View>
             <TitleContainer>
-              <Title>{texts.eventRecord.appointments}</Title>
+              <Title accessibilityLabel={`${texts.eventRecord.appointments} (Überschrift) `}>
+                {texts.eventRecord.appointments}
+              </Title>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <OpeningTimesCard openingHours={dates} />
@@ -156,7 +158,9 @@ export const EventRecord = ({ data, navigation }) => {
         {!!priceInformations && !!priceInformations.length && !!priceInformations[0].description && (
           <View>
             <TitleContainer>
-              <Title>{texts.eventRecord.prices}</Title>
+              <Title accessibilityLabel={`${texts.eventRecord.prices} (Überschrift)`}>
+                {texts.eventRecord.prices}
+              </Title>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <PriceCard prices={priceInformations} />
@@ -166,7 +170,9 @@ export const EventRecord = ({ data, navigation }) => {
         {!!description && (
           <View>
             <TitleContainer>
-              <Title>{texts.eventRecord.description}</Title>
+              <Title accessibilityLabel={`${texts.eventRecord.description} (Überschrift)`}>
+                {texts.eventRecord.description}
+              </Title>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <Wrapper>
@@ -185,7 +191,9 @@ export const EventRecord = ({ data, navigation }) => {
         {!!operatingCompany && (
           <View>
             <TitleContainer>
-              <Title>{texts.eventRecord.operatingCompany}</Title>
+              <Title accessibilityLabel={`${texts.eventRecord.operatingCompany} (Überschrift)`}>
+                {texts.eventRecord.operatingCompany}
+              </Title>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <OperatingCompanyInfo

--- a/src/components/screens/EventRecord.js
+++ b/src/components/screens/EventRecord.js
@@ -117,7 +117,11 @@ export const EventRecord = ({ data, navigation }) => {
 
         {!!title && !!link ? (
           <TitleContainer>
-            <Touchable onPress={openWebScreen}>
+            <Touchable
+              onPress={openWebScreen}
+              accessibilityLabel="Webseite"
+              accessibilityHint="Navigieren zur Webseite"
+            >
               <Title>{title}</Title>
             </Touchable>
           </TitleContainer>

--- a/src/components/screens/InfoCard.js
+++ b/src/components/screens/InfoCard.js
@@ -32,7 +32,7 @@ const contactView = (contact) => (
       <InfoBox>
         <Icon xml={phoneIcon(colors.primary)} style={styles.margin} />
         <TouchableOpacity
-          accessibilityLabel={`(Telefonnummer) (${contact.phone}) (Taste) (Wechselt zur Telefon-App)`}
+          accessibilityLabel={`(Telefonnummer) ${contact.phone} (Taste) (Wechselt zur Telefon-App)`}
           onPress={() => openLink(`tel:${contact.phone}`)}
         >
           <RegularText primary>{contact.phone}</RegularText>
@@ -45,7 +45,7 @@ const contactView = (contact) => (
         <Icon xml={mail(colors.primary)} style={styles.margin} />
         <TouchableOpacity
           onPress={() => openLink(`mailto:${contact.email}`)}
-          accessibilityLabel={`(E-mail) (${contact.email}) (Taste) (Wechselt zur E-Mail-App)`}
+          accessibilityLabel={`(E-mail) ${contact.email} (Taste) (Wechselt zur E-Mail-App)`}
         >
           <RegularText primary>{contact.email}</RegularText>
         </TouchableOpacity>
@@ -55,7 +55,9 @@ const contactView = (contact) => (
     {!!contact.fax && (
       <InfoBox>
         <RNEIcon name="print" type="material" color={colors.primary} iconStyle={styles.margin} />
-        <RegularText primary>{contact.fax}</RegularText>
+        <RegularText primary accessible accessibilityLabel={`(Fax) ${contact.fax}`}>
+          {contact.fax}
+        </RegularText>
       </InfoBox>
     )}
   </View>
@@ -70,14 +72,14 @@ export const InfoCard = ({ addresses, category, contact, contacts, webUrls, open
     {!!category && !!category.name && (
       <InfoBox>
         <RNEIcon
-          accessible={true}
+          accessible
           accessibilityLabel="Menü icon"
           name="list"
           type="material"
           color={colors.primary}
           iconStyle={styles.margin}
         />
-        <RegularText accessible={true} accessibilityLabel={`(Kategorie) (${category.name}`}>
+        <RegularText accessible accessibilityLabel={`(Kategorie) ${category.name}`}>
           {category.name}
         </RegularText>
       </InfoBox>
@@ -108,7 +110,7 @@ export const InfoCard = ({ addresses, category, contact, contacts, webUrls, open
           <InfoBox key={index}>
             <Icon xml={location(colors.primary)} style={styles.margin} />
             <TouchableOpacity
-              accessibilityLabel={`(Adresse) (${address}) (Taste) (Wechselt zur Karten-App)`}
+              accessibilityLabel={`(Adresse) ${address} (Taste) (Wechselt zur Karten-App)`}
               onPress={() => addressOnPress(address)}
             >
               <RegularText primary>{address}</RegularText>
@@ -153,7 +155,7 @@ export const InfoCard = ({ addresses, category, contact, contacts, webUrls, open
             <Icon xml={urlIcon(colors.primary)} style={styles.margin} />
             <TouchableOpacity
               onPress={() => openLink(url, openWebScreen)}
-              accessibilityLabel={`(Webseite) (${description}) (Taste) (Öffnet Webseite in der aktuellen App)`}
+              accessibilityLabel={`(Webseite) ${description} (Taste) (Öffnet Webseite in der aktuellen App)`}
             >
               {!description && <RegularText primary>{url}</RegularText>}
               {!!description && <RegularText primary>{description}</RegularText>}

--- a/src/components/screens/InfoCard.js
+++ b/src/components/screens/InfoCard.js
@@ -31,7 +31,11 @@ const contactView = (contact) => (
     {!!contact.phone && (
       <InfoBox>
         <Icon xml={phoneIcon(colors.primary)} style={styles.margin} />
-        <TouchableOpacity onPress={() => openLink(`tel:${contact.phone}`)}>
+        <TouchableOpacity
+          accessibilityLabel="Telefonnummer"
+          accessibilityHint="Navigieren zu anruf option"
+          onPress={() => openLink(`tel:${contact.phone}`)}
+        >
           <RegularText primary>{contact.phone}</RegularText>
         </TouchableOpacity>
       </InfoBox>
@@ -40,7 +44,11 @@ const contactView = (contact) => (
     {!!contact.email && (
       <InfoBox>
         <Icon xml={mail(colors.primary)} style={styles.margin} />
-        <TouchableOpacity onPress={() => openLink(`mailto:${contact.email}`)}>
+        <TouchableOpacity
+          onPress={() => openLink(`mailto:${contact.email}`)}
+          accessibilityLabel="E-mail-Adresse"
+          accessibilityHint="Navigieren zur E-mail-App"
+        >
           <RegularText primary>{contact.email}</RegularText>
         </TouchableOpacity>
       </InfoBox>
@@ -92,7 +100,11 @@ export const InfoCard = ({ addresses, category, contact, contacts, webUrls, open
         return (
           <InfoBox key={index}>
             <Icon xml={location(colors.primary)} style={styles.margin} />
-            <TouchableOpacity onPress={() => addressOnPress(address)}>
+            <TouchableOpacity
+              accessibilityLabel="Adresse"
+              accessibilityHint="Navigieren zur Karten-App"
+              onPress={() => addressOnPress(address)}
+            >
               <RegularText primary>{address}</RegularText>
             </TouchableOpacity>
           </InfoBox>
@@ -133,7 +145,11 @@ export const InfoCard = ({ addresses, category, contact, contacts, webUrls, open
         return (
           <InfoBox key={index}>
             <Icon xml={urlIcon(colors.primary)} style={styles.margin} />
-            <TouchableOpacity onPress={() => openLink(url, openWebScreen)}>
+            <TouchableOpacity
+              onPress={() => openLink(url, openWebScreen)}
+              accessibilityLabel="Webseite"
+              accessibilityHint="Navigieren zur Webseite"
+            >
               {!description && <RegularText primary>{url}</RegularText>}
               {!!description && <RegularText primary>{description}</RegularText>}
             </TouchableOpacity>

--- a/src/components/screens/InfoCard.js
+++ b/src/components/screens/InfoCard.js
@@ -32,8 +32,7 @@ const contactView = (contact) => (
       <InfoBox>
         <Icon xml={phoneIcon(colors.primary)} style={styles.margin} />
         <TouchableOpacity
-          accessibilityLabel="Telefonnummer"
-          accessibilityHint="Navigieren zu anruf option"
+          accessibilityLabel={`(Telefonnummer) (${contact.phone}) (Taste) (Wechselt zur Telefon-App)`}
           onPress={() => openLink(`tel:${contact.phone}`)}
         >
           <RegularText primary>{contact.phone}</RegularText>
@@ -46,8 +45,7 @@ const contactView = (contact) => (
         <Icon xml={mail(colors.primary)} style={styles.margin} />
         <TouchableOpacity
           onPress={() => openLink(`mailto:${contact.email}`)}
-          accessibilityLabel="E-mail-Adresse"
-          accessibilityHint="Navigieren zur E-mail-App"
+          accessibilityLabel={`(E-mail) (${contact.email}) (Taste) (Wechselt zur E-Mail-App)`}
         >
           <RegularText primary>{contact.email}</RegularText>
         </TouchableOpacity>
@@ -71,8 +69,17 @@ export const InfoCard = ({ addresses, category, contact, contacts, webUrls, open
   <View>
     {!!category && !!category.name && (
       <InfoBox>
-        <RNEIcon name="list" type="material" color={colors.primary} iconStyle={styles.margin} />
-        <RegularText>{category.name}</RegularText>
+        <RNEIcon
+          accessible={true}
+          accessibilityLabel="Menü icon"
+          name="list"
+          type="material"
+          color={colors.primary}
+          iconStyle={styles.margin}
+        />
+        <RegularText accessible={true} accessibilityLabel={`(Kategorie) (${category.name}`}>
+          {category.name}
+        </RegularText>
       </InfoBox>
     )}
 
@@ -101,8 +108,7 @@ export const InfoCard = ({ addresses, category, contact, contacts, webUrls, open
           <InfoBox key={index}>
             <Icon xml={location(colors.primary)} style={styles.margin} />
             <TouchableOpacity
-              accessibilityLabel="Adresse"
-              accessibilityHint="Navigieren zur Karten-App"
+              accessibilityLabel={`(Adresse) (${address}) (Taste) (Wechselt zur Karten-App)`}
               onPress={() => addressOnPress(address)}
             >
               <RegularText primary>{address}</RegularText>
@@ -147,8 +153,7 @@ export const InfoCard = ({ addresses, category, contact, contacts, webUrls, open
             <Icon xml={urlIcon(colors.primary)} style={styles.margin} />
             <TouchableOpacity
               onPress={() => openLink(url, openWebScreen)}
-              accessibilityLabel="Webseite"
-              accessibilityHint="Navigieren zur Webseite"
+              accessibilityLabel={`(Webseite) (${description}) (Taste) (Öffnet Webseite in der aktuellen App)`}
             >
               {!description && <RegularText primary>{url}</RegularText>}
               {!!description && <RegularText primary>{description}</RegularText>}

--- a/src/components/screens/InfoCard.js
+++ b/src/components/screens/InfoCard.js
@@ -31,11 +31,13 @@ const contactView = (contact) => (
     {!!contact.phone && (
       <InfoBox>
         <Icon xml={phoneIcon(colors.primary)} style={styles.margin} />
-        <TouchableOpacity
-          accessibilityLabel={`(Telefonnummer) ${contact.phone} (Taste) (Wechselt zur Telefon-App)`}
-          onPress={() => openLink(`tel:${contact.phone}`)}
-        >
-          <RegularText primary>{contact.phone}</RegularText>
+        <TouchableOpacity onPress={() => openLink(`tel:${contact.phone}`)}>
+          <RegularText
+            primary
+            accessibilityLabel={`(Telefonnummer) ${contact.phone} (Taste) (Wechselt zur Telefon-App)`}
+          >
+            {contact.phone}
+          </RegularText>
         </TouchableOpacity>
       </InfoBox>
     )}
@@ -43,11 +45,13 @@ const contactView = (contact) => (
     {!!contact.email && (
       <InfoBox>
         <Icon xml={mail(colors.primary)} style={styles.margin} />
-        <TouchableOpacity
-          onPress={() => openLink(`mailto:${contact.email}`)}
-          accessibilityLabel={`(E-mail) ${contact.email} (Taste) (Wechselt zur E-Mail-App)`}
-        >
-          <RegularText primary>{contact.email}</RegularText>
+        <TouchableOpacity onPress={() => openLink(`mailto:${contact.email}`)}>
+          <RegularText
+            primary
+            accessibilityLabel={`(E-Mail) ${contact.email} (Taste) (Wechselt zur E-Mail-App)`}
+          >
+            {contact.email}
+          </RegularText>
         </TouchableOpacity>
       </InfoBox>
     )}
@@ -55,7 +59,7 @@ const contactView = (contact) => (
     {!!contact.fax && (
       <InfoBox>
         <RNEIcon name="print" type="material" color={colors.primary} iconStyle={styles.margin} />
-        <RegularText primary accessible accessibilityLabel={`(Fax) ${contact.fax}`}>
+        <RegularText primary accessibilityLabel={`(Fax) ${contact.fax}`}>
           {contact.fax}
         </RegularText>
       </InfoBox>
@@ -71,15 +75,8 @@ export const InfoCard = ({ addresses, category, contact, contacts, webUrls, open
   <View>
     {!!category && !!category.name && (
       <InfoBox>
-        <RNEIcon
-          accessible
-          accessibilityLabel="Menü icon"
-          name="list"
-          type="material"
-          color={colors.primary}
-          iconStyle={styles.margin}
-        />
-        <RegularText accessible accessibilityLabel={`(Kategorie) ${category.name}`}>
+        <RNEIcon name="list" type="material" color={colors.primary} iconStyle={styles.margin} />
+        <RegularText accessibilityLabel={`(Kategorie) ${category.name}`}>
           {category.name}
         </RegularText>
       </InfoBox>
@@ -109,11 +106,13 @@ export const InfoCard = ({ addresses, category, contact, contacts, webUrls, open
         return (
           <InfoBox key={index}>
             <Icon xml={location(colors.primary)} style={styles.margin} />
-            <TouchableOpacity
-              accessibilityLabel={`(Adresse) ${address} (Taste) (Wechselt zur Karten-App)`}
-              onPress={() => addressOnPress(address)}
-            >
-              <RegularText primary>{address}</RegularText>
+            <TouchableOpacity onPress={() => addressOnPress(address)}>
+              <RegularText
+                primary
+                accessibilityLabel={`(Adresse) ${address} (Taste) (Wechselt zur Karten-App)`}
+              >
+                {address}
+              </RegularText>
             </TouchableOpacity>
           </InfoBox>
         );
@@ -154,8 +153,10 @@ export const InfoCard = ({ addresses, category, contact, contacts, webUrls, open
           <InfoBox key={index}>
             <Icon xml={urlIcon(colors.primary)} style={styles.margin} />
             <TouchableOpacity
+              accessibilityLabel={`(Webseite) ${
+                description || url
+              } (Taste) (Öffnet Webseite in der aktuellen App)`}
               onPress={() => openLink(url, openWebScreen)}
-              accessibilityLabel={`(Webseite) ${description} (Taste) (Öffnet Webseite in der aktuellen App)`}
             >
               {!description && <RegularText primary>{url}</RegularText>}
               {!!description && <RegularText primary>{description}</RegularText>}

--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -208,13 +208,17 @@ export const NewsItem = ({ data, navigation }) => {
         {!!title && !!link ? (
           <TitleContainer>
             <Touchable onPress={openWebScreen}>
-              <Title accessibilityLabel={`${title} (Überschrift)`}>{trimNewLines(title)}</Title>
+              <Title accessibilityLabel={`${trimNewLines(title)} (Überschrift)`}>
+                {trimNewLines(title)}
+              </Title>
             </Touchable>
           </TitleContainer>
         ) : (
           !!title && (
             <TitleContainer>
-              <Title accessibilityLabel={`${title} (Überschrift)`}>{trimNewLines(title)}</Title>
+              <Title accessibilityLabel={`${trimNewLines(title)} (Überschrift)`}>
+                {trimNewLines(title)}
+              </Title>
             </TitleContainer>
           )
         )}

--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -208,13 +208,13 @@ export const NewsItem = ({ data, navigation }) => {
         {!!title && !!link ? (
           <TitleContainer>
             <Touchable onPress={openWebScreen}>
-              <Title>{trimNewLines(title)}</Title>
+              <Title accessibilityLabel={`${title} (Überschrift)`}>{trimNewLines(title)}</Title>
             </Touchable>
           </TitleContainer>
         ) : (
           !!title && (
             <TitleContainer>
-              <Title>{trimNewLines(title)}</Title>
+              <Title accessibilityLabel={`${title} (Überschrift)`}>{trimNewLines(title)}</Title>
             </TitleContainer>
           )
         )}

--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -67,7 +67,8 @@ export const NewsItem = ({ data, navigation }) => {
         mainImages.push({
           picture: {
             uri: mediaContent.sourceUrl.url,
-            copyright: mediaContent.copyright
+            copyright: mediaContent.copyright,
+            captionText: mediaContent.captionText
           }
         });
     });
@@ -123,7 +124,8 @@ export const NewsItem = ({ data, navigation }) => {
               sectionImages.push({
                 picture: {
                   uri: mediaContent.sourceUrl.url,
-                  copyright: mediaContent.copyright
+                  copyright: mediaContent.copyright,
+                  captionText: mediaContent.captionText
                 }
               });
           });

--- a/src/components/screens/OperatingCompanyInfo.js
+++ b/src/components/screens/OperatingCompanyInfo.js
@@ -63,11 +63,13 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
       {!!companyAddress && (
         <InfoBox>
           <Icon xml={location(colors.primary)} style={styles.margin} />
-          <TouchableOpacity
-            onPress={() => addressOnPress(companyAddress)}
-            accessibilityLabel={`(Adresse) ${companyAddress} (Taste) (Wechselt zur Karten-App)`}
-          >
-            <RegularText primary>{companyAddress}</RegularText>
+          <TouchableOpacity onPress={() => addressOnPress(companyAddress)}>
+            <RegularText
+              primary
+              accessibilityLabel={`(Adresse) ${companyAddress} (Taste) (Wechselt zur Karten-App)`}
+            >
+              {companyAddress}
+            </RegularText>
           </TouchableOpacity>
         </InfoBox>
       )}
@@ -89,22 +91,26 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
           {!!contact.phone && (
             <InfoBox>
               <Icon xml={phoneIcon(colors.primary)} style={styles.margin} />
-              <TouchableOpacity
-                onPress={() => openLink(`tel:${contact.phone}`)}
-                accessibilityLabel={`(Telefonnummer) ${contact.phone} (Taste) (Wechselt zur Telefon-App)`}
-              >
-                <RegularText primary>{contact.phone}</RegularText>
+              <TouchableOpacity onPress={() => openLink(`tel:${contact.phone}`)}>
+                <RegularText
+                  primary
+                  accessibilityLabel={`(Telefonnummer) ${contact.phone} (Taste) (Wechselt zur Telefon-App)`}
+                >
+                  {contact.phone}
+                </RegularText>
               </TouchableOpacity>
             </InfoBox>
           )}
           {!!contact.email && (
             <InfoBox>
               <Icon xml={mail(colors.primary)} style={styles.margin} />
-              <TouchableOpacity
-                onPress={() => openLink(`mailto:${contact.email}`)}
-                accessibilityLabel={`(E-mail-Adresse) ${contact.email} (Taste) (Wechselt zur Email-App)`}
-              >
-                <RegularText primary>{contact.email}</RegularText>
+              <TouchableOpacity onPress={() => openLink(`mailto:${contact.email}`)}>
+                <RegularText
+                  primary
+                  accessibilityLabel={`(E-Mail-Adresse) ${contact.email} (Taste) (Wechselt zur E-Mail-App)`}
+                >
+                  {contact.email}
+                </RegularText>
               </TouchableOpacity>
             </InfoBox>
           )}
@@ -116,7 +122,7 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
                 color={colors.primary}
                 iconStyle={{ marginRight: normalize(10) }}
               />
-              <RegularText primary accessible accessibilityLabel={`(Fax) ${contact.fax}`}>
+              <RegularText primary accessibilityLabel={`(Fax) ${contact.fax}`}>
                 {contact.fax}
               </RegularText>
             </InfoBox>
@@ -124,11 +130,13 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
           {!!contact.www && (
             <InfoBox>
               <Icon xml={link(colors.primary)} style={styles.marginWww} />
-              <TouchableOpacity
-                onPress={() => openLink(contact.www, openWebScreen)}
-                accessibilityLabel={`(Webseite) ${contact.www} (Taste) (Öffnet Webseite in der aktuellen App)`}
-              >
-                <RegularText primary>{contact.www}</RegularText>
+              <TouchableOpacity onPress={() => openLink(contact.www, openWebScreen)}>
+                <RegularText
+                  primary
+                  accessibilityLabel={`(Webseite) ${contact.www} (Taste) (Öffnet Webseite in der aktuellen App)`}
+                >
+                  {contact.www}
+                </RegularText>
               </TouchableOpacity>
             </InfoBox>
           )}

--- a/src/components/screens/OperatingCompanyInfo.js
+++ b/src/components/screens/OperatingCompanyInfo.js
@@ -63,7 +63,11 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
       {!!companyAddress && (
         <InfoBox>
           <Icon xml={location(colors.primary)} style={styles.margin} />
-          <TouchableOpacity onPress={() => addressOnPress(companyAddress)}>
+          <TouchableOpacity
+            onPress={() => addressOnPress(companyAddress)}
+            accessibilityLabel="Adresse"
+            accessibilityHint="Navigieren zur Karten-App"
+          >
             <RegularText primary>{companyAddress}</RegularText>
           </TouchableOpacity>
         </InfoBox>
@@ -86,7 +90,11 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
           {!!contact.phone && (
             <InfoBox>
               <Icon xml={phoneIcon(colors.primary)} style={styles.margin} />
-              <TouchableOpacity onPress={() => openLink(`tel:${contact.phone}`)}>
+              <TouchableOpacity
+                onPress={() => openLink(`tel:${contact.phone}`)}
+                accessibilityLabel="Telefonnummer"
+                accessibilityHint="Navigieren zu anruf option"
+              >
                 <RegularText primary>{contact.phone}</RegularText>
               </TouchableOpacity>
             </InfoBox>
@@ -94,26 +102,36 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
           {!!contact.email && (
             <InfoBox>
               <Icon xml={mail(colors.primary)} style={styles.margin} />
-              <TouchableOpacity onPress={() => openLink(`mailto:${contact.email}`)}>
+              <TouchableOpacity
+                onPress={() => openLink(`mailto:${contact.email}`)}
+                accessibilityLabel="E-mail-Adresse"
+                accessibilityHint="Navigieren zur E-mail-App"
+              >
                 <RegularText primary>{contact.email}</RegularText>
               </TouchableOpacity>
             </InfoBox>
           )}
           {!!contact.fax && (
-            <InfoBox>
+            <InfoBox accessible={true}>
               <RNEIcon
                 name="print"
                 type="material"
                 color={colors.primary}
                 iconStyle={{ marginRight: normalize(10) }}
               />
-              <RegularText primary>{contact.fax}</RegularText>
+              <RegularText primary accessibilityLabel="Fax-nummer">
+                {contact.fax}
+              </RegularText>
             </InfoBox>
           )}
           {!!contact.www && (
             <InfoBox>
               <Icon xml={link(colors.primary)} style={styles.marginWww} />
-              <TouchableOpacity onPress={() => openLink(contact.www, openWebScreen)}>
+              <TouchableOpacity
+                onPress={() => openLink(contact.www, openWebScreen)}
+                accessibilityLabel="Webseite"
+                accessibilityHint="Navigieren zur Webseite"
+              >
                 <RegularText primary>{contact.www}</RegularText>
               </TouchableOpacity>
             </InfoBox>
@@ -130,7 +148,11 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
           return (
             <InfoBox key={index}>
               <Icon xml={urlIcon(colors.primary)} style={styles.margin} />
-              <TouchableOpacity onPress={() => openLink(url, openWebScreen)}>
+              <TouchableOpacity
+                onPress={() => openLink(url, openWebScreen)}
+                accessibilityLabel="Webseite"
+                accessibilityHint="Navigieren zur Webseite"
+              >
                 <RegularText primary>{url}</RegularText>
               </TouchableOpacity>
             </InfoBox>

--- a/src/components/screens/OperatingCompanyInfo.js
+++ b/src/components/screens/OperatingCompanyInfo.js
@@ -65,8 +65,7 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
           <Icon xml={location(colors.primary)} style={styles.margin} />
           <TouchableOpacity
             onPress={() => addressOnPress(companyAddress)}
-            accessibilityLabel="Adresse"
-            accessibilityHint="Navigieren zur Karten-App"
+            accessibilityLabel={`(Adresse) (${companyAddress}) (Taste) (Wechselt zur Karten-App)`}
           >
             <RegularText primary>{companyAddress}</RegularText>
           </TouchableOpacity>
@@ -92,8 +91,7 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
               <Icon xml={phoneIcon(colors.primary)} style={styles.margin} />
               <TouchableOpacity
                 onPress={() => openLink(`tel:${contact.phone}`)}
-                accessibilityLabel="Telefonnummer"
-                accessibilityHint="Navigieren zu anruf option"
+                accessibilityLabel={`(Telefonnummer) (${contact.phone}) (Taste) (Wechselt zur Telefon-App)`}
               >
                 <RegularText primary>{contact.phone}</RegularText>
               </TouchableOpacity>
@@ -104,22 +102,21 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
               <Icon xml={mail(colors.primary)} style={styles.margin} />
               <TouchableOpacity
                 onPress={() => openLink(`mailto:${contact.email}`)}
-                accessibilityLabel="E-mail-Adresse"
-                accessibilityHint="Navigieren zur E-mail-App"
+                accessibilityLabel={`(E-mail-Adresse) (${contact.email}) (Taste) (Wechselt zur Email-App)`}
               >
                 <RegularText primary>{contact.email}</RegularText>
               </TouchableOpacity>
             </InfoBox>
           )}
           {!!contact.fax && (
-            <InfoBox accessible={true}>
+            <InfoBox>
               <RNEIcon
                 name="print"
                 type="material"
                 color={colors.primary}
                 iconStyle={{ marginRight: normalize(10) }}
               />
-              <RegularText primary accessibilityLabel="Fax-nummer">
+              <RegularText primary accessible={true} accessibilityLabel={`(Fax) (${contact.fax}`}>
                 {contact.fax}
               </RegularText>
             </InfoBox>
@@ -129,8 +126,7 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
               <Icon xml={link(colors.primary)} style={styles.marginWww} />
               <TouchableOpacity
                 onPress={() => openLink(contact.www, openWebScreen)}
-                accessibilityLabel="Webseite"
-                accessibilityHint="Navigieren zur Webseite"
+                accessibilityLabel={`(Webseite) (${contact.www}) (Taste) (Öffnet Webseite in der aktuellen App)`}
               >
                 <RegularText primary>{contact.www}</RegularText>
               </TouchableOpacity>
@@ -150,8 +146,7 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
               <Icon xml={urlIcon(colors.primary)} style={styles.margin} />
               <TouchableOpacity
                 onPress={() => openLink(url, openWebScreen)}
-                accessibilityLabel="Webseite"
-                accessibilityHint="Navigieren zur Webseite"
+                accessibilityLabel={`(Webseite) (${url}) (Taste) (Öffnet Webseite in der aktuellen App)`}
               >
                 <RegularText primary>{url}</RegularText>
               </TouchableOpacity>

--- a/src/components/screens/OperatingCompanyInfo.js
+++ b/src/components/screens/OperatingCompanyInfo.js
@@ -65,7 +65,7 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
           <Icon xml={location(colors.primary)} style={styles.margin} />
           <TouchableOpacity
             onPress={() => addressOnPress(companyAddress)}
-            accessibilityLabel={`(Adresse) (${companyAddress}) (Taste) (Wechselt zur Karten-App)`}
+            accessibilityLabel={`(Adresse) ${companyAddress} (Taste) (Wechselt zur Karten-App)`}
           >
             <RegularText primary>{companyAddress}</RegularText>
           </TouchableOpacity>
@@ -91,7 +91,7 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
               <Icon xml={phoneIcon(colors.primary)} style={styles.margin} />
               <TouchableOpacity
                 onPress={() => openLink(`tel:${contact.phone}`)}
-                accessibilityLabel={`(Telefonnummer) (${contact.phone}) (Taste) (Wechselt zur Telefon-App)`}
+                accessibilityLabel={`(Telefonnummer) ${contact.phone} (Taste) (Wechselt zur Telefon-App)`}
               >
                 <RegularText primary>{contact.phone}</RegularText>
               </TouchableOpacity>
@@ -102,7 +102,7 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
               <Icon xml={mail(colors.primary)} style={styles.margin} />
               <TouchableOpacity
                 onPress={() => openLink(`mailto:${contact.email}`)}
-                accessibilityLabel={`(E-mail-Adresse) (${contact.email}) (Taste) (Wechselt zur Email-App)`}
+                accessibilityLabel={`(E-mail-Adresse) ${contact.email} (Taste) (Wechselt zur Email-App)`}
               >
                 <RegularText primary>{contact.email}</RegularText>
               </TouchableOpacity>
@@ -116,7 +116,7 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
                 color={colors.primary}
                 iconStyle={{ marginRight: normalize(10) }}
               />
-              <RegularText primary accessible={true} accessibilityLabel={`(Fax) (${contact.fax}`}>
+              <RegularText primary accessible accessibilityLabel={`(Fax) ${contact.fax}`}>
                 {contact.fax}
               </RegularText>
             </InfoBox>
@@ -126,7 +126,7 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
               <Icon xml={link(colors.primary)} style={styles.marginWww} />
               <TouchableOpacity
                 onPress={() => openLink(contact.www, openWebScreen)}
-                accessibilityLabel={`(Webseite) (${contact.www}) (Taste) (Öffnet Webseite in der aktuellen App)`}
+                accessibilityLabel={`(Webseite) ${contact.www} (Taste) (Öffnet Webseite in der aktuellen App)`}
               >
                 <RegularText primary>{contact.www}</RegularText>
               </TouchableOpacity>
@@ -146,7 +146,7 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
               <Icon xml={urlIcon(colors.primary)} style={styles.margin} />
               <TouchableOpacity
                 onPress={() => openLink(url, openWebScreen)}
-                accessibilityLabel={`(Webseite) (${url}) (Taste) (Öffnet Webseite in der aktuellen App)`}
+                accessibilityLabel={`(Webseite) ${url} (Taste) (Öffnet Webseite in der aktuellen App)`}
               >
                 <RegularText primary>{url}</RegularText>
               </TouchableOpacity>

--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -87,7 +87,9 @@ export const PointOfInterest = ({ data, navigation }) => {
         {/* {!!location && (
           <View>
             <TitleContainer>
-              <Title accessibilityLabel={`${texts.pointOfInterest.location} (Überschrift)`}>{texts.pointOfInterest.location}</Title>
+              <Title accessibilityLabel={`${texts.pointOfInterest.location} (Überschrift)`}>
+                {texts.pointOfInterest.location}
+              </Title>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
           </View>

--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -57,7 +57,8 @@ export const PointOfInterest = ({ data, navigation }) => {
         images.push({
           picture: {
             uri: item.sourceUrl.url,
-            copyright: item.copyright
+            copyright: item.copyright,
+            captionText: item.captionText
           }
         });
     });

--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -73,7 +73,7 @@ export const PointOfInterest = ({ data, navigation }) => {
         {!!title && (
           <View>
             <TitleContainer>
-              <Title>{title}</Title>
+              <Title accessibilityLabel={`${title} (Überschrift)`}>{title}</Title>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
           </View>
@@ -87,7 +87,7 @@ export const PointOfInterest = ({ data, navigation }) => {
         {/* {!!location && (
           <View>
             <TitleContainer>
-              <Title>{texts.pointOfInterest.location}</Title>
+              <Title accessibilityLabel={`${texts.pointOfInterest.location} (Überschrift)`}>{texts.pointOfInterest.location}</Title>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
           </View>
@@ -96,7 +96,9 @@ export const PointOfInterest = ({ data, navigation }) => {
         {!!openingHours && !!openingHours.length && (
           <View>
             <TitleContainer>
-              <Title>{texts.pointOfInterest.openingTime}</Title>
+              <Title accessibilityLabel={`${texts.pointOfInterest.openingTime} (Überschrift)`}>
+                {texts.pointOfInterest.openingTime}
+              </Title>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <OpeningTimesCard openingHours={openingHours} />
@@ -106,7 +108,9 @@ export const PointOfInterest = ({ data, navigation }) => {
         {!!priceInformations && !!priceInformations.length && (
           <View>
             <TitleContainer>
-              <Title>{texts.pointOfInterest.prices}</Title>
+              <Title accessibilityLabel={`${texts.pointOfInterest.prices} (Überschrift)`}>
+                {texts.pointOfInterest.prices}
+              </Title>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <PriceCard prices={priceInformations} />
@@ -116,7 +120,9 @@ export const PointOfInterest = ({ data, navigation }) => {
         {!!description && (
           <View>
             <TitleContainer>
-              <Title>{texts.pointOfInterest.description}</Title>
+              <Title accessibilityLabel={`${texts.pointOfInterest.description} (Überschrift)`}>
+                {texts.pointOfInterest.description}
+              </Title>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <Wrapper>
@@ -133,7 +139,9 @@ export const PointOfInterest = ({ data, navigation }) => {
         {!!operatingCompany && (
           <View>
             <TitleContainer>
-              <Title>{texts.pointOfInterest.operatingCompany}</Title>
+              <Title accessibilityLabel={`${texts.pointOfInterest.operatingCompany} (Überschrift)`}>
+                {texts.pointOfInterest.operatingCompany}
+              </Title>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <OperatingCompanyInfo

--- a/src/components/screens/Service.js
+++ b/src/components/screens/Service.js
@@ -61,7 +61,9 @@ export const Service = ({ navigation, refreshing }) => {
           <View>
             {!!headlineService && (
               <TitleContainer>
-                <Title>{headlineService}</Title>
+                <Title accessibilityLabel={`${headlineService} (Überschrift)`}>
+                  {headlineService}
+                </Title>
               </TitleContainer>
             )}
             {!!headlineService && device.platform === 'ios' && <TitleShadow />}
@@ -88,7 +90,12 @@ export const Service = ({ navigation, refreshing }) => {
                               PlaceholderContent={null}
                             />
                           )}
-                          <BoldText small lightest center>
+                          <BoldText
+                            small
+                            lightest
+                            center
+                            accessibilityLabel={`${item.title} (Taste)`}
+                          >
                             {item.title}
                           </BoldText>
                         </View>

--- a/src/components/screens/Tour.js
+++ b/src/components/screens/Tour.js
@@ -74,7 +74,7 @@ export const Tour = ({ data, navigation }) => {
         {!!title && (
           <View>
             <TitleContainer>
-              <Title>{title}</Title>
+              <Title accessibilityLabel={`${title} (Überschrift)`}>{title}</Title>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
           </View>
@@ -91,7 +91,9 @@ export const Tour = ({ data, navigation }) => {
         {!!description && (
           <View>
             <TitleContainer>
-              <Title>{texts.tour.description}</Title>
+              <Title accessibilityLabel={`${texts.tour.description} (Überschrift)`}>
+                {texts.tour.description}
+              </Title>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <Wrapper>
@@ -108,7 +110,9 @@ export const Tour = ({ data, navigation }) => {
         {!!operatingCompany && (
           <View>
             <TitleContainer>
-              <Title>{texts.tour.operatingCompany}</Title>
+              <Title accessibilityLabel={`${texts.tour.operatingCompany} (Überschrift)`}>
+                {texts.tour.operatingCompany}
+              </Title>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <OperatingCompanyInfo

--- a/src/components/screens/Tour.js
+++ b/src/components/screens/Tour.js
@@ -58,7 +58,8 @@ export const Tour = ({ data, navigation }) => {
         images.push({
           picture: {
             uri: item.sourceUrl.url,
-            copyright: item.copyright
+            copyright: item.copyright,
+            captionText: item.captionText
           }
         });
     });

--- a/src/components/screens/TourCard.js
+++ b/src/components/screens/TourCard.js
@@ -24,7 +24,7 @@ const addressOnPress = (address) => {
 export const TourCard = ({ addresses, lengthKm }) => (
   <View>
     <TitleContainer>
-      <Title>{texts.tour.tour}</Title>
+      <Title accessibilityLabel={`${texts.tour.tour} (Überschrift) `}>{texts.tour.tour}</Title>
     </TitleContainer>
     {device.platform === 'ios' && <TitleShadow />}
     <Wrapper>

--- a/src/components/screens/TourCard.js
+++ b/src/components/screens/TourCard.js
@@ -24,7 +24,7 @@ const addressOnPress = (address) => {
 export const TourCard = ({ addresses, lengthKm }) => (
   <View>
     <TitleContainer>
-      <Title accessibilityLabel={`${texts.tour.tour} (Überschrift) `}>{texts.tour.tour}</Title>
+      <Title accessibilityLabel={`${texts.tour.tour} (Überschrift)`}>{texts.tour.tour}</Title>
     </TitleContainer>
     {device.platform === 'ios' && <TitleShadow />}
     <Wrapper>

--- a/src/navigation/CustomDrawerContentComponent.js
+++ b/src/navigation/CustomDrawerContentComponent.js
@@ -20,7 +20,12 @@ export const CustomDrawerContentComponent = (props) => {
     <DiagonalGradient>
       <View style={styles.headerContainer}>
         <View style={stylesWithProps({ orientation }).header}>
-          <TouchableOpacity onPress={() => props.navigation.closeDrawer()} delayPressIn={0}>
+          <TouchableOpacity
+            accessibilityLabel="Schließen Taste"
+            accessibilityHint="Menü schließen"
+            onPress={() => props.navigation.closeDrawer()}
+            delayPressIn={0}
+          >
             <Icon
               name="ios-close"
               type="ionicon"

--- a/src/navigation/DrawerNavigatorItems.js
+++ b/src/navigation/DrawerNavigatorItems.js
@@ -56,8 +56,6 @@ const DrawerNavigatorItems = memo(
       navigation.closeDrawer();
     };
 
-    console.warn('drawer');
-
     return (
       <ScrollView bounces={false} style={itemsContainerStyle}>
         {items.map((route, index) => {

--- a/src/navigation/defaultStackNavigatorConfig.js
+++ b/src/navigation/defaultStackNavigatorConfig.js
@@ -22,7 +22,11 @@ export const defaultStackNavigatorConfig = (initialRouteName, headerRight = true
         lineHeight: normalize(29)
       },
       headerRight: headerRight && (
-        <TouchableOpacity onPress={() => navigation.openDrawer()}>
+        <TouchableOpacity
+          onPress={() => navigation.openDrawer()}
+          accessibilityLabel="Menü Taste"
+          accessibilityHint="Navigiert zum Menü"
+        >
           <Icon xml={drawerMenu(colors.lightestText)} style={styles.icon} />
         </TouchableOpacity>
       )

--- a/src/queries/eventRecords.js
+++ b/src/queries/eventRecords.js
@@ -21,6 +21,7 @@ export const GET_EVENT_RECORDS = gql`
       mediaContents {
         id
         contentType
+        captionText
         copyright
         sourceUrl {
           url
@@ -62,6 +63,7 @@ export const GET_EVENT_RECORD = gql`
       mediaContents {
         id
         contentType
+        captionText
         copyright
         sourceUrl {
           url

--- a/src/queries/newsItems.js
+++ b/src/queries/newsItems.js
@@ -14,6 +14,7 @@ export const GET_NEWS_ITEMS = gql`
         mediaContents {
           id
           contentType
+          captionText
           copyright
           sourceUrl {
             url
@@ -51,6 +52,7 @@ export const GET_FILTERED_NEWS_ITEMS = gql`
         mediaContents {
           id
           contentType
+          captionText
           copyright
           sourceUrl {
             url
@@ -88,6 +90,7 @@ export const GET_FILTERED_NEWS_ITEMS_AND_DATA_PROVIDERS = gql`
         mediaContents {
           id
           contentType
+          captionText
           copyright
           sourceUrl {
             url
@@ -128,6 +131,7 @@ export const GET_NEWS_ITEM = gql`
         mediaContents {
           id
           contentType
+          captionText
           copyright
           sourceUrl {
             url

--- a/src/queries/pointsOfInterest.js
+++ b/src/queries/pointsOfInterest.js
@@ -11,6 +11,7 @@ export const GET_POINTS_OF_INTEREST = gql`
       description
       mediaContents {
         contentType
+        captionText
         copyright
         sourceUrl {
           url
@@ -45,6 +46,7 @@ export const GET_POINT_OF_INTEREST = gql`
       description
       mediaContents {
         contentType
+        captionText
         copyright
         sourceUrl {
           url

--- a/src/queries/pointsOfInterestAndTours.js
+++ b/src/queries/pointsOfInterestAndTours.js
@@ -15,6 +15,7 @@ export const GET_POINTS_OF_INTEREST_AND_TOURS = gql`
       description
       mediaContents {
         contentType
+        captionText
         copyright
         sourceUrl {
           url
@@ -45,6 +46,7 @@ export const GET_POINTS_OF_INTEREST_AND_TOURS = gql`
       description
       mediaContents {
         contentType
+        captionText
         copyright
         sourceUrl {
           url

--- a/src/queries/tours.js
+++ b/src/queries/tours.js
@@ -11,6 +11,7 @@ export const GET_TOURS = gql`
       description
       mediaContents {
         contentType
+        captionText
         copyright
         sourceUrl {
           url
@@ -43,6 +44,7 @@ export const GET_TOUR = gql`
       description
       mediaContents {
         contentType
+        captionText
         copyright
         sourceUrl {
           url

--- a/src/screens/AboutScreen.js
+++ b/src/screens/AboutScreen.js
@@ -76,12 +76,11 @@ export const AboutScreen = ({ navigation }) => {
 
           if (!publicJsonFileContent || !publicJsonFileContent.length) return <VersionNumber />;
 
-          // TODO Title is not accessible here, why ?
           return (
             <>
               {!!headlineAbout && (
                 <TitleContainer>
-                  <Title accessible accessibilityLabel={`${headlineAbout} (Überschrift)`}>
+                  <Title accessibilityLabel={`${headlineAbout} (Überschrift)`}>
                     {headlineAbout}
                   </Title>
                 </TitleContainer>

--- a/src/screens/AboutScreen.js
+++ b/src/screens/AboutScreen.js
@@ -76,12 +76,12 @@ export const AboutScreen = ({ navigation }) => {
 
           if (!publicJsonFileContent || !publicJsonFileContent.length) return <VersionNumber />;
 
-          // TODO accessibility not working on Title
+          // TODO Title is not accessible here, why ?
           return (
             <>
               {!!headlineAbout && (
-                <TitleContainer accessible={true}>
-                  <Title accessibilityHint="Kopfzeile der Über die App Liste">
+                <TitleContainer>
+                  <Title accessible={true} accessibilityLabel={`${headlineAbout} (Überschrift)`}>
                     {headlineAbout}
                   </Title>
                 </TitleContainer>

--- a/src/screens/AboutScreen.js
+++ b/src/screens/AboutScreen.js
@@ -81,7 +81,7 @@ export const AboutScreen = ({ navigation }) => {
             <>
               {!!headlineAbout && (
                 <TitleContainer>
-                  <Title accessible={true} accessibilityLabel={`${headlineAbout} (Überschrift)`}>
+                  <Title accessible accessibilityLabel={`${headlineAbout} (Überschrift)`}>
                     {headlineAbout}
                   </Title>
                 </TitleContainer>

--- a/src/screens/AboutScreen.js
+++ b/src/screens/AboutScreen.js
@@ -76,11 +76,14 @@ export const AboutScreen = ({ navigation }) => {
 
           if (!publicJsonFileContent || !publicJsonFileContent.length) return <VersionNumber />;
 
+          // TODO accessibility not working on Title
           return (
             <>
               {!!headlineAbout && (
-                <TitleContainer>
-                  <Title>{headlineAbout}</Title>
+                <TitleContainer accessible={true}>
+                  <Title accessibilityHint="Kopfzeile der Über die App Liste">
+                    {headlineAbout}
+                  </Title>
                 </TitleContainer>
               )}
               {!!headlineAbout && device.platform === 'ios' && <TitleShadow />}

--- a/src/screens/CompanyScreen.js
+++ b/src/screens/CompanyScreen.js
@@ -90,7 +90,9 @@ export const CompanyScreen = ({ navigation }) => {
             <>
               {!!headlineCompany && (
                 <TitleContainer>
-                  <Title>{headlineCompany}</Title>
+                  <Title accessibilityLabel={`${headlineCompany} (Überschrift)`}>
+                    {headlineCompany}
+                  </Title>
                 </TitleContainer>
               )}
               {!!headlineCompany && device.platform === 'ios' && <TitleShadow />}
@@ -119,11 +121,7 @@ export const CompanyScreen = ({ navigation }) => {
                           >
                             <View>
                               {item.iconName ? (
-                                <Icon
-                                  name={item.iconName}
-                                  size={30}
-                                  style={styles.serviceIcon}
-                                />
+                                <Icon name={item.iconName} size={30} style={styles.serviceIcon} />
                               ) : (
                                 <Image
                                   source={{ uri: item.icon }}

--- a/src/screens/CompanyScreen.js
+++ b/src/screens/CompanyScreen.js
@@ -129,7 +129,12 @@ export const CompanyScreen = ({ navigation }) => {
                                   PlaceholderContent={null}
                                 />
                               )}
-                              <BoldText small primary center>
+                              <BoldText
+                                small
+                                primary
+                                center
+                                accessibilityLabel={`${item.title} (Taste)`}
+                              >
                                 {item.title}
                               </BoldText>
                             </View>

--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -148,7 +148,11 @@ DetailScreen.navigationOptions = ({ navigation, navigationOptions }) => {
   return {
     headerLeft: (
       <View>
-        <TouchableOpacity onPress={() => navigation.goBack()}>
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          accessibilityLabel="Zurück Taste"
+          accessibilityHint="Navigieren zurück zur vorherigen Seite"
+        >
           <Icon xml={arrowLeft(colors.lightestText)} style={styles.icon} />
         </TouchableOpacity>
       </View>
@@ -156,7 +160,11 @@ DetailScreen.navigationOptions = ({ navigation, navigationOptions }) => {
     headerRight: (
       <WrapperRow>
         {shareContent && (
-          <TouchableOpacity onPress={() => openShare(shareContent)}>
+          <TouchableOpacity
+            onPress={() => openShare(shareContent)}
+            accessibilityLabel="Teilen Taste"
+            accessibilityHint="Inhalte auf der Seite teilen"
+          >
             <Icon
               xml={share(colors.lightestText)}
               style={headerRight ? styles.iconLeft : styles.iconRight}

--- a/src/screens/FormScreen.js
+++ b/src/screens/FormScreen.js
@@ -121,7 +121,11 @@ FormScreen.navigationOptions = ({ navigation }) => {
   return {
     headerLeft: (
       <View>
-        <TouchableOpacity onPress={() => navigation.goBack()}>
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          accessibilityLabel="Zurück Taste"
+          accessibilityHint="Navigieren zurück zur vorherigen Seite"
+        >
           <Icon xml={arrowLeft(colors.lightestText)} style={styles.icon} />
         </TouchableOpacity>
       </View>

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -117,7 +117,11 @@ export const HomeScreen = ({ navigation }) => {
         {showNews && (
           <>
             <TitleContainer>
-              <Touchable onPress={() => navigation.navigate(NAVIGATION.NEWS_ITEMS_INDEX)}>
+              <Touchable
+                accessibilityLabel="Kopfzeile der Vorschau der Nachrichtenliste"
+                accessibilityHint="Navigiert zur Nachrichtenliste"
+                onPress={() => navigation.navigate(NAVIGATION.NEWS_ITEMS_INDEX)}
+              >
                 <Title>{headlineNews}</Title>
               </Touchable>
             </TitleContainer>
@@ -185,7 +189,11 @@ export const HomeScreen = ({ navigation }) => {
         {showPointsOfInterestAndTours && (
           <>
             <TitleContainer>
-              <Touchable onPress={() => navigation.navigate(NAVIGATION.CATEGORIES_INDEX)}>
+              <Touchable
+                accessibilityLabel="Kopfzeile der Vorschau der Touren- und Orteliste"
+                accessibilityHint="Navigiert zur Touren- und Orteliste"
+                onPress={() => navigation.navigate(NAVIGATION.CATEGORIES_INDEX)}
+              >
                 <Title>{headlinePointsOfInterestAndTours}</Title>
               </Touchable>
             </TitleContainer>
@@ -272,7 +280,11 @@ export const HomeScreen = ({ navigation }) => {
         {showEvents && (
           <>
             <TitleContainer>
-              <Touchable onPress={() => navigation.navigate(NAVIGATION.EVENT_RECORDS_INDEX)}>
+              <Touchable
+                accessibilityLabel="Kopfzeile der Vorschau der Veranstaltungsliste"
+                accessibilityHint="Navigiert zur Veranstaltungsliste"
+                onPress={() => navigation.navigate(NAVIGATION.EVENT_RECORDS_INDEX)}
+              >
                 <Title>{headlineEvents}</Title>
               </Touchable>
             </TitleContainer>

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -118,8 +118,7 @@ export const HomeScreen = ({ navigation }) => {
           <>
             <TitleContainer>
               <Touchable
-                accessibilityLabel="Kopfzeile der Vorschau der Nachrichtenliste"
-                accessibilityHint="Navigiert zur Nachrichtenliste"
+                accessibilityLabel={`${headlineNews} (Überschrift) (Taste)`}
                 onPress={() => navigation.navigate(NAVIGATION.NEWS_ITEMS_INDEX)}
               >
                 <Title>{headlineNews}</Title>
@@ -190,8 +189,7 @@ export const HomeScreen = ({ navigation }) => {
           <>
             <TitleContainer>
               <Touchable
-                accessibilityLabel="Kopfzeile der Vorschau der Touren- und Orteliste"
-                accessibilityHint="Navigiert zur Touren- und Orteliste"
+                accessibilityLabel={`${headlinePointsOfInterestAndTours} (Überschrift) (Taste)`}
                 onPress={() => navigation.navigate(NAVIGATION.CATEGORIES_INDEX)}
               >
                 <Title>{headlinePointsOfInterestAndTours}</Title>
@@ -281,8 +279,7 @@ export const HomeScreen = ({ navigation }) => {
           <>
             <TitleContainer>
               <Touchable
-                accessibilityLabel="Kopfzeile der Vorschau der Veranstaltungsliste"
-                accessibilityHint="Navigiert zur Veranstaltungsliste"
+                accessibilityLabel={`${headlineEvents} (Überschrift) (Taste)`}
                 onPress={() => navigation.navigate(NAVIGATION.EVENT_RECORDS_INDEX)}
               >
                 <Title>{headlineEvents}</Title>

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -117,11 +117,10 @@ export const HomeScreen = ({ navigation }) => {
         {showNews && (
           <>
             <TitleContainer>
-              <Touchable
-                accessibilityLabel={`${headlineNews} (Überschrift) (Taste)`}
-                onPress={() => navigation.navigate(NAVIGATION.NEWS_ITEMS_INDEX)}
-              >
-                <Title>{headlineNews}</Title>
+              <Touchable onPress={() => navigation.navigate(NAVIGATION.NEWS_ITEMS_INDEX)}>
+                <Title accessibilityLabel={`${headlineNews} (Überschrift) (Taste)`}>
+                  {headlineNews}
+                </Title>
               </Touchable>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
@@ -188,11 +187,12 @@ export const HomeScreen = ({ navigation }) => {
         {showPointsOfInterestAndTours && (
           <>
             <TitleContainer>
-              <Touchable
-                accessibilityLabel={`${headlinePointsOfInterestAndTours} (Überschrift) (Taste)`}
-                onPress={() => navigation.navigate(NAVIGATION.CATEGORIES_INDEX)}
-              >
-                <Title>{headlinePointsOfInterestAndTours}</Title>
+              <Touchable onPress={() => navigation.navigate(NAVIGATION.CATEGORIES_INDEX)}>
+                <Title
+                  accessibilityLabel={`${headlinePointsOfInterestAndTours} (Überschrift) (Taste)`}
+                >
+                  {headlinePointsOfInterestAndTours}
+                </Title>
               </Touchable>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
@@ -278,11 +278,10 @@ export const HomeScreen = ({ navigation }) => {
         {showEvents && (
           <>
             <TitleContainer>
-              <Touchable
-                accessibilityLabel={`${headlineEvents} (Überschrift) (Taste)`}
-                onPress={() => navigation.navigate(NAVIGATION.EVENT_RECORDS_INDEX)}
-              >
-                <Title>{headlineEvents}</Title>
+              <Touchable onPress={() => navigation.navigate(NAVIGATION.EVENT_RECORDS_INDEX)}>
+                <Title accessibilityLabel={`${headlineEvents} (Überschrift) (Taste)`}>
+                  {headlineEvents}
+                </Title>
               </Touchable>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}

--- a/src/screens/HtmlScreen.js
+++ b/src/screens/HtmlScreen.js
@@ -179,7 +179,11 @@ HtmlScreen.navigationOptions = ({ navigation }) => {
   return {
     headerLeft: (
       <View>
-        <TouchableOpacity onPress={() => navigation.goBack()}>
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          accessibilityLabel="Zurück Taste"
+          accessibilityHint="Navigieren zurück zur vorherigen Seite"
+        >
           <Icon xml={arrowLeft(colors.lightestText)} style={styles.icon} />
         </TouchableOpacity>
       </View>

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -294,7 +294,11 @@ IndexScreen.navigationOptions = ({ navigation }) => {
   return {
     headerLeft: (
       <View>
-        <TouchableOpacity onPress={() => navigation.goBack()}>
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          accessibilityLabel="Zurück Taste"
+          accessibilityHint="Navigieren zurück zur vorherigen Seite"
+        >
           <Icon xml={arrowLeft(colors.lightestText)} style={styles.icon} />
         </TouchableOpacity>
       </View>

--- a/src/screens/ServiceScreen.js
+++ b/src/screens/ServiceScreen.js
@@ -86,10 +86,14 @@ export const ServiceScreen = ({ navigation }) => {
 
           if (!publicJsonFileContent || !publicJsonFileContent.length) return null;
 
+          // TODO accessibility not working on Title
           return (
             <>
               {!!headlineService && (
-                <TitleContainer>
+                <TitleContainer
+                  accessible={true}
+                  accessibilityLabel="Kopfzeile des Service-Abschnitts"
+                >
                   <Title>{headlineService}</Title>
                 </TitleContainer>
               )}

--- a/src/screens/ServiceScreen.js
+++ b/src/screens/ServiceScreen.js
@@ -57,7 +57,7 @@ export const ServiceScreen = ({ navigation }) => {
 
   const refresh = async (refetch) => {
     setRefreshing(true);
-    isConnected && await refetch();
+    isConnected && (await refetch());
     setRefreshing(false);
   };
 
@@ -86,15 +86,14 @@ export const ServiceScreen = ({ navigation }) => {
 
           if (!publicJsonFileContent || !publicJsonFileContent.length) return null;
 
-          // TODO accessibility not working on Title
+          // TODO: elements are not accessible here, why?
           return (
             <>
               {!!headlineService && (
-                <TitleContainer
-                  accessible={true}
-                  accessibilityLabel="Kopfzeile des Service-Abschnitts"
-                >
-                  <Title>{headlineService}</Title>
+                <TitleContainer>
+                  <Title accessible={true} accessibilityLabel={`${headlineService} (Überschrift)`}>
+                    {headlineService}
+                  </Title>
                 </TitleContainer>
               )}
               {!!headlineService && device.platform === 'ios' && <TitleShadow />}
@@ -123,11 +122,7 @@ export const ServiceScreen = ({ navigation }) => {
                           >
                             <View>
                               {item.iconName ? (
-                                <Icon
-                                  name={item.iconName}
-                                  size={30}
-                                  style={styles.serviceIcon}
-                                />
+                                <Icon name={item.iconName} size={30} style={styles.serviceIcon} />
                               ) : (
                                 <Image
                                   source={{ uri: item.icon }}
@@ -135,7 +130,13 @@ export const ServiceScreen = ({ navigation }) => {
                                   PlaceholderContent={null}
                                 />
                               )}
-                              <BoldText small primary center>
+                              <BoldText
+                                small
+                                primary
+                                center
+                                accessible={true}
+                                accessibilityLabel={`${item.title} (Taste)`}
+                              >
                                 {item.title}
                               </BoldText>
                             </View>

--- a/src/screens/ServiceScreen.js
+++ b/src/screens/ServiceScreen.js
@@ -86,12 +86,11 @@ export const ServiceScreen = ({ navigation }) => {
 
           if (!publicJsonFileContent || !publicJsonFileContent.length) return null;
 
-          // TODO: elements are not accessible here, why?
           return (
             <>
               {!!headlineService && (
                 <TitleContainer>
-                  <Title accessible accessibilityLabel={`${headlineService} (Überschrift)`}>
+                  <Title accessibilityLabel={`${headlineService} (Überschrift)`}>
                     {headlineService}
                   </Title>
                 </TitleContainer>

--- a/src/screens/ServiceScreen.js
+++ b/src/screens/ServiceScreen.js
@@ -91,7 +91,7 @@ export const ServiceScreen = ({ navigation }) => {
             <>
               {!!headlineService && (
                 <TitleContainer>
-                  <Title accessible={true} accessibilityLabel={`${headlineService} (Überschrift)`}>
+                  <Title accessible accessibilityLabel={`${headlineService} (Überschrift)`}>
                     {headlineService}
                   </Title>
                 </TitleContainer>
@@ -134,7 +134,7 @@ export const ServiceScreen = ({ navigation }) => {
                                 small
                                 primary
                                 center
-                                accessible={true}
+                                accessible
                                 accessibilityLabel={`${item.title} (Taste)`}
                               >
                                 {item.title}

--- a/src/screens/WebScreen.js
+++ b/src/screens/WebScreen.js
@@ -36,7 +36,11 @@ WebScreen.navigationOptions = ({ navigation }) => {
   return {
     headerLeft: (
       <View>
-        <TouchableOpacity onPress={() => navigation.goBack()}>
+        <TouchableOpacity
+          accessibilityLabel="Zurück Taste"
+          accessibilityHint="Navigieren zurück zur vorherigen Seite"
+          onPress={() => navigation.goBack()}
+        >
           <Icon xml={arrowLeft(colors.lightestText)} style={styles.icon} />
         </TouchableOpacity>
       </View>


### PR DESCRIPTION
- tested with voiceOver and compared to other App to test labels and hints level of understanding
- most of interactive elements of the app are accessible from VoiceOver now, using two different properties:
  - accessibilityLabel : gives a title to the element
  - accessibilityHint : gives a functionality to the element
- property accessibility it's not working like aspected for non interactive elements
  - see TODOS
- buttons are not accessible elements, intentionally , because every button title , it's always explanatory of its functionality and voiceOver can access it
- Images are not jet accessible, it would be good to implement a logic that has access to a short image description
- CardList Item not jet accessible would be good to implement a logic that can distinguish Orte from Touren
  - maybe for textList Item as well since there is no difference at the moment between News and Veranstaltungen items in index and preview 
- Dropdown and Carousel are not accessible elements jet

SVA-94

- VoiceOver (iOS) and TalkBack (Android) can read :
  - in TextLIstItem the specific title of that item + with a proper pause makes clear what kind of element , in this case a button
  - in CardListItem the specific category and the specific title of that item +  pause and what kind of element
  - in CategoryListItem the specific title of that item plus using 'count' logic , how many articles are available in this category + pause and what kind of element
  - in InfoCar and OperatingCompanyInfo every element , it says the title/name, the actual content, what kind of element and what kind of action "the element can do"
  - in Button the specific title + pause and what kind of element
  - in HomeScreen the specific heading + description + pause and what kind of element
  - in VersionNumber what kind of version have the App currently
  - in Link description + pause and what kind of element ( it seams that this component is not used )
  - Image, ServiceScreen and AboutScreen are not accessible I couldn't understand why

SVA-94

- semicolon to help voiceover and talkback readability
  - after 'Einträge' and 'App version'
- update accessible is the same as accessible={true}
- removed unnecessary brackets around contact."" in InfoCard and OperatingCompanyInfo
- added missing fax label in InfoCard
- accessibilityHint in HomeScreen , not necessary at the moment

SVA-94