### PR TITLE
feat(button): new style on landscape mode

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,12 +1,14 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useContext } from 'react';
 import { StyleSheet } from 'react-native';
 import { Button as RNEButton } from 'react-native-elements';
 
 import { colors, normalize } from '../config';
 import { DiagonalGradient } from './DiagonalGradient';
+import { OrientationContext } from '../OrientationProvider';
 
 export const Button = ({ title, onPress }) => {
+  const { orientation } = useContext(OrientationContext);
   return (
     <RNEButton
       onPress={onPress}
@@ -14,6 +16,7 @@ export const Button = ({ title, onPress }) => {
       titleStyle={styles.titleStyle}
       containerStyle={styles.containerStyle}
       ViewComponent={DiagonalGradient}
+      buttonStyle={orientation === 'landscape' ? styles.buttonStyle : {}}
       useForeground
     />
   );
@@ -23,6 +26,10 @@ const styles = StyleSheet.create({
   titleStyle: {
     color: colors.lightestText,
     fontFamily: 'titillium-web-bold'
+  },
+  buttonStyle: {
+    width: '60%',
+    alignSelf: 'center'
   },
   containerStyle: {
     marginBottom: normalize(21)

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -16,7 +16,7 @@ export const Button = ({ title, onPress }) => {
       titleStyle={styles.titleStyle}
       containerStyle={styles.containerStyle}
       ViewComponent={DiagonalGradient}
-      buttonStyle={orientation === 'landscape' ? styles.buttonStyle : {}}
+      buttonStyle={orientation === 'landscape' && styles.buttonStyleLandscape}
       useForeground
     />
   );
@@ -27,9 +27,9 @@ const styles = StyleSheet.create({
     color: colors.lightestText,
     fontFamily: 'titillium-web-bold'
   },
-  buttonStyle: {
-    width: '60%',
-    alignSelf: 'center'
+  buttonStyleLandscape: {
+    alignSelf: 'center',
+    width: '60%'
   },
   containerStyle: {
     marginBottom: normalize(21)

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -9,14 +9,16 @@ import { OrientationContext } from '../OrientationProvider';
 
 export const Button = ({ title, onPress }) => {
   const { orientation } = useContext(OrientationContext);
+
   return (
     <RNEButton
       onPress={onPress}
       title={title}
-      titleStyle={styles.titleStyle}
-      containerStyle={
-        orientation === 'landscape' ? styles.containerStyleLandscape : styles.containerStyle
-      }
+      titleStyle={[styles.titleStyle, orientation === 'landscape' && styles.titleStyleLandscape]}
+      containerStyle={[
+        styles.containerStyle,
+        orientation === 'landscape' && styles.containerStyleLandscape
+      ]}
       ViewComponent={DiagonalGradient}
       useForeground
     />
@@ -28,13 +30,15 @@ const styles = StyleSheet.create({
     color: colors.lightestText,
     fontFamily: 'titillium-web-bold'
   },
-  containerStyleLandscape: {
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginBottom: normalize(21)
+  titleStyleLandscape: {
+    paddingHorizontal: normalize(14)
   },
   containerStyle: {
     marginBottom: normalize(21)
+  },
+  containerStyleLandscape: {
+    alignItems: 'center',
+    justifyContent: 'center'
   }
 });
 

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -14,9 +14,10 @@ export const Button = ({ title, onPress }) => {
       onPress={onPress}
       title={title}
       titleStyle={styles.titleStyle}
-      containerStyle={styles.containerStyle}
+      containerStyle={
+        orientation === 'landscape' ? styles.containerStyleLandscape : styles.containerStyle
+      }
       ViewComponent={DiagonalGradient}
-      buttonStyle={orientation === 'landscape' && styles.buttonStyleLandscape}
       useForeground
     />
   );
@@ -27,9 +28,10 @@ const styles = StyleSheet.create({
     color: colors.lightestText,
     fontFamily: 'titillium-web-bold'
   },
-  buttonStyleLandscape: {
-    alignSelf: 'center',
-    width: '60%'
+  containerStyleLandscape: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: normalize(21)
   },
   containerStyle: {
     marginBottom: normalize(21)


### PR DESCRIPTION
- implemented OrientationContext , which knows when device is on portrait or landscape mode
- buttonStyle condition , when on landscape mode button is on 60% of its width and centred in the screen
  - if portrait we don't want to render new style for button so it must be an empty object


SVA-93

feat(button): corrections on style and condition for landscape mode

- buttonStyleLandscape is an appropriate name, more specific
  - it is also in alphabetical order
- refactored conditional logic , aim dry code

SVA-93

- now the condition for new style on landscape mode is placed in the button container
  - using alignSelf in order to see the container shrink to the size of its content
- thanks to this article: https://www.skptricks.com/2019/02/react-native-button-width-fit-to-content.html

SVA-93