### PR TITLE
feat(NetInfo): refactor usage on app load

### DIFF
--- a/src/NetworkProvider.js
+++ b/src/NetworkProvider.js
@@ -22,13 +22,9 @@ export const NetworkProvider = ({ children }) => {
       setInternetReachable(state.isInternetReachable);
     });
 
-    // returned function will be called on component unmount
+    // returned function will be called when component unmounts
     return () => unsubscribe();
   }, []);
-
-  // TODO: remove logs
-  // console.log('NetworkProvider isConnected', connected);
-  // console.log('NetworkProvider isMainserverUp', internetReachable);
 
   return (
     <NetworkContext.Provider value={{ isConnected: connected, isMainserverUp: internetReachable }}>


### PR DESCRIPTION
- removed `NetworkContext` to eliminate the behavior of reloading
  the whole app container when network connectivity changes
- changed usage to get network information to `NetInfo.fetch()`,
  which get called in a loop until main server reachability is
  set