### PR TITLE
fix: revert additional check in HtmlScreen

### DIFF
--- a/src/screens/HtmlScreen.js
+++ b/src/screens/HtmlScreen.js
@@ -135,7 +135,7 @@ export const HtmlScreen = ({ navigation }) => {
                   openWebScreen={openWebScreen}
                   navigation={navigation}
                 />
-                {!!subQuery && !!subQuery.routeName && !!subQuery.webUrl && (
+                {!!subQuery && !!subQuery.routeName && (
                   <Button
                     title={subQuery.buttonTitle || `${title} öffnen`}
                     onPress={() => openWebScreen()}


### PR DESCRIPTION
- removed ` && !!subQuery.webUrl` as this does not work
  for screen, where the navigation goes to other routes than `Web`