### PR TITLE
Update icons in tab bar

### DIFF
--- a/src/components/CategoryListItem.js
+++ b/src/components/CategoryListItem.js
@@ -40,7 +40,7 @@ export class CategoryListItem extends React.PureComponent {
           backgroundColor: colors.transparent,
           paddingVertical: normalize(12)
         }}
-        rightIcon={<Icon icon={arrowRight(colors.primary)} />}
+        rightIcon={<Icon xml={arrowRight(colors.primary)} />}
         onPress={() =>
           navigation.navigate({
             routeName,

--- a/src/components/DropdownSelect.js
+++ b/src/components/DropdownSelect.js
@@ -60,7 +60,7 @@ export const DropdownSelect = memo(({ data, setData, label }) => {
       >
         <WrapperRow style={styles.dropdownTextWrapper}>
           <RegularText>{selectedData.value}</RegularText>
-          <Icon icon={arrow == 'down' ? arrowDown(colors.primary) : arrowUp(colors.primary)} />
+          <Icon xml={arrow == 'down' ? arrowDown(colors.primary) : arrowUp(colors.primary)} />
         </WrapperRow>
       </Dropdown>
     </View>

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -1,39 +1,55 @@
 import PropTypes from 'prop-types';
-import React, { useContext } from 'react';
-
-import { StyleSheet, View } from 'react-native';
+import React from 'react';
+import { View } from 'react-native';
 import { SvgXml } from 'react-native-svg';
+import { Ionicons } from '@expo/vector-icons';
 
-import { normalize } from '../config';
-import { OrientationContext } from '../OrientationProvider';
+import { colors, normalize } from '../config';
 
-export const Icon = ({ icon, width, height, style, landscapeStyle }) => {
-  const { orientation } = useContext(OrientationContext);
-  // const landscapeStyle = orientation === 'landscape' ? style : null;
+/**
+ * Smart icon component which can handle SVGs passed as `xml` prop or icon fonts, which are
+ * rendered with a given `name` prop.
+ */
+export const Icon = ({ xml, width, height, name, size, focused, style, iconStyle }) => {
+  const color = focused ? colors.accent : colors.primary;
 
   return (
-    <View style={[style, orientation === 'landscape' && landscapeStyle]}>
-      <SvgXml width={width} height={height} xml={icon} />
+    <View style={style}>
+      {xml && <SvgXml xml={xml} width={width} height={height} style={iconStyle} />}
+      {name && <Ionicons name={name} size={size} color={color} style={iconStyle} />}
     </View>
   );
 };
 
-const styles = StyleSheet.create({
-  marginIcon: {
-    marginRight: normalize(10)
+// thx to: https://stackoverflow.com/a/49682510/9956365
+const isRequired = (props, propName, componentName) => {
+  // ensure, that one of 'xml' or 'name' is given
+  if (!props.xml && !props.name) {
+    return new Error(`One of 'xml' or 'name' is required by '${componentName}' component.`);
   }
-});
+
+  // ensure, that only one of 'xml' or 'name' is passed at a time
+  if (props.xml && props.name) {
+    return new Error(`Only one of 'xml' or 'name' is required by '${componentName}' component.`);
+  }
+};
 
 Icon.propTypes = {
-  icon: PropTypes.string.isRequired,
+  xml: isRequired,
   width: PropTypes.number,
   height: PropTypes.number,
+  name: isRequired,
+  size: PropTypes.number,
+  focused: PropTypes.bool,
   style: PropTypes.object,
-  landscapeStyle: PropTypes.object
+  iconStyle: PropTypes.object
 };
 
 Icon.defaultProps = {
+  // width & height marks the size for svg
   width: normalize(24),
   height: normalize(24),
-  landscapeStyle: styles.marginIcon
+  // size is for font icon
+  size: normalize(26),
+  focused: false
 };

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -7,12 +7,12 @@ import { SvgXml } from 'react-native-svg';
 import { normalize } from '../config';
 import { OrientationContext } from '../OrientationProvider';
 
-export const Icon = ({ icon, width, height, style }) => {
+export const Icon = ({ icon, width, height, style, landscapeStyle }) => {
   const { orientation } = useContext(OrientationContext);
-  const landscapeStyle = orientation === 'landscape' ? style : null;
+  // const landscapeStyle = orientation === 'landscape' ? style : null;
 
   return (
-    <View style={landscapeStyle}>
+    <View style={[style, orientation === 'landscape' && landscapeStyle]}>
       <SvgXml width={width} height={height} xml={icon} />
     </View>
   );
@@ -28,11 +28,12 @@ Icon.propTypes = {
   icon: PropTypes.string.isRequired,
   width: PropTypes.number,
   height: PropTypes.number,
-  style: PropTypes.object
+  style: PropTypes.object,
+  landscapeStyle: PropTypes.object
 };
 
 Icon.defaultProps = {
   width: normalize(24),
   height: normalize(24),
-  style: styles.marginIcon
+  landscapeStyle: styles.marginIcon
 };

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -1,15 +1,28 @@
 import PropTypes from 'prop-types';
-import React from 'react';
-import { View } from 'react-native';
+import React, { useContext } from 'react';
+
+import { StyleSheet, View } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 
 import { normalize } from '../config';
+import { OrientationContext } from '../OrientationProvider';
 
-export const Icon = ({ icon, width, height, style }) => (
-  <View style={style}>
-    <SvgXml width={width} height={height} xml={icon} />
-  </View>
-);
+export const Icon = ({ icon, width, height, style }) => {
+  const { orientation } = useContext(OrientationContext);
+  const landscapeStyle = orientation === 'landscape' ? style : null;
+
+  return (
+    <View style={landscapeStyle}>
+      <SvgXml width={width} height={height} xml={icon} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  marginIcon: {
+    marginRight: normalize(10)
+  }
+});
 
 Icon.propTypes = {
   icon: PropTypes.string.isRequired,
@@ -20,5 +33,6 @@ Icon.propTypes = {
 
 Icon.defaultProps = {
   width: normalize(24),
-  height: normalize(24)
+  height: normalize(24),
+  style: styles.marginIcon
 };

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -12,7 +12,7 @@ import { WrapperRow } from './Wrapper';
 export const Link = ({ url, description, openWebScreen }) => (
   <TouchableOpacity onPress={() => openLink(url, openWebScreen)}>
     <WrapperRow>
-      <Icon icon={link(colors.secondary)} style={styles.icon} />
+      <Icon xml={link(colors.secondary)} style={styles.icon} />
       <RegularText primary>{description}</RegularText>
     </WrapperRow>
   </TouchableOpacity>

--- a/src/components/TabBarIcon.js
+++ b/src/components/TabBarIcon.js
@@ -4,6 +4,7 @@ import { Ionicons } from '@expo/vector-icons';
 
 import { colors, normalize } from '../config';
 
+//TODO refactor TabBarIcon to be a function component that can use OrientationContext
 export default function TabBarIcon(props) {
   return (
     <Ionicons

--- a/src/components/TabBarIcon.js
+++ b/src/components/TabBarIcon.js
@@ -1,21 +1,35 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useContext } from 'react';
+import { StyleSheet, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
 import { colors, normalize } from '../config';
+import { OrientationContext } from '../OrientationProvider';
 
 //TODO refactor TabBarIcon to be a function component that can use OrientationContext
-export default function TabBarIcon(props) {
+export const TabBarIcon = ({ name, focused, style }) => {
+  const { orientation } = useContext(OrientationContext);
+  const size = orientation === 'landscape' ? normalize(28) : normalize(26);
+  const landscapeStyle = orientation === 'landscape' ? style : null;
+
   return (
-    <Ionicons
-      name={props.name}
-      size={normalize(26)}
-      color={props.focused ? colors.accent : colors.primary}
-    />
+    <View style={landscapeStyle}>
+      <Ionicons name={name} size={size} color={focused ? colors.accent : colors.primary} />
+    </View>
   );
-}
+};
+const styles = StyleSheet.create({
+  marginIcon: {
+    marginRight: normalize(10)
+  }
+});
 
 TabBarIcon.propTypes = {
   name: PropTypes.string.isRequired,
-  focused: PropTypes.object
+  focused: PropTypes.object,
+  style: PropTypes.object
+};
+
+TabBarIcon.defaultProps = {
+  style: styles.marginIcon
 };

--- a/src/components/TabBarIcon.js
+++ b/src/components/TabBarIcon.js
@@ -26,7 +26,7 @@ const styles = StyleSheet.create({
 
 TabBarIcon.propTypes = {
   name: PropTypes.string.isRequired,
-  focused: PropTypes.object,
+  focused: PropTypes.bool,
   style: PropTypes.object
 };
 

--- a/src/components/TabBarIcon.js
+++ b/src/components/TabBarIcon.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Ionicons } from '@expo/vector-icons';
 
@@ -8,8 +9,12 @@ export default function TabBarIcon(props) {
     <Ionicons
       name={props.name}
       size={normalize(26)}
-      style={{ marginTop: normalize(7) }}
       color={props.focused ? colors.accent : colors.primary}
     />
   );
 }
+
+TabBarIcon.propTypes = {
+  name: PropTypes.string.isRequired,
+  focused: PropTypes.object
+};

--- a/src/components/TextListItem.js
+++ b/src/components/TextListItem.js
@@ -24,7 +24,7 @@ export class TextListItem extends React.PureComponent {
           backgroundColor: colors.transparent,
           paddingVertical: normalize(12)
         }}
-        rightIcon={<Icon icon={arrowRight(colors.primary)} />}
+        rightIcon={<Icon xml={arrowRight(colors.primary)} />}
         onPress={() =>
           navigation.navigate({
             routeName,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -18,6 +18,7 @@ export * from './LoadingContainer';
 export * from './Logo';
 export * from './SafeAreaViewFlex';
 export * from './ServiceBox';
+export * from './TabBarIcon';
 export * from './Text';
 export * from './TextList';
 export * from './TextListItem';

--- a/src/components/screens/InfoCard.js
+++ b/src/components/screens/InfoCard.js
@@ -30,7 +30,7 @@ const contactView = (contact) => (
 
     {!!contact.phone && (
       <InfoBox>
-        <Icon icon={phoneIcon(colors.primary)} style={styles.margin} />
+        <Icon xml={phoneIcon(colors.primary)} style={styles.margin} />
         <TouchableOpacity onPress={() => openLink(`tel:${contact.phone}`)}>
           <RegularText primary>{contact.phone}</RegularText>
         </TouchableOpacity>
@@ -39,7 +39,7 @@ const contactView = (contact) => (
 
     {!!contact.email && (
       <InfoBox>
-        <Icon icon={mail(colors.primary)} style={styles.margin} />
+        <Icon xml={mail(colors.primary)} style={styles.margin} />
         <TouchableOpacity onPress={() => openLink(`mailto:${contact.email}`)}>
           <RegularText primary>{contact.email}</RegularText>
         </TouchableOpacity>
@@ -91,7 +91,7 @@ export const InfoCard = ({ addresses, category, contact, contacts, webUrls, open
 
         return (
           <InfoBox key={index}>
-            <Icon icon={location(colors.primary)} style={styles.margin} />
+            <Icon xml={location(colors.primary)} style={styles.margin} />
             <TouchableOpacity onPress={() => addressOnPress(address)}>
               <RegularText primary>{address}</RegularText>
             </TouchableOpacity>
@@ -132,7 +132,7 @@ export const InfoCard = ({ addresses, category, contact, contacts, webUrls, open
 
         return (
           <InfoBox key={index}>
-            <Icon icon={urlIcon(colors.primary)} style={styles.margin} />
+            <Icon xml={urlIcon(colors.primary)} style={styles.margin} />
             <TouchableOpacity onPress={() => openLink(url, openWebScreen)}>
               {!description && <RegularText primary>{url}</RegularText>}
               {!!description && <RegularText primary>{description}</RegularText>}

--- a/src/components/screens/OperatingCompanyInfo.js
+++ b/src/components/screens/OperatingCompanyInfo.js
@@ -62,7 +62,7 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
 
       {!!companyAddress && (
         <InfoBox>
-          <Icon icon={location(colors.primary)} style={styles.margin} />
+          <Icon xml={location(colors.primary)} style={styles.margin} />
           <TouchableOpacity onPress={() => addressOnPress(companyAddress)}>
             <RegularText primary>{companyAddress}</RegularText>
           </TouchableOpacity>
@@ -85,7 +85,7 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
           )}
           {!!contact.phone && (
             <InfoBox>
-              <Icon icon={phoneIcon(colors.primary)} style={styles.margin} />
+              <Icon xml={phoneIcon(colors.primary)} style={styles.margin} />
               <TouchableOpacity onPress={() => openLink(`tel:${contact.phone}`)}>
                 <RegularText primary>{contact.phone}</RegularText>
               </TouchableOpacity>
@@ -93,7 +93,7 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
           )}
           {!!contact.email && (
             <InfoBox>
-              <Icon icon={mail(colors.primary)} style={styles.margin} />
+              <Icon xml={mail(colors.primary)} style={styles.margin} />
               <TouchableOpacity onPress={() => openLink(`mailto:${contact.email}`)}>
                 <RegularText primary>{contact.email}</RegularText>
               </TouchableOpacity>
@@ -112,7 +112,7 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
           )}
           {!!contact.www && (
             <InfoBox>
-              <Icon icon={link(colors.primary)} style={styles.marginWww} />
+              <Icon xml={link(colors.primary)} style={styles.marginWww} />
               <TouchableOpacity onPress={() => openLink(contact.www, openWebScreen)}>
                 <RegularText primary>{contact.www}</RegularText>
               </TouchableOpacity>
@@ -129,7 +129,7 @@ export const OperatingCompanyInfo = ({ address, contact, name, webUrls, openWebS
 
           return (
             <InfoBox key={index}>
-              <Icon icon={urlIcon(colors.primary)} style={styles.margin} />
+              <Icon xml={urlIcon(colors.primary)} style={styles.margin} />
               <TouchableOpacity onPress={() => openLink(url, openWebScreen)}>
                 <RegularText primary>{url}</RegularText>
               </TouchableOpacity>

--- a/src/components/screens/Service.js
+++ b/src/components/screens/Service.js
@@ -14,7 +14,7 @@ import { Title, TitleContainer, TitleShadow } from '../Title';
 import { WrapperWrap } from '../Wrapper';
 import { getQuery } from '../../queries';
 import { graphqlFetchPolicy, refreshTimeFor } from '../../helpers';
-import TabBarIcon from '../TabBarIcon';
+import { TabBarIcon } from '../TabBarIcon';
 
 export const Service = ({ navigation }) => {
   const [refreshTime, setRefreshTime] = useState();

--- a/src/components/screens/Service.js
+++ b/src/components/screens/Service.js
@@ -12,9 +12,9 @@ import { ServiceBox } from '../ServiceBox';
 import { BoldText } from '../Text';
 import { Title, TitleContainer, TitleShadow } from '../Title';
 import { WrapperWrap } from '../Wrapper';
+import { Icon } from '../Icon';
 import { getQuery } from '../../queries';
 import { graphqlFetchPolicy, refreshTimeFor } from '../../helpers';
-import { TabBarIcon } from '../TabBarIcon';
 
 export const Service = ({ navigation }) => {
   const [refreshTime, setRefreshTime] = useState();
@@ -74,7 +74,7 @@ export const Service = ({ navigation }) => {
                       >
                         <View>
                           {item.iconName ? (
-                            <TabBarIcon name={item.iconName} size={30} style={styles.serviceIcon} />
+                            <Icon name={item.iconName} size={30} style={styles.serviceIcon} />
                           ) : (
                             <Image
                               source={{ uri: item.icon }}

--- a/src/components/screens/TourCard.js
+++ b/src/components/screens/TourCard.js
@@ -56,7 +56,7 @@ export const TourCard = ({ addresses, lengthKm }) => (
 
             return (
               <InfoBox key={index}>
-                <Icon icon={location(colors.primary)} style={styles.margin} />
+                <Icon xml={location(colors.primary)} style={styles.margin} />
                 <View>
                   <RegularText>{kind === 'start' ? texts.tour.start : texts.tour.end}</RegularText>
                   <TouchableOpacity onPress={() => addressOnPress(address)}>

--- a/src/navigation/MainTabNavigator.js
+++ b/src/navigation/MainTabNavigator.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createStackNavigator, createBottomTabNavigator } from 'react-navigation';
 
-import TabBarIcon from '../components/TabBarIcon';
+import { TabBarIcon } from '../components/TabBarIcon';
 import { home, service } from '../icons';
 import { Icon } from '../components';
 import {
@@ -124,6 +124,7 @@ AboutStack.navigationOptions = {
   )
 };
 
+// TODO: labelStyle needs a logic to apply some left margin to text label just on landscape mode
 const MainTabNavigator = createBottomTabNavigator(
   {
     HomeStack,
@@ -135,8 +136,7 @@ const MainTabNavigator = createBottomTabNavigator(
     tabBarOptions: {
       activeTintColor: colors.accent,
       inactiveTintColor: colors.primary,
-      tabStyle: { marginTop: normalize(5) },
-      labelStyle: { margin: normalize(3) }
+      tabStyle: { marginTop: normalize(5) }
     }
   }
 );

--- a/src/navigation/MainTabNavigator.js
+++ b/src/navigation/MainTabNavigator.js
@@ -123,8 +123,6 @@ AboutStack.navigationOptions = {
     <TabBarIcon focused={focused} name={device.patform === 'ios' ? 'ios-menu' : 'md-menu'} />
   )
 };
-
-// TODO: labelStyle needs a logic to apply some left margin to text label just on landscape mode
 const MainTabNavigator = createBottomTabNavigator(
   {
     HomeStack,

--- a/src/navigation/MainTabNavigator.js
+++ b/src/navigation/MainTabNavigator.js
@@ -15,7 +15,7 @@ import {
 
 import AppStackNavigator from './AppStackNavigator';
 import { defaultStackNavigatorConfig } from './defaultStackNavigatorConfig';
-import { colors, device, texts } from '../config';
+import { colors, device, normalize, texts } from '../config';
 
 const HomeStack = AppStackNavigator(false);
 
@@ -132,7 +132,12 @@ const MainTabNavigator = createBottomTabNavigator(
     AboutStack
   },
   {
-    tabBarOptions: { activeTintColor: colors.accent, inactiveTintColor: colors.primary }
+    tabBarOptions: {
+      activeTintColor: colors.accent,
+      inactiveTintColor: colors.primary,
+      tabStyle: { marginTop: normalize(5) },
+      labelStyle: { margin: normalize(3) }
+    }
   }
 );
 

--- a/src/navigation/MainTabNavigator.js
+++ b/src/navigation/MainTabNavigator.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { createStackNavigator, createBottomTabNavigator } from 'react-navigation';
 
-import { TabBarIcon } from '../components/TabBarIcon';
 import { home, service } from '../icons';
-import { Icon } from '../components';
+import { TabBarIcon } from '../components';
 import {
   AboutScreen,
   CompanyScreen,
@@ -21,7 +20,7 @@ const HomeStack = AppStackNavigator(false);
 
 HomeStack.navigationOptions = {
   tabBarLabel: texts.tabBarLabel.home,
-  tabBarIcon: ({ focused }) => <Icon icon={home(focused ? colors.accent : colors.primary)} />
+  tabBarIcon: ({ focused }) => <TabBarIcon xml={home(focused ? colors.accent : colors.primary)} />
 };
 
 const ServiceStack = createStackNavigator(
@@ -50,7 +49,9 @@ const ServiceStack = createStackNavigator(
 
 ServiceStack.navigationOptions = {
   tabBarLabel: texts.tabBarLabel.service,
-  tabBarIcon: ({ focused }) => <Icon icon={service(focused ? colors.accent : colors.primary)} />
+  tabBarIcon: ({ focused }) => (
+    <TabBarIcon xml={service(focused ? colors.accent : colors.primary)} />
+  )
 };
 
 const CompanyStack = createStackNavigator(
@@ -81,8 +82,10 @@ CompanyStack.navigationOptions = {
   tabBarLabel: texts.tabBarLabel.company,
   tabBarIcon: ({ focused }) => (
     <TabBarIcon
-      focused={focused}
       name={device.patform === 'ios' ? 'ios-briefcase' : 'md-briefcase'}
+      style={{ marginTop: normalize(3) }}
+      landscapeStyle={{ marginRight: -normalize(4), marginTop: 0 }}
+      focused={focused}
     />
   )
 };
@@ -120,9 +123,16 @@ const AboutStack = createStackNavigator(
 AboutStack.navigationOptions = {
   tabBarLabel: texts.tabBarLabel.about,
   tabBarIcon: ({ focused }) => (
-    <TabBarIcon focused={focused} name={device.patform === 'ios' ? 'ios-menu' : 'md-menu'} />
+    <TabBarIcon
+      name={device.patform === 'ios' ? 'ios-menu' : 'md-menu'}
+      size={normalize(28)}
+      style={{ marginTop: normalize(3) }}
+      landscapeStyle={{ marginRight: -normalize(6) }}
+      focused={focused}
+    />
   )
 };
+
 const MainTabNavigator = createBottomTabNavigator(
   {
     HomeStack,
@@ -134,7 +144,7 @@ const MainTabNavigator = createBottomTabNavigator(
     tabBarOptions: {
       activeTintColor: colors.accent,
       inactiveTintColor: colors.primary,
-      tabStyle: { marginTop: normalize(5) }
+      tabStyle: { marginTop: normalize(0) }
     }
   }
 );

--- a/src/navigation/defaultStackNavigatorConfig.js
+++ b/src/navigation/defaultStackNavigatorConfig.js
@@ -23,7 +23,7 @@ export const defaultStackNavigatorConfig = (initialRouteName, headerRight = true
       },
       headerRight: headerRight && (
         <TouchableOpacity onPress={() => navigation.openDrawer()}>
-          <Icon icon={drawerMenu(colors.lightestText)} style={styles.icon} />
+          <Icon xml={drawerMenu(colors.lightestText)} style={styles.icon} />
         </TouchableOpacity>
       )
     }),

--- a/src/screens/CompanyScreen.js
+++ b/src/screens/CompanyScreen.js
@@ -19,7 +19,7 @@ import {
 } from '../components';
 import { getQuery } from '../queries';
 import { graphqlFetchPolicy, refreshTimeFor } from '../helpers';
-import TabBarIcon from '../components/TabBarIcon';
+import { TabBarIcon } from '../components/TabBarIcon';
 
 export const CompanyScreen = ({ navigation }) => {
   const [refreshTime, setRefreshTime] = useState();

--- a/src/screens/CompanyScreen.js
+++ b/src/screens/CompanyScreen.js
@@ -8,6 +8,7 @@ import { GlobalSettingsContext } from '../GlobalSettingsProvider';
 import { colors, consts, device, normalize, texts } from '../config';
 import {
   BoldText,
+  Icon,
   Image,
   LoadingContainer,
   SafeAreaViewFlex,
@@ -19,7 +20,6 @@ import {
 } from '../components';
 import { getQuery } from '../queries';
 import { graphqlFetchPolicy, refreshTimeFor } from '../helpers';
-import { TabBarIcon } from '../components/TabBarIcon';
 
 export const CompanyScreen = ({ navigation }) => {
   const [refreshTime, setRefreshTime] = useState();
@@ -92,7 +92,7 @@ export const CompanyScreen = ({ navigation }) => {
                         >
                           <View>
                             {item.iconName ? (
-                              <TabBarIcon
+                              <Icon
                                 name={item.iconName}
                                 size={30}
                                 style={styles.serviceIcon}

--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -130,7 +130,7 @@ DetailScreen.navigationOptions = ({ navigation, navigationOptions }) => {
     headerLeft: (
       <View>
         <TouchableOpacity onPress={() => navigation.goBack()}>
-          <Icon icon={arrowLeft(colors.lightestText)} style={styles.icon} />
+          <Icon xml={arrowLeft(colors.lightestText)} style={styles.icon} />
         </TouchableOpacity>
       </View>
     ),
@@ -139,7 +139,7 @@ DetailScreen.navigationOptions = ({ navigation, navigationOptions }) => {
         {shareContent && (
           <TouchableOpacity onPress={() => openShare(shareContent)}>
             <Icon
-              icon={share(colors.lightestText)}
+              xml={share(colors.lightestText)}
               style={headerRight ? styles.iconLeft : styles.iconRight}
             />
           </TouchableOpacity>

--- a/src/screens/FormScreen.js
+++ b/src/screens/FormScreen.js
@@ -118,7 +118,7 @@ FormScreen.navigationOptions = ({ navigation }) => {
     headerLeft: (
       <View>
         <TouchableOpacity onPress={() => navigation.goBack()}>
-          <Icon icon={arrowLeft(colors.lightestText)} style={styles.icon} />
+          <Icon xml={arrowLeft(colors.lightestText)} style={styles.icon} />
         </TouchableOpacity>
       </View>
     )

--- a/src/screens/HtmlScreen.js
+++ b/src/screens/HtmlScreen.js
@@ -140,7 +140,7 @@ HtmlScreen.navigationOptions = ({ navigation }) => {
     headerLeft: (
       <View>
         <TouchableOpacity onPress={() => navigation.goBack()}>
-          <Icon icon={arrowLeft(colors.lightestText)} style={styles.icon} />
+          <Icon xml={arrowLeft(colors.lightestText)} style={styles.icon} />
         </TouchableOpacity>
       </View>
     )

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -290,7 +290,7 @@ IndexScreen.navigationOptions = ({ navigation }) => {
     headerLeft: (
       <View>
         <TouchableOpacity onPress={() => navigation.goBack()}>
-          <Icon icon={arrowLeft(colors.lightestText)} style={styles.icon} />
+          <Icon xml={arrowLeft(colors.lightestText)} style={styles.icon} />
         </TouchableOpacity>
       </View>
     )

--- a/src/screens/ServiceScreen.js
+++ b/src/screens/ServiceScreen.js
@@ -8,6 +8,7 @@ import { GlobalSettingsContext } from '../GlobalSettingsProvider';
 import { colors, consts, device, normalize, texts } from '../config';
 import {
   BoldText,
+  Icon,
   Image,
   LoadingContainer,
   SafeAreaViewFlex,
@@ -19,7 +20,6 @@ import {
 } from '../components';
 import { getQuery } from '../queries';
 import { graphqlFetchPolicy, refreshTimeFor } from '../helpers';
-import { TabBarIcon } from '../components/TabBarIcon';
 
 export const ServiceScreen = ({ navigation }) => {
   const [refreshTime, setRefreshTime] = useState();
@@ -92,7 +92,7 @@ export const ServiceScreen = ({ navigation }) => {
                         >
                           <View>
                             {item.iconName ? (
-                              <TabBarIcon
+                              <Icon
                                 name={item.iconName}
                                 size={30}
                                 style={styles.serviceIcon}

--- a/src/screens/ServiceScreen.js
+++ b/src/screens/ServiceScreen.js
@@ -19,7 +19,7 @@ import {
 } from '../components';
 import { getQuery } from '../queries';
 import { graphqlFetchPolicy, refreshTimeFor } from '../helpers';
-import TabBarIcon from '../components/TabBarIcon';
+import { TabBarIcon } from '../components/TabBarIcon';
 
 export const ServiceScreen = ({ navigation }) => {
   const [refreshTime, setRefreshTime] = useState();
@@ -65,7 +65,7 @@ export const ServiceScreen = ({ navigation }) => {
           }
 
           let publicJsonFileContent =
-              data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
+            data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
 
           if (!publicJsonFileContent || !publicJsonFileContent.length) return null;
 

--- a/src/screens/WebScreen.js
+++ b/src/screens/WebScreen.js
@@ -13,7 +13,7 @@ export class WebScreen extends React.PureComponent {
       headerLeft: (
         <View>
           <TouchableOpacity onPress={() => navigation.goBack()}>
-            <Icon icon={arrowLeft(colors.lightestText)} style={styles.icon} />
+            <Icon xml={arrowLeft(colors.lightestText)} style={styles.icon} />
           </TouchableOpacity>
         </View>
       )


### PR DESCRIPTION
- we are using tow different kind of Icons in our tabBar;
  - first two are 'svg' fils saved in the app ( home and service )
  - second two are 'Ionicons', which have a small white frame on the bottom on the icon
     - that's why they were having some margin that now I remove
- add some marginTop for all tabBar icons in order to have space between icons and top of tabBar
 - now icons in tabBar are aligned, and text looks centred
  - but still looks a bit off on iPad screen ( info on SVA-92 )
- PropTypes for name and focused were missing

 SVA-93

- on changes orientation, tab bar icons get some extra margin to the right
 - both (Icon and TabBarIcon) are wrapped in a view which as a landscapeStyle prop
   - and just on TabBarIcon component icon size increases a bit
    - here there is a bug , on landscape this two icons are cut on the right
- TabBarIcon component is not default function component anymore that's why now it's imported inside curly brackets

 SVA-93

- TODO is made so comment is gone
- focused prop in TabBarIcon it's a boolean data type not an object
- corrections on Icon are made based on Daniel's comment ( https://github.com/ikuseiGmbH/smart-village-app-app/pull/98/files/8700e6836f9a305fbfa210d62f3252d0d6019c5d#r497405526 )

 SVA-93


before : 
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-09-23 at 14 05 43](https://user-images.githubusercontent.com/43641321/94565858-034b7d80-026a-11eb-8d25-fd24b800f263.png)


now : 
![IMG_0274](https://user-images.githubusercontent.com/43641321/94599369-a1ead500-0290-11eb-8dcf-db59d6a72dba.PNG)






- Maybe we should use just one kind of icon in tabBar, to simplify stylization. 
here icons examples on debug, the see the difference  : 
svg: 
<img width="98" alt="Screenshot 2020-09-28 at 17 10 34" src="https://user-images.githubusercontent.com/43641321/94456715-e5bbdc80-01b3-11eb-9c8b-ab0118f3cbae.png">
ionicon: 
<img width="86" alt="Screenshot 2020-09-28 at 17 10 20" src="https://user-images.githubusercontent.com/43641321/94456753-ee141780-01b3-11eb-970c-e51fa1b5f567.png">




SVA-93


