### PR TITLE
Refetch should not be triggered when offline

### DIFF
--- a/src/screens/AboutScreen.js
+++ b/src/screens/AboutScreen.js
@@ -47,7 +47,7 @@ export const AboutScreen = ({ navigation }) => {
 
   const refresh = async (refetch) => {
     setRefreshing(true);
-    await refetch();
+    isConnected && await refetch();
     setRefreshing(false);
   };
 

--- a/src/screens/CompanyScreen.js
+++ b/src/screens/CompanyScreen.js
@@ -57,7 +57,7 @@ export const CompanyScreen = ({ navigation }) => {
 
   const refresh = async (refetch) => {
     setRefreshing(true);
-    await refetch();
+    isConnected && await refetch();
     setRefreshing(false);
   };
 

--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -82,7 +82,7 @@ export const DetailScreen = ({ navigation }) => {
 
   const refresh = async (refetch) => {
     setRefreshing(true);
-    await refetch();
+    isConnected && await refetch();
     setRefreshing(false);
   };
 

--- a/src/screens/HtmlScreen.js
+++ b/src/screens/HtmlScreen.js
@@ -54,7 +54,7 @@ export const HtmlScreen = ({ navigation }) => {
 
   const refresh = async (refetch) => {
     setRefreshing(true);
-    await refetch();
+    isConnected && await refetch();
     setRefreshing(false);
   };
 

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -193,7 +193,7 @@ export const IndexScreen = ({ navigation }) => {
 
   const refresh = async (refetch) => {
     setRefreshing(true);
-    await refetch();
+    isConnected && await refetch();
     setRefreshing(false);
   };
 

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -201,22 +201,6 @@ export const IndexScreen = ({ navigation }) => {
   const globalSettings = useContext(GlobalSettingsContext);
   const { filter = {} } = globalSettings;
   const { news: showNewsFilter = false } = filter;
-
-  // if offline, pagination with partially fetching data is not possible, so we cannot pass
-  // a probably given `limit` variable. remove that `limit` with destructing, like in this
-  // example: https://stackoverflow.com/a/51478664/9956365
-  const getQueryVariables = () => {
-    if (!isConnected) {
-      /* NOTE: remove `limit`, which is super easy with spread operator */
-      /* eslint-disable-next-line no-unused-vars */
-      const { limit, ...queryVariablesWithoutLimit } = queryVariables;
-
-      return queryVariablesWithoutLimit;
-    }
-
-    return queryVariables;
-  };
-
   const Component = getComponent(query);
 
   const updateListData = (selectedDataProvider) => {
@@ -237,7 +221,7 @@ export const IndexScreen = ({ navigation }) => {
   return (
     <Query
       query={getQuery(query, { showNewsFilter })}
-      variables={getQueryVariables()}
+      variables={queryVariables}
       fetchPolicy={fetchPolicy}
     >
       {({ data, loading, fetchMore, refetch }) => {

--- a/src/screens/ServiceScreen.js
+++ b/src/screens/ServiceScreen.js
@@ -57,7 +57,7 @@ export const ServiceScreen = ({ navigation }) => {
 
   const refresh = async (refetch) => {
     setRefreshing(true);
-    await refetch();
+    isConnected && await refetch();
     setRefreshing(false);
   };
 


### PR DESCRIPTION
Fixed offline behavior for index screens, to show cached data and added a check to not refetch data if offline when using pull to refresh.