### PR TITLE
feat(query types): created constants with all types

### DIFF
--- a/src/components/screens/About.js
+++ b/src/components/screens/About.js
@@ -8,7 +8,7 @@ import { GlobalSettingsContext } from '../../GlobalSettingsProvider';
 import { consts, device, texts } from '../../config';
 import { Title, TitleContainer, TitleShadow } from '../Title';
 import { TextList } from '../TextList';
-import { getQuery } from '../../queries';
+import { getQuery, QUERY_TYPES } from '../../queries';
 import { graphqlFetchPolicy, refreshTimeFor } from '../../helpers';
 
 export const About = ({ navigation, refreshing }) => {
@@ -34,7 +34,7 @@ export const About = ({ navigation, refreshing }) => {
 
   return (
     <Query
-      query={getQuery('publicJsonFile')}
+      query={getQuery(QUERY_TYPES.PUBLIC_JSON_FILE)}
       variables={{ name: 'homeAbout' }}
       fetchPolicy={fetchPolicy}
     >

--- a/src/components/screens/Carousel.js
+++ b/src/components/screens/Carousel.js
@@ -8,7 +8,7 @@ import { NetworkContext } from '../../NetworkProvider';
 import { colors, consts } from '../../config';
 import { ImagesCarousel } from '../ImagesCarousel';
 import { LoadingContainer } from '../LoadingContainer';
-import { getQuery } from '../../queries';
+import { getQuery, QUERY_TYPES } from '../../queries';
 import { graphqlFetchPolicy, refreshTimeFor } from '../../helpers';
 
 export const Carousel = ({ navigation, refreshing }) => {
@@ -37,7 +37,7 @@ export const Carousel = ({ navigation, refreshing }) => {
 
   return (
     <Query
-      query={getQuery('publicJsonFile')}
+      query={getQuery(QUERY_TYPES.PUBLIC_JSON_FILE)}
       variables={{ name: 'homeCarousel' }}
       fetchPolicy={fetchPolicy}
     >

--- a/src/components/screens/Service.js
+++ b/src/components/screens/Service.js
@@ -12,7 +12,7 @@ import { ServiceBox } from '../ServiceBox';
 import { BoldText } from '../Text';
 import { Title, TitleContainer, TitleShadow } from '../Title';
 import { WrapperWrap } from '../Wrapper';
-import { getQuery } from '../../queries';
+import { getQuery, QUERY_TYPES } from '../../queries';
 import { graphqlFetchPolicy, refreshTimeFor } from '../../helpers';
 import TabBarIcon from '../TabBarIcon';
 
@@ -39,7 +39,7 @@ export const Service = ({ navigation, refreshing }) => {
 
   return (
     <Query
-      query={getQuery('publicJsonFile')}
+      query={getQuery(QUERY_TYPES.PUBLIC_JSON_FILE)}
       variables={{ name: 'homeService' }}
       fetchPolicy={fetchPolicy}
     >

--- a/src/helpers/shareHelper.js
+++ b/src/helpers/shareHelper.js
@@ -1,6 +1,7 @@
 import { Share } from 'react-native';
 
 import appJson from '../../app.json';
+import { QUERY_TYPES } from '../queries';
 import { momentFormat } from './momentHelper';
 
 // https://facebook.github.io/react-native/docs/share
@@ -37,18 +38,18 @@ export const openShare = async ({ message, title, url }) => {
 export const shareMessage = (data, query) => {
   const buildMessage = (query) => {
     switch (query) {
-    case 'eventRecord':
+    case QUERY_TYPES.EVENT_RECORD:
       return `${momentFormat(data.listDate)} | ${data.addresses &&
           data.addresses.length &&
           (data.addresses[0].addition || data.addresses[0].city)}: ${data.title}`;
-    case 'newsItem':
+    case QUERY_TYPES.NEWS_ITEM:
       return `${momentFormat(data.publishedAt)} | ${data.dataProvider &&
           data.dataProvider.name}: ${data.contentBlocks &&
           data.contentBlocks.length &&
           data.contentBlocks[0].title}`;
-    case 'pointOfInterest':
+    case QUERY_TYPES.POINT_OF_INTEREST:
       return `${data.category && data.category.name}: ${data.name}`;
-    case 'tour':
+    case QUERY_TYPES.TOUR:
       return `${data.category && data.category.name}: ${data.name}`;
     }
   };

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ import appJson from '../app.json';
 import { auth } from './auth';
 import { colors, consts, device, secrets, texts } from './config';
 import { graphqlFetchPolicy, storageHelper } from './helpers';
-import { getQuery } from './queries';
+import { getQuery, QUERY_TYPES } from './queries';
 import { NetworkProvider } from './NetworkProvider';
 import NetInfo from './NetInfo';
 import { GlobalSettingsProvider } from './GlobalSettingsProvider';
@@ -148,7 +148,7 @@ const MainAppWithApolloProvider = () => {
 
     try {
       const response = await client.query({
-        query: getQuery('publicJsonFile'),
+        query: getQuery(QUERY_TYPES.PUBLIC_JSON_FILE),
         variables: { name: 'globalSettings' },
         fetchPolicy
       });
@@ -190,7 +190,7 @@ const MainAppWithApolloProvider = () => {
       // setup drawer routes for navigation
       try {
         const response = await client.query({
-          query: getQuery('publicJsonFile'),
+          query: getQuery(QUERY_TYPES.PUBLIC_JSON_FILE),
           variables: { name: 'navigation' },
           fetchPolicy
         });

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -11,36 +11,39 @@ import { GET_TOUR, GET_TOURS } from './tours';
 import { GET_POINTS_OF_INTEREST_AND_TOURS } from './pointsOfInterestAndTours';
 import { GET_PUBLIC_HTML_FILE } from './publicHtmlFiles';
 import { GET_PUBLIC_JSON_FILE } from './publicJsonFiles';
+import { QUERY_TYPES } from './types';
+
+export * from './types';
 
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const getQuery = (query, filterOptions = {}) => {
   switch (query) {
-  case 'categories':
+  case QUERY_TYPES.CATEGORIES:
     return GET_CATEGORIES;
-  case 'eventRecord':
+  case QUERY_TYPES.EVENT_RECORD:
     return GET_EVENT_RECORD;
-  case 'eventRecords':
+  case QUERY_TYPES.EVENT_RECORDS:
     return GET_EVENT_RECORDS;
-  case 'newsItem':
+  case QUERY_TYPES.NEWS_ITEM:
     return GET_NEWS_ITEM;
-  case 'newsItems':
+  case QUERY_TYPES.NEWS_ITEMS:
     return filterOptions.showNewsFilter
       ? GET_FILTERED_NEWS_ITEMS_AND_DATA_PROVIDERS
       : GET_NEWS_ITEMS;
-  case 'tour':
+  case QUERY_TYPES.TOUR:
     return GET_TOUR;
-  case 'tours':
+  case QUERY_TYPES.TOURS:
     return GET_TOURS;
-  case 'pointOfInterest':
+  case QUERY_TYPES.POINT_OF_INTEREST:
     return GET_POINT_OF_INTEREST;
-  case 'pointsOfInterest':
+  case QUERY_TYPES.POINTS_OF_INTEREST:
     return GET_POINTS_OF_INTEREST;
-  case 'pointsOfInterestAndTours':
+  case QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS:
     return GET_POINTS_OF_INTEREST_AND_TOURS;
-  case 'publicHtmlFile':
+  case QUERY_TYPES.PUBLIC_HTML_FILE:
     return GET_PUBLIC_HTML_FILE;
-  case 'publicJsonFile':
+  case QUERY_TYPES.PUBLIC_JSON_FILE:
     return GET_PUBLIC_JSON_FILE;
   }
 };
@@ -48,9 +51,9 @@ export const getQuery = (query, filterOptions = {}) => {
 
 export const getFetchMoreQuery = (query, filterOptions = {}) => {
   switch (query) {
-  case 'eventRecords':
+  case QUERY_TYPES.EVENT_RECORDS:
     return GET_EVENT_RECORDS;
-  case 'newsItems':
+  case QUERY_TYPES.NEWS_ITEMS:
     return filterOptions.showNewsFilter ? GET_FILTERED_NEWS_ITEMS : GET_NEWS_ITEMS;
   }
 };

--- a/src/queries/types.js
+++ b/src/queries/types.js
@@ -1,0 +1,15 @@
+export const QUERY_TYPES = {
+  APP_USER_CONTENT: 'appUserContent',
+  CATEGORIES: 'categories',
+  EVENT_RECORD: 'eventRecord',
+  EVENT_RECORDS: 'eventRecords',
+  NEWS_ITEM: 'newsItem',
+  NEWS_ITEMS: 'newsItems',
+  POINT_OF_INTEREST: 'pointOfInterest',
+  POINTS_OF_INTEREST: 'pointsOfInterest',
+  POINTS_OF_INTEREST_AND_TOURS: 'pointsOfInterestAndTours',
+  PUBLIC_HTML_FILE: 'publicHtmlFile',
+  PUBLIC_JSON_FILE: 'publicJsonFile',
+  TOUR: 'tour',
+  TOURS: 'tours'
+};

--- a/src/screens/AboutScreen.js
+++ b/src/screens/AboutScreen.js
@@ -15,7 +15,7 @@ import {
   TitleShadow,
   VersionNumber
 } from '../components';
-import { getQuery } from '../queries';
+import { getQuery, QUERY_TYPES } from '../queries';
 import { graphqlFetchPolicy, refreshTimeFor } from '../helpers';
 
 export const AboutScreen = ({ navigation }) => {
@@ -55,7 +55,7 @@ export const AboutScreen = ({ navigation }) => {
   return (
     <SafeAreaViewFlex>
       <Query
-        query={getQuery('publicJsonFile')}
+        query={getQuery(QUERY_TYPES.PUBLIC_JSON_FILE)}
         variables={{ name: 'homeAbout' }}
         fetchPolicy={fetchPolicy}
       >

--- a/src/screens/CompanyScreen.js
+++ b/src/screens/CompanyScreen.js
@@ -24,7 +24,7 @@ import {
   TitleShadow,
   WrapperWrap
 } from '../components';
-import { getQuery } from '../queries';
+import { getQuery, QUERY_TYPES } from '../queries';
 import { graphqlFetchPolicy, refreshTimeFor } from '../helpers';
 import TabBarIcon from '../components/TabBarIcon';
 
@@ -65,7 +65,7 @@ export const CompanyScreen = ({ navigation }) => {
   return (
     <SafeAreaViewFlex>
       <Query
-        query={getQuery('publicJsonFile')}
+        query={getQuery(QUERY_TYPES.PUBLIC_JSON_FILE)}
         variables={{ name: 'homeCompanies' }}
         fetchPolicy={fetchPolicy}
       >

--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -23,32 +23,32 @@ import {
   Tour,
   WrapperRow
 } from '../components';
-import { getQuery } from '../queries';
+import { getQuery, QUERY_TYPES } from '../queries';
 import { arrowLeft, share } from '../icons';
 import { graphqlFetchPolicy, openShare, refreshTimeFor } from '../helpers';
 
 const getComponent = (query) => {
   switch (query) {
-  case 'newsItem':
+  case QUERY_TYPES.NEWS_ITEM:
     return NewsItem;
-  case 'eventRecord':
+  case QUERY_TYPES.EVENT_RECORD:
     return EventRecord;
-  case 'pointOfInterest':
+  case QUERY_TYPES.POINT_OF_INTEREST:
     return PointOfInterest;
-  case 'tour':
+  case QUERY_TYPES.TOUR:
     return Tour;
   }
 };
 
 const getRefreshInterval = (query) => {
   switch (query) {
-  case 'newsItem':
+  case QUERY_TYPES.NEWS_ITEM:
     return consts.NEWS;
-  case 'eventRecord':
+  case QUERY_TYPES.EVENT_RECORD:
     return consts.EVENTS;
-  case 'pointOfInterest':
+  case QUERY_TYPES.POINT_OF_INTEREST:
     return consts.POINTS_OF_INTEREST;
-  case 'tour':
+  case QUERY_TYPES.TOUR:
     return consts.TOURS;
   }
 };

--- a/src/screens/FormScreen.js
+++ b/src/screens/FormScreen.js
@@ -3,8 +3,8 @@ import React, { useState } from 'react';
 import { Alert, ScrollView, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
 import { CheckBox } from 'react-native-elements';
 import { Mutation } from 'react-apollo';
-import { getQuery } from '../queries';
 
+import { getQuery, QUERY_TYPES } from '../queries';
 import { colors, normalize } from '../config';
 import { BoldText, Button, Icon, SafeAreaViewFlex } from '../components';
 import { arrowLeft } from '../icons';
@@ -58,7 +58,7 @@ export const FormScreen = () => {
   return (
     <SafeAreaViewFlex>
       <ScrollView>
-        <Mutation mutation={getQuery('appUserContent')}>
+        <Mutation mutation={getQuery(QUERY_TYPES.APP_USER_CONTENT)}>
           {(createAppUserContent) => (
             <View style={{ padding: normalize(14) }}>
               <BoldText>Name</BoldText>

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -70,6 +70,36 @@ export const HomeScreen = ({ navigation }) => {
     }, 500);
   };
 
+  const NAVIGATION = {
+    CATEGORIES_INDEX: {
+      routeName: 'Index',
+      params: {
+        title: 'Touren und Orte',
+        query: QUERY_TYPES.CATEGORIES,
+        queryVariables: {},
+        rootRouteName: 'PointsOfInterestAndTours'
+      }
+    },
+    EVENT_RECORDS_INDEX: {
+      routeName: 'Index',
+      params: {
+        title: 'Veranstaltungen',
+        query: QUERY_TYPES.EVENT_RECORDS,
+        queryVariables: { limit: 15, order: 'listDate_ASC' },
+        rootRouteName: 'EventRecords'
+      }
+    },
+    NEWS_ITEMS_INDEX: {
+      routeName: 'Index',
+      params: {
+        title: 'Nachrichten',
+        query: QUERY_TYPES.NEWS_ITEMS,
+        queryVariables: { limit: 15 },
+        rootRouteName: 'NewsItems'
+      }
+    }
+  };
+
   return (
     <SafeAreaViewFlex>
       <ScrollView
@@ -87,19 +117,7 @@ export const HomeScreen = ({ navigation }) => {
         {showNews && (
           <>
             <TitleContainer>
-              <Touchable
-                onPress={() =>
-                  navigation.navigate({
-                    routeName: 'Index',
-                    params: {
-                      title: 'Nachrichten',
-                      query: QUERY_TYPES.NEWS_ITEMS,
-                      queryVariables: { limit: 15 },
-                      rootRouteName: 'NewsItems'
-                    }
-                  })
-                }
-              >
+              <Touchable onPress={() => navigation.navigate(NAVIGATION.NEWS_ITEMS_INDEX)}>
                 <Title>{headlineNews}</Title>
               </Touchable>
             </TitleContainer>
@@ -154,17 +172,7 @@ export const HomeScreen = ({ navigation }) => {
                     <Wrapper>
                       <Button
                         title={buttonNews}
-                        onPress={() =>
-                          navigation.navigate({
-                            routeName: 'Index',
-                            params: {
-                              title: 'Nachrichten',
-                              query: QUERY_TYPES.NEWS_ITEMS,
-                              queryVariables: { limit: 15 },
-                              rootRouteName: 'NewsItems'
-                            }
-                          })
-                        }
+                        onPress={() => navigation.navigate(NAVIGATION.NEWS_ITEMS_INDEX)}
                       />
                     </Wrapper>
                   </View>
@@ -177,19 +185,7 @@ export const HomeScreen = ({ navigation }) => {
         {showPointsOfInterestAndTours && (
           <>
             <TitleContainer>
-              <Touchable
-                onPress={() =>
-                  navigation.navigate({
-                    routeName: 'Index',
-                    params: {
-                      title: 'Touren und Orte',
-                      query: QUERY_TYPES.CATEGORIES,
-                      queryVariables: {},
-                      rootRouteName: 'PointsOfInterestAndTours'
-                    }
-                  })
-                }
-              >
+              <Touchable onPress={() => navigation.navigate(NAVIGATION.CATEGORIES_INDEX)}>
                 <Title>{headlinePointsOfInterestAndTours}</Title>
               </Touchable>
             </TitleContainer>
@@ -263,17 +259,7 @@ export const HomeScreen = ({ navigation }) => {
                     <Wrapper>
                       <Button
                         title={buttonPointsOfInterestAndTours}
-                        onPress={() =>
-                          navigation.navigate({
-                            routeName: 'Index',
-                            params: {
-                              title: 'Touren und Orte',
-                              query: QUERY_TYPES.CATEGORIES,
-                              queryVariables: {},
-                              rootRouteName: 'PointsOfInterestAndTours'
-                            }
-                          })
-                        }
+                        onPress={() => navigation.navigate(NAVIGATION.CATEGORIES_INDEX)}
                       />
                     </Wrapper>
                   </View>
@@ -286,19 +272,7 @@ export const HomeScreen = ({ navigation }) => {
         {showEvents && (
           <>
             <TitleContainer>
-              <Touchable
-                onPress={() =>
-                  navigation.navigate({
-                    routeName: 'Index',
-                    params: {
-                      title: 'Veranstaltungen',
-                      query: QUERY_TYPES.EVENT_RECORDS,
-                      queryVariables: { limit: 15, order: 'listDate_ASC' },
-                      rootRouteName: 'EventRecords'
-                    }
-                  })
-                }
-              >
+              <Touchable onPress={() => navigation.navigate(NAVIGATION.EVENT_RECORDS_INDEX)}>
                 <Title>{headlineEvents}</Title>
               </Touchable>
             </TitleContainer>
@@ -352,17 +326,7 @@ export const HomeScreen = ({ navigation }) => {
                     <Wrapper>
                       <Button
                         title={buttonEvents}
-                        onPress={() =>
-                          navigation.navigate({
-                            routeName: 'Index',
-                            params: {
-                              title: 'Veranstaltungen',
-                              query: QUERY_TYPES.EVENT_RECORDS,
-                              queryVariables: { limit: 15, order: 'listDate_ASC' },
-                              rootRouteName: 'EventRecords'
-                            }
-                          })
-                        }
+                        onPress={() => navigation.navigate(NAVIGATION.EVENT_RECORDS_INDEX)}
                       />
                     </Wrapper>
                   </View>

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -24,7 +24,7 @@ import {
   VersionNumber,
   Wrapper
 } from '../components';
-import { getQuery } from '../queries';
+import { getQuery, QUERY_TYPES } from '../queries';
 import {
   eventDate,
   graphqlFetchPolicy,
@@ -93,7 +93,7 @@ export const HomeScreen = ({ navigation }) => {
                     routeName: 'Index',
                     params: {
                       title: 'Nachrichten',
-                      query: 'newsItems',
+                      query: QUERY_TYPES.NEWS_ITEMS,
                       queryVariables: { limit: 15 },
                       rootRouteName: 'NewsItems'
                     }
@@ -104,7 +104,11 @@ export const HomeScreen = ({ navigation }) => {
               </Touchable>
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
-            <Query query={getQuery('newsItems')} variables={{ limit: 3 }} fetchPolicy={fetchPolicy}>
+            <Query
+              query={getQuery(QUERY_TYPES.NEWS_ITEMS)}
+              variables={{ limit: 3 }}
+              fetchPolicy={fetchPolicy}
+            >
               {({ data, loading }) => {
                 if (loading) {
                   return (
@@ -129,11 +133,11 @@ export const HomeScreen = ({ navigation }) => {
                     routeName: 'Detail',
                     params: {
                       title: 'Nachricht',
-                      query: 'newsItem',
+                      query: QUERY_TYPES.NEWS_ITEM,
                       queryVariables: { id: `${newsItem.id}` },
                       rootRouteName: 'NewsItems',
                       shareContent: {
-                        message: shareMessage(newsItem, 'newsItem')
+                        message: shareMessage(newsItem, QUERY_TYPES.NEWS_ITEM)
                       },
                       details: newsItem
                     },
@@ -155,7 +159,7 @@ export const HomeScreen = ({ navigation }) => {
                             routeName: 'Index',
                             params: {
                               title: 'Nachrichten',
-                              query: 'newsItems',
+                              query: QUERY_TYPES.NEWS_ITEMS,
                               queryVariables: { limit: 15 },
                               rootRouteName: 'NewsItems'
                             }
@@ -179,7 +183,7 @@ export const HomeScreen = ({ navigation }) => {
                     routeName: 'Index',
                     params: {
                       title: 'Touren und Orte',
-                      query: 'categories',
+                      query: QUERY_TYPES.CATEGORIES,
                       queryVariables: {},
                       rootRouteName: 'PointsOfInterestAndTours'
                     }
@@ -191,7 +195,7 @@ export const HomeScreen = ({ navigation }) => {
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <Query
-              query={getQuery('pointsOfInterestAndTours')}
+              query={getQuery(QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS)}
               variables={{ limit: 10, orderPoi: 'RAND', orderTour: 'RAND' }}
               fetchPolicy={fetchPolicy}
             >
@@ -215,11 +219,11 @@ export const HomeScreen = ({ navigation }) => {
                     routeName: 'Detail',
                     params: {
                       title: 'Ort',
-                      query: 'pointOfInterest',
+                      query: QUERY_TYPES.POINT_OF_INTEREST,
                       queryVariables: { id: `${pointOfInterest.id}` },
                       rootRouteName: 'PointsOfInterest',
                       shareContent: {
-                        message: shareMessage(pointOfInterest, 'pointOfInterest')
+                        message: shareMessage(pointOfInterest, QUERY_TYPES.POINT_OF_INTEREST)
                       },
                       details: pointOfInterest
                     },
@@ -237,11 +241,11 @@ export const HomeScreen = ({ navigation }) => {
                     routeName: 'Detail',
                     params: {
                       title: 'Tour',
-                      query: 'tour',
+                      query: QUERY_TYPES.TOUR,
                       queryVariables: { id: `${tour.id}` },
                       rootRouteName: 'Tours',
                       shareContent: {
-                        message: shareMessage(tour, 'tour')
+                        message: shareMessage(tour, QUERY_TYPES.TOUR)
                       },
                       details: tour
                     },
@@ -264,7 +268,7 @@ export const HomeScreen = ({ navigation }) => {
                             routeName: 'Index',
                             params: {
                               title: 'Touren und Orte',
-                              query: 'categories',
+                              query: QUERY_TYPES.CATEGORIES,
                               queryVariables: {},
                               rootRouteName: 'PointsOfInterestAndTours'
                             }
@@ -288,7 +292,7 @@ export const HomeScreen = ({ navigation }) => {
                     routeName: 'Index',
                     params: {
                       title: 'Veranstaltungen',
-                      query: 'eventRecords',
+                      query: QUERY_TYPES.EVENT_RECORDS,
                       queryVariables: { limit: 15, order: 'listDate_ASC' },
                       rootRouteName: 'EventRecords'
                     }
@@ -300,7 +304,7 @@ export const HomeScreen = ({ navigation }) => {
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <Query
-              query={getQuery('eventRecords')}
+              query={getQuery(QUERY_TYPES.EVENT_RECORDS)}
               variables={{ limit: 3, order: 'listDate_ASC' }}
               fetchPolicy={fetchPolicy}
             >
@@ -327,11 +331,11 @@ export const HomeScreen = ({ navigation }) => {
                     routeName: 'Detail',
                     params: {
                       title: 'Veranstaltung',
-                      query: 'eventRecord',
+                      query: QUERY_TYPES.EVENT_RECORD,
                       queryVariables: { id: `${eventRecord.id}` },
                       rootRouteName: 'EventRecords',
                       shareContent: {
-                        message: shareMessage(eventRecord, 'eventRecord')
+                        message: shareMessage(eventRecord, QUERY_TYPES.EVENT_RECORD)
                       },
                       details: eventRecord
                     },
@@ -353,7 +357,7 @@ export const HomeScreen = ({ navigation }) => {
                             routeName: 'Index',
                             params: {
                               title: 'Veranstaltungen',
-                              query: 'eventRecords',
+                              query: QUERY_TYPES.EVENT_RECORDS,
                               queryVariables: { limit: 15, order: 'listDate_ASC' },
                               rootRouteName: 'EventRecords'
                             }

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -22,7 +22,7 @@ import {
   SafeAreaViewFlex,
   TextList
 } from '../components';
-import { getQuery, getFetchMoreQuery } from '../queries';
+import { getQuery, getFetchMoreQuery, QUERY_TYPES } from '../queries';
 import { arrowLeft } from '../icons';
 import {
   eventDate,
@@ -36,7 +36,7 @@ import {
 /* NOTE: we need to check a lot for presence, so this is that complex */
 const getListItems = (query, data) => {
   switch (query) {
-  case 'eventRecords':
+  case QUERY_TYPES.EVENT_RECORDS:
     return (
       data &&
         data[query] &&
@@ -51,17 +51,17 @@ const getListItems = (query, data) => {
           routeName: 'Detail',
           params: {
             title: 'Veranstaltung',
-            query: 'eventRecord',
+            query: QUERY_TYPES.EVENT_RECORD,
             queryVariables: { id: `${eventRecord.id}` },
             rootRouteName: 'EventRecords',
             shareContent: {
-              message: shareMessage(eventRecord, 'eventRecord')
+              message: shareMessage(eventRecord, QUERY_TYPES.EVENT_RECORD)
             },
             details: eventRecord
           }
         }))
     );
-  case 'newsItems':
+  case QUERY_TYPES.NEWS_ITEMS:
     return (
       data &&
         data[query] &&
@@ -77,17 +77,17 @@ const getListItems = (query, data) => {
           routeName: 'Detail',
           params: {
             title: 'Nachricht',
-            query: 'newsItem',
+            query: QUERY_TYPES.NEWS_ITEM,
             queryVariables: { id: `${newsItem.id}` },
             rootRouteName: 'NewsItems',
             shareContent: {
-              message: shareMessage(newsItem, 'newsItem')
+              message: shareMessage(newsItem, QUERY_TYPES.NEWS_ITEM)
             },
             details: newsItem
           }
         }))
     );
-  case 'pointsOfInterest':
+  case QUERY_TYPES.POINTS_OF_INTEREST:
     return (
       data &&
         data[query] &&
@@ -99,17 +99,17 @@ const getListItems = (query, data) => {
           routeName: 'Detail',
           params: {
             title: 'Ort',
-            query: 'pointOfInterest',
+            query: QUERY_TYPES.POINT_OF_INTEREST,
             queryVariables: { id: `${pointOfInterest.id}` },
             rootRouteName: 'PointsOfInterest',
             shareContent: {
-              message: shareMessage(pointOfInterest, 'pointOfInterest')
+              message: shareMessage(pointOfInterest, QUERY_TYPES.POINT_OF_INTEREST)
             },
             details: pointOfInterest
           }
         }))
     );
-  case 'tours':
+  case QUERY_TYPES.TOURS:
     return (
       data &&
         data[query] &&
@@ -121,18 +121,18 @@ const getListItems = (query, data) => {
           routeName: 'Detail',
           params: {
             title: 'Tour',
-            query: 'tour',
+            query: QUERY_TYPES.TOUR,
             queryVariables: { id: `${tour.id}` },
             rootRouteName: 'Tours',
             shareContent: {
-              message: shareMessage(tour, 'tour')
+              message: shareMessage(tour, QUERY_TYPES.TOUR)
             },
             details: tour
           }
         }))
     );
 
-  case 'categories': {
+  case QUERY_TYPES.CATEGORIES: {
     return (
       data &&
         data[query] &&
@@ -144,7 +144,10 @@ const getListItems = (query, data) => {
           routeName: 'Index',
           params: {
             title: category.name,
-            query: category.pointsOfInterestCount > 0 ? 'pointsOfInterest' : 'tours',
+            query:
+              category.pointsOfInterestCount > 0
+                ? QUERY_TYPES.POINTS_OF_INTEREST
+                : QUERY_TYPES.TOURS,
             queryVariables: { order: 'name_ASC', category: `${category.name}` },
             rootRouteName: category.pointsOfInterestCount > 0 ? 'PointsOfInterest' : 'Tours'
           }
@@ -157,22 +160,22 @@ const getListItems = (query, data) => {
 
 const getComponent = (query) => {
   switch (query) {
-  case 'eventRecords':
+  case QUERY_TYPES.EVENT_RECORDS:
     return TextList;
-  case 'newsItems':
+  case QUERY_TYPES.NEWS_ITEMS:
     return TextList;
-  case 'pointsOfInterest':
+  case QUERY_TYPES.POINTS_OF_INTEREST:
     return CardList;
-  case 'tours':
+  case QUERY_TYPES.TOURS:
     return CardList;
-  case 'categories':
+  case QUERY_TYPES.CATEGORIES:
     return CategoryList;
   }
 };
 
 const getListHeaderComponent = (query, queryVariables, data, updateListData) => {
   switch (query) {
-  case 'newsItems':
+  case QUERY_TYPES.NEWS_ITEMS:
     return (
       <ListHeader queryVariables={queryVariables} data={data} updateListData={updateListData} />
     );

--- a/src/screens/ServiceScreen.js
+++ b/src/screens/ServiceScreen.js
@@ -24,7 +24,7 @@ import {
   TitleShadow,
   WrapperWrap
 } from '../components';
-import { getQuery } from '../queries';
+import { getQuery, QUERY_TYPES } from '../queries';
 import { graphqlFetchPolicy, refreshTimeFor } from '../helpers';
 import TabBarIcon from '../components/TabBarIcon';
 
@@ -65,7 +65,7 @@ export const ServiceScreen = ({ navigation }) => {
   return (
     <SafeAreaViewFlex>
       <Query
-        query={getQuery('publicJsonFile')}
+        query={getQuery(QUERY_TYPES.PUBLIC_JSON_FILE)}
         variables={{ name: 'homeService' }}
         fetchPolicy={fetchPolicy}
       >


### PR DESCRIPTION
- created constants for all available query types, which are
  used everywhere now instead of hardcoded strings, because
  we lost the overview

refactor: remove duplication in navigation calls on HomeScreen

- created constants object with index navigation values for
  navigating to categories, event records and news items