### PR TITLE
feat(detail and html screens): condition for landscape mode

### DIFF
--- a/src/OrientationProvider.js
+++ b/src/OrientationProvider.js
@@ -9,7 +9,7 @@ const defaultDimensions = {
 };
 
 // default orientation should be portrait up, because we defined that in the expo configs. but we
-// want to be sure with checking the devive dimension.
+// want to be sure with checking the device dimension.
 const defaultOrientation =
   defaultDimensions.width < defaultDimensions.height ? 'portrait' : 'landscape';
 

--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -5,6 +5,7 @@ import { ActivityIndicator, FlatList } from 'react-native';
 import { colors, normalize } from '../config';
 import { CardListItem } from './CardListItem';
 
+// TODO in order to implement landscape logic CardList needs to become a function component
 export class CardList extends React.PureComponent {
   state = {
     listEndReached: false

--- a/src/components/HtmlView.js
+++ b/src/components/HtmlView.js
@@ -53,8 +53,10 @@ const htmlConfig = {
   ignoredTags: IGNORED_TAGS
 };
 
-export const HtmlView = ({ html, tagsStyles, openWebScreen }) => {
-  const maxWidth = imageWidth() - 2 * normalize(14); // width of an image minus paddings
+export const HtmlView = ({ html, tagsStyles, openWebScreen, orientation, dimensions }) => {
+  // size images correctly on landscape
+  const width = orientation === 'landscape' ? dimensions.height : dimensions.width;
+  const maxWidth = width - 2 * normalize(14); // width of an image minus paddings
 
   return (
     <HTML
@@ -82,7 +84,9 @@ export const HtmlView = ({ html, tagsStyles, openWebScreen }) => {
 HtmlView.propTypes = {
   html: PropTypes.string,
   tagsStyles: PropTypes.object,
-  openWebScreen: PropTypes.func
+  openWebScreen: PropTypes.func,
+  orientation: PropTypes.string.isRequired,
+  dimensions: PropTypes.string.isRequired
 };
 
 HtmlView.defaultProps = {

--- a/src/components/ImagesCarousel.js
+++ b/src/components/ImagesCarousel.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import Carousel from 'react-native-snap-carousel';
 import React, { useContext } from 'react';
-import { ActivityIndicator, TouchableOpacity } from 'react-native';
+import { ActivityIndicator, StyleSheet, TouchableOpacity } from 'react-native';
 import { Query } from 'react-apollo';
 
 import { colors } from '../config';
@@ -90,14 +90,14 @@ export const ImagesCarousel = ({ data, navigation, fetchPolicy }) => {
           </Query>
         );
       } else {
-        return <TouchableImage navigation={navigation} item={item}>
-          <Image source={item.picture} style={imageStyle} />
-        </TouchableImage>;
+        return (
+          <TouchableImage navigation={navigation} item={item}>
+            <Image source={item.picture} style={imageStyle} />
+          </TouchableImage>
+        );
       }
     } else {
-      return (
-        <Image source={item.picture} style={imageStyle} />
-      );
+      return <Image source={item.picture} style={imageStyle} />;
     }
   };
 
@@ -112,9 +112,16 @@ export const ImagesCarousel = ({ data, navigation, fetchPolicy }) => {
       loop
       autoplayDelay={0}
       autoplayInterval={4000}
+      containerCustomStyle={styles.center}
     />
   );
 };
+
+const styles = StyleSheet.create({
+  center: {
+    alignSelf: 'center'
+  }
+});
 
 ImagesCarousel.propTypes = {
   data: PropTypes.array.isRequired,

--- a/src/components/Wrapper.js
+++ b/src/components/Wrapper.js
@@ -11,6 +11,10 @@ export const WrapperHorizontal = styled.View`
   padding-right: ${normalize(14)}px;
 `;
 
+export const WrapperLandscape = styled.View`
+  padding-left: ${normalize(150)}px;
+  padding-right: ${normalize(150)}px;
+`;
 export const WrapperRow = styled.View`
   flex-direction: row;
 `;

--- a/src/components/Wrapper.js
+++ b/src/components/Wrapper.js
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types';
+import React from 'react';
 import styled from 'styled-components/native';
 
 import { normalize } from '../config';
@@ -12,9 +14,10 @@ export const WrapperHorizontal = styled.View`
 `;
 
 export const WrapperLandscape = styled.View`
-  padding-left: ${normalize(150)}px;
-  padding-right: ${normalize(150)}px;
+  padding-left: 15%;
+  padding-right: 15%;
 `;
+
 export const WrapperRow = styled.View`
   flex-direction: row;
 `;
@@ -28,3 +31,15 @@ export const WrapperWrap = styled(WrapperRow)`
 export const InfoBox = styled(WrapperRow)`
   margin-bottom: ${normalize(5)}px;
 `;
+
+export const WrapperWithOrientation = ({ orientation, children }) => {
+  if (orientation === 'landscape') {
+    return <WrapperLandscape>{children}</WrapperLandscape>;
+  }
+  return children;
+};
+
+WrapperWithOrientation.propTypes = {
+  orientation: PropTypes.string.isRequired,
+  children: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired
+};

--- a/src/components/screens/EventRecord.js
+++ b/src/components/screens/EventRecord.js
@@ -33,7 +33,7 @@ const INJECTED_JAVASCRIPT_FOR_IFRAME_WEBVIEW = `
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const EventRecord = ({ data, navigation }) => {
-  const { orientation } = useContext(OrientationContext);
+  const { orientation, dimensions } = useContext(OrientationContext);
   const {
     addresses,
     category,
@@ -169,7 +169,12 @@ export const EventRecord = ({ data, navigation }) => {
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <Wrapper>
-              <HtmlView html={description} openWebScreen={openWebScreen} />
+              <HtmlView
+                html={description}
+                openWebScreen={openWebScreen}
+                orientation={orientation}
+                dimensions={dimensions}
+              />
             </Wrapper>
           </View>
         )}

--- a/src/components/screens/EventRecord.js
+++ b/src/components/screens/EventRecord.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useContext } from 'react';
 import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 import _filter from 'lodash/filter';
@@ -11,13 +11,14 @@ import { LoadingContainer } from '../LoadingContainer';
 import { Logo } from '../Logo';
 import { Title, TitleContainer, TitleShadow } from '../Title';
 import { Touchable } from '../Touchable';
-import { Wrapper, WrapperHorizontal } from '../Wrapper';
+import { Wrapper, WrapperHorizontal, WrapperWithOrientation } from '../Wrapper';
 import { PriceCard } from './PriceCard';
 import { InfoCard } from './InfoCard';
 import { OperatingCompanyInfo } from './OperatingCompanyInfo';
 import { OpeningTimesCard } from './OpeningTimesCard';
 import { ImagesCarousel } from '../ImagesCarousel';
 import { trimNewLines } from '../../helpers';
+import { OrientationContext } from '../../OrientationProvider';
 
 // necessary hacky way of implementing iframe in webview with correct zoom level
 // thx to: https://stackoverflow.com/a/55780430
@@ -32,6 +33,7 @@ const INJECTED_JAVASCRIPT_FOR_IFRAME_WEBVIEW = `
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const EventRecord = ({ data, navigation }) => {
+  const { orientation } = useContext(OrientationContext);
   const {
     addresses,
     category,
@@ -109,84 +111,87 @@ export const EventRecord = ({ data, navigation }) => {
   return (
     <View>
       {!!images && images.length > 1 && <ImagesCarousel data={images} />}
-      {!!images && images.length === 1 && <Image source={images[0].picture} />}
 
-      {!!title && !!link ? (
-        <TitleContainer>
-          <Touchable onPress={openWebScreen}>
-            <Title>{title}</Title>
-          </Touchable>
-        </TitleContainer>
-      ) : (
-        !!title && (
+      <WrapperWithOrientation orientation={orientation}>
+        {!!images && images.length === 1 && <Image source={images[0].picture} />}
+
+        {!!title && !!link ? (
           <TitleContainer>
-            <Title>{title}</Title>
+            <Touchable onPress={openWebScreen}>
+              <Title>{title}</Title>
+            </Touchable>
           </TitleContainer>
-        )
-      )}
-      {device.platform === 'ios' && <TitleShadow />}
-      <Wrapper>
-        {!!logo && <Logo source={{ uri: logo }} />}
+        ) : (
+          !!title && (
+            <TitleContainer>
+              <Title>{title}</Title>
+            </TitleContainer>
+          )
+        )}
+        {device.platform === 'ios' && <TitleShadow />}
+        <Wrapper>
+          {!!logo && <Logo source={{ uri: logo }} />}
 
-        <InfoCard
-          category={category}
-          addresses={addresses}
-          contacts={contacts}
-          webUrls={webUrls}
-          openWebScreen={openWebScreen}
-        />
-      </Wrapper>
-
-      {!!dates && !!dates.length && (
-        <View>
-          <TitleContainer>
-            <Title>{texts.eventRecord.appointments}</Title>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
-          <OpeningTimesCard openingHours={dates} />
-        </View>
-      )}
-
-      {/* temporary logic in order to show PriceCard just when description is present for the first index */}
-      {!!priceInformations && !!priceInformations.length && !!priceInformations[0].description && (
-        <View>
-          <TitleContainer>
-            <Title>{texts.eventRecord.prices}</Title>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
-          <PriceCard prices={priceInformations} />
-        </View>
-      )}
-
-      {!!description && (
-        <View>
-          <TitleContainer>
-            <Title>{texts.eventRecord.description}</Title>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
-          <Wrapper>
-            <HtmlView html={description} openWebScreen={openWebScreen} />
-          </Wrapper>
-        </View>
-      )}
-
-      {!!media.length && media}
-
-      {!!operatingCompany && (
-        <View>
-          <TitleContainer>
-            <Title>{texts.eventRecord.operatingCompany}</Title>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
-          <OperatingCompanyInfo
-            name={operatingCompany.name}
-            address={operatingCompany.address}
-            contact={operatingCompany.contact}
-            webUrls={operatingCompany.contact.webUrls}
+          <InfoCard
+            category={category}
+            addresses={addresses}
+            contacts={contacts}
+            webUrls={webUrls}
             openWebScreen={openWebScreen}
           />
-        </View>
-      )}
+        </Wrapper>
+
+        {!!dates && !!dates.length && (
+          <View>
+            <TitleContainer>
+              <Title>{texts.eventRecord.appointments}</Title>
+            </TitleContainer>
+            {device.platform === 'ios' && <TitleShadow />}
+            <OpeningTimesCard openingHours={dates} />
+          </View>
+        )}
+
+        {/* temporary logic in order to show PriceCard just when description is present for the first index */}
+        {!!priceInformations && !!priceInformations.length && !!priceInformations[0].description && (
+          <View>
+            <TitleContainer>
+              <Title>{texts.eventRecord.prices}</Title>
+            </TitleContainer>
+            {device.platform === 'ios' && <TitleShadow />}
+            <PriceCard prices={priceInformations} />
+          </View>
+        )}
+
+        {!!description && (
+          <View>
+            <TitleContainer>
+              <Title>{texts.eventRecord.description}</Title>
+            </TitleContainer>
+            {device.platform === 'ios' && <TitleShadow />}
+            <Wrapper>
+              <HtmlView html={description} openWebScreen={openWebScreen} />
+            </Wrapper>
+          </View>
+        )}
+
+        {!!media.length && media}
+
+        {!!operatingCompany && (
+          <View>
+            <TitleContainer>
+              <Title>{texts.eventRecord.operatingCompany}</Title>
+            </TitleContainer>
+            {device.platform === 'ios' && <TitleShadow />}
+            <OperatingCompanyInfo
+              name={operatingCompany.name}
+              address={operatingCompany.address}
+              contact={operatingCompany.contact}
+              webUrls={operatingCompany.contact.webUrls}
+              openWebScreen={openWebScreen}
+            />
+          </View>
+        )}
+      </WrapperWithOrientation>
     </View>
   );
 };

--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -31,7 +31,7 @@ const INJECTED_JAVASCRIPT_FOR_IFRAME_WEBVIEW = `
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const NewsItem = ({ data, navigation }) => {
-  const { orientation } = useContext(OrientationContext);
+  const { orientation, dimensions } = useContext(OrientationContext);
   const { dataProvider, mainTitle, contentBlocks, publishedAt, sourceUrl, settings } = data;
 
   const logo = dataProvider && dataProvider.logo && dataProvider.logo.url;
@@ -103,6 +103,8 @@ export const NewsItem = ({ data, navigation }) => {
               )}
               tagsStyles={{ div: { fontFamily: 'titillium-web-bold' } }}
               openWebScreen={openWebScreen}
+              orientation={orientation}
+              dimensions={dimensions}
             />
           </WrapperHorizontal>
         );
@@ -143,7 +145,12 @@ export const NewsItem = ({ data, navigation }) => {
         !!contentBlock.body &&
         section.push(
           <WrapperHorizontal key={`${index}-${contentBlock.id}-body`}>
-            <HtmlView html={trimNewLines(contentBlock.body)} openWebScreen={openWebScreen} />
+            <HtmlView
+              html={trimNewLines(contentBlock.body)}
+              openWebScreen={openWebScreen}
+              orientation={orientation}
+              dimensions={dimensions}
+            />
           </WrapperHorizontal>
         );
 

--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useContext } from 'react';
 import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 import _filter from 'lodash/filter';
@@ -11,11 +11,12 @@ import { LoadingContainer } from '../LoadingContainer';
 import { Logo } from '../Logo';
 import { Title, TitleContainer, TitleShadow } from '../Title';
 import { Touchable } from '../Touchable';
-import { Wrapper, WrapperHorizontal } from '../Wrapper';
+import { Wrapper, WrapperHorizontal, WrapperWithOrientation } from '../Wrapper';
 import { ImagesCarousel } from '../ImagesCarousel';
 import { containsHtml, momentFormat, trimNewLines } from '../../helpers';
 import { BoldText, RegularText } from '../Text';
 import { Button } from '../Button';
+import { OrientationContext } from '../../OrientationProvider';
 
 // necessary hacky way of implementing iframe in webview with correct zoom level
 // thx to: https://stackoverflow.com/a/55780430
@@ -30,6 +31,7 @@ const INJECTED_JAVASCRIPT_FOR_IFRAME_WEBVIEW = `
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const NewsItem = ({ data, navigation }) => {
+  const { orientation } = useContext(OrientationContext);
   const { dataProvider, mainTitle, contentBlocks, publishedAt, sourceUrl, settings } = data;
 
   const logo = dataProvider && dataProvider.logo && dataProvider.logo.url;
@@ -190,28 +192,31 @@ export const NewsItem = ({ data, navigation }) => {
   return (
     <View>
       {!!mainImages && mainImages.length > 1 && <ImagesCarousel data={mainImages} />}
-      {!!mainImages && mainImages.length === 1 && <Image source={mainImages[0].picture} />}
 
-      {!!title && !!link ? (
-        <TitleContainer>
-          <Touchable onPress={openWebScreen}>
-            <Title>{trimNewLines(title)}</Title>
-          </Touchable>
-        </TitleContainer>
-      ) : (
-        !!title && (
+      <WrapperWithOrientation orientation={orientation}>
+        {!!mainImages && mainImages.length === 1 && <Image source={mainImages[0].picture} />}
+
+        {!!title && !!link ? (
           <TitleContainer>
-            <Title>{trimNewLines(title)}</Title>
+            <Touchable onPress={openWebScreen}>
+              <Title>{trimNewLines(title)}</Title>
+            </Touchable>
           </TitleContainer>
-        )
-      )}
-      {device.platform === 'ios' && <TitleShadow />}
-      <Wrapper>
-        {!!subtitle && <RegularText small>{subtitle}</RegularText>}
-        {!!logo && <Logo source={{ uri: logo }} />}
-      </Wrapper>
+        ) : (
+          !!title && (
+            <TitleContainer>
+              <Title>{trimNewLines(title)}</Title>
+            </TitleContainer>
+          )
+        )}
+        {device.platform === 'ios' && <TitleShadow />}
+        <Wrapper>
+          {!!subtitle && <RegularText small>{subtitle}</RegularText>}
+          {!!logo && <Logo source={{ uri: logo }} />}
+        </Wrapper>
 
-      {!!story && story}
+        {!!story && story}
+      </WrapperWithOrientation>
     </View>
   );
 };

--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useContext } from 'react';
 import { View } from 'react-native';
 import _filter from 'lodash/filter';
 
@@ -7,16 +7,18 @@ import { device, texts } from '../../config';
 import { HtmlView } from '../HtmlView';
 import { Image } from '../Image';
 import { Title, TitleContainer, TitleShadow } from '../Title';
-import { Wrapper } from '../Wrapper';
+import { Wrapper, WrapperWithOrientation } from '../Wrapper';
 import { PriceCard } from './PriceCard';
 import { InfoCard } from './InfoCard';
 import { OperatingCompanyInfo } from './OperatingCompanyInfo';
 import { OpeningTimesCard } from './OpeningTimesCard';
 import { ImagesCarousel } from '../ImagesCarousel';
+import { OrientationContext } from '../../OrientationProvider';
 
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const PointOfInterest = ({ data, navigation }) => {
+  const { orientation } = useContext(OrientationContext);
   const {
     addresses,
     category,
@@ -63,78 +65,81 @@ export const PointOfInterest = ({ data, navigation }) => {
   return (
     <View>
       {!!images && images.length > 1 && <ImagesCarousel data={images} />}
-      {!!images && images.length === 1 && <Image source={images[0].picture} />}
 
-      {!!title && (
-        <View>
-          <TitleContainer>
-            <Title>{title}</Title>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
-        </View>
-      )}
+      <WrapperWithOrientation orientation={orientation}>
+        {!!images && images.length === 1 && <Image source={images[0].picture} />}
 
-      <Wrapper>
-        <InfoCard category={category} addresses={addresses} contact={contact} webUrls={webUrls} />
-      </Wrapper>
+        {!!title && (
+          <View>
+            <TitleContainer>
+              <Title>{title}</Title>
+            </TitleContainer>
+            {device.platform === 'ios' && <TitleShadow />}
+          </View>
+        )}
 
-      {/* TODO: show map for location */}
-      {/* {!!location && (
-        <View>
-          <TitleContainer>
-            <Title>{texts.pointOfInterest.location}</Title>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
-        </View>
-      )} */}
+        <Wrapper>
+          <InfoCard category={category} addresses={addresses} contact={contact} webUrls={webUrls} />
+        </Wrapper>
 
-      {!!openingHours && !!openingHours.length && (
-        <View>
-          <TitleContainer>
-            <Title>{texts.pointOfInterest.openingTime}</Title>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
-          <OpeningTimesCard openingHours={openingHours} />
-        </View>
-      )}
+        {/* TODO: show map for location */}
+        {/* {!!location && (
+          <View>
+            <TitleContainer>
+              <Title>{texts.pointOfInterest.location}</Title>
+            </TitleContainer>
+            {device.platform === 'ios' && <TitleShadow />}
+          </View>
+        )} */}
 
-      {!!priceInformations && !!priceInformations.length && (
-        <View>
-          <TitleContainer>
-            <Title>{texts.pointOfInterest.prices}</Title>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
-          <PriceCard prices={priceInformations} />
-        </View>
-      )}
+        {!!openingHours && !!openingHours.length && (
+          <View>
+            <TitleContainer>
+              <Title>{texts.pointOfInterest.openingTime}</Title>
+            </TitleContainer>
+            {device.platform === 'ios' && <TitleShadow />}
+            <OpeningTimesCard openingHours={openingHours} />
+          </View>
+        )}
 
-      {!!description && (
-        <View>
-          <TitleContainer>
-            <Title>{texts.pointOfInterest.description}</Title>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
-          <Wrapper>
-            <HtmlView html={description} openWebScreen={openWebScreen} />
-          </Wrapper>
-        </View>
-      )}
+        {!!priceInformations && !!priceInformations.length && (
+          <View>
+            <TitleContainer>
+              <Title>{texts.pointOfInterest.prices}</Title>
+            </TitleContainer>
+            {device.platform === 'ios' && <TitleShadow />}
+            <PriceCard prices={priceInformations} />
+          </View>
+        )}
 
-      {!!operatingCompany && (
-        <View>
-          <TitleContainer>
-            <Title>{texts.pointOfInterest.operatingCompany}</Title>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
-          <OperatingCompanyInfo
-            name={operatingCompany.name}
-            address={operatingCompany.address}
-            contact={operatingCompany.contact}
-            webUrls={operatingCompany.contact.webUrls}
-            openWebScreen={openWebScreen}
-          />
-        </View>
-      )}
+        {!!description && (
+          <View>
+            <TitleContainer>
+              <Title>{texts.pointOfInterest.description}</Title>
+            </TitleContainer>
+            {device.platform === 'ios' && <TitleShadow />}
+            <Wrapper>
+              <HtmlView html={description} openWebScreen={openWebScreen} />
+            </Wrapper>
+          </View>
+        )}
+
+        {!!operatingCompany && (
+          <View>
+            <TitleContainer>
+              <Title>{texts.pointOfInterest.operatingCompany}</Title>
+            </TitleContainer>
+            {device.platform === 'ios' && <TitleShadow />}
+            <OperatingCompanyInfo
+              name={operatingCompany.name}
+              address={operatingCompany.address}
+              contact={operatingCompany.contact}
+              webUrls={operatingCompany.contact.webUrls}
+              openWebScreen={openWebScreen}
+            />
+          </View>
+        )}
+      </WrapperWithOrientation>
     </View>
   );
 };

--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -18,7 +18,7 @@ import { OrientationContext } from '../../OrientationProvider';
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const PointOfInterest = ({ data, navigation }) => {
-  const { orientation } = useContext(OrientationContext);
+  const { orientation, dimensions } = useContext(OrientationContext);
   const {
     addresses,
     category,
@@ -119,7 +119,12 @@ export const PointOfInterest = ({ data, navigation }) => {
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <Wrapper>
-              <HtmlView html={description} openWebScreen={openWebScreen} />
+              <HtmlView
+                html={description}
+                openWebScreen={openWebScreen}
+                orientation={orientation}
+                dimensions={dimensions}
+              />
             </Wrapper>
           </View>
         )}

--- a/src/components/screens/Tour.js
+++ b/src/components/screens/Tour.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useContext } from 'react';
 import { View } from 'react-native';
 import _filter from 'lodash/filter';
 
@@ -8,16 +8,17 @@ import { HtmlView } from '../HtmlView';
 import { Image } from '../Image';
 import { Logo } from '../Logo';
 import { Title, TitleContainer, TitleShadow } from '../Title';
-import { Wrapper } from '../Wrapper';
-
+import { Wrapper, WrapperWithOrientation } from '../Wrapper';
 import { InfoCard } from './InfoCard';
 import { TourCard } from './TourCard';
 import { OperatingCompanyInfo } from './OperatingCompanyInfo';
 import { ImagesCarousel } from '../ImagesCarousel';
+import { OrientationContext } from '../../OrientationProvider';
 
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const Tour = ({ data, navigation }) => {
+  const { orientation } = useContext(OrientationContext);
   const {
     addresses,
     category,
@@ -65,52 +66,55 @@ export const Tour = ({ data, navigation }) => {
   return (
     <View>
       {!!images && images.length > 1 && <ImagesCarousel data={images} />}
-      {!!images && images.length === 1 && <Image source={images[0].picture} />}
 
-      {!!title && (
-        <View>
-          <TitleContainer>
-            <Title>{title}</Title>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
-        </View>
-      )}
+      <WrapperWithOrientation orientation={orientation}>
+        {!!images && images.length === 1 && <Image source={images[0].picture} />}
 
-      <Wrapper>
-        {!!logo && <Logo source={{ uri: logo }} />}
+        {!!title && (
+          <View>
+            <TitleContainer>
+              <Title>{title}</Title>
+            </TitleContainer>
+            {device.platform === 'ios' && <TitleShadow />}
+          </View>
+        )}
 
-        <InfoCard category={category} addresses={addresses} contact={contact} webUrls={webUrls} />
-      </Wrapper>
+        <Wrapper>
+          {!!logo && <Logo source={{ uri: logo }} />}
 
-      <TourCard lengthKm={lengthKm} addresses={addresses} />
+          <InfoCard category={category} addresses={addresses} contact={contact} webUrls={webUrls} />
+        </Wrapper>
 
-      {!!description && (
-        <View>
-          <TitleContainer>
-            <Title>{texts.eventRecord.description}</Title>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
-          <Wrapper>
-            <HtmlView html={description} openWebScreen={openWebScreen} />
-          </Wrapper>
-        </View>
-      )}
+        <TourCard lengthKm={lengthKm} addresses={addresses} />
 
-      {!!operatingCompany && (
-        <View>
-          <TitleContainer>
-            <Title>{texts.eventRecord.operatingCompany}</Title>
-          </TitleContainer>
-          {device.platform === 'ios' && <TitleShadow />}
-          <OperatingCompanyInfo
-            name={operatingCompany.name}
-            address={operatingCompany.address}
-            contact={operatingCompany.contact}
-            webUrls={operatingCompany.contact.webUrls}
-            openWebScreen={openWebScreen}
-          />
-        </View>
-      )}
+        {!!description && (
+          <View>
+            <TitleContainer>
+              <Title>{texts.eventRecord.description}</Title>
+            </TitleContainer>
+            {device.platform === 'ios' && <TitleShadow />}
+            <Wrapper>
+              <HtmlView html={description} openWebScreen={openWebScreen} />
+            </Wrapper>
+          </View>
+        )}
+
+        {!!operatingCompany && (
+          <View>
+            <TitleContainer>
+              <Title>{texts.eventRecord.operatingCompany}</Title>
+            </TitleContainer>
+            {device.platform === 'ios' && <TitleShadow />}
+            <OperatingCompanyInfo
+              name={operatingCompany.name}
+              address={operatingCompany.address}
+              contact={operatingCompany.contact}
+              webUrls={operatingCompany.contact.webUrls}
+              openWebScreen={openWebScreen}
+            />
+          </View>
+        )}
+      </WrapperWithOrientation>
     </View>
   );
 };

--- a/src/components/screens/Tour.js
+++ b/src/components/screens/Tour.js
@@ -18,7 +18,7 @@ import { OrientationContext } from '../../OrientationProvider';
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const Tour = ({ data, navigation }) => {
-  const { orientation } = useContext(OrientationContext);
+  const { orientation, dimensions } = useContext(OrientationContext);
   const {
     addresses,
     category,
@@ -94,7 +94,12 @@ export const Tour = ({ data, navigation }) => {
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <Wrapper>
-              <HtmlView html={description} openWebScreen={openWebScreen} />
+              <HtmlView
+                html={description}
+                openWebScreen={openWebScreen}
+                orientation={orientation}
+                dimensions={dimensions}
+              />
             </Wrapper>
           </View>
         )}

--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -15,7 +15,7 @@ import {
   SafeAreaViewFlex,
   Tour,
   WrapperRow,
-  WrapperLandscape
+  WrapperWithOrientation
 } from '../components';
 import { getQuery } from '../queries';
 import { arrowLeft, share } from '../icons';
@@ -24,33 +24,34 @@ import { OrientationContext } from '../OrientationProvider';
 
 const getComponent = (query) => {
   switch (query) {
-  case 'newsItem':
-    return NewsItem;
-  case 'eventRecord':
-    return EventRecord;
-  case 'pointOfInterest':
-    return PointOfInterest;
-  case 'tour':
-    return Tour;
+    case 'newsItem':
+      return NewsItem;
+    case 'eventRecord':
+      return EventRecord;
+    case 'pointOfInterest':
+      return PointOfInterest;
+    case 'tour':
+      return Tour;
   }
 };
 
 const getRefreshInterval = (query) => {
   switch (query) {
-  case 'newsItem':
-    return consts.NEWS;
-  case 'eventRecord':
-    return consts.EVENTS;
-  case 'pointOfInterest':
-    return consts.POINTS_OF_INTEREST;
-  case 'tour':
-    return consts.TOURS;
+    case 'newsItem':
+      return consts.NEWS;
+    case 'eventRecord':
+      return consts.EVENTS;
+    case 'pointOfInterest':
+      return consts.POINTS_OF_INTEREST;
+    case 'tour':
+      return consts.TOURS;
   }
 };
 
 export const DetailScreen = ({ navigation }) => {
   const [refreshTime, setRefreshTime] = useState();
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
+  const { orientation } = useContext(OrientationContext);
   const query = navigation.getParam('query', '');
   const queryVariables = navigation.getParam('queryVariables', {});
 
@@ -97,26 +98,16 @@ export const DetailScreen = ({ navigation }) => {
         if ((!data || !data[query]) && !details) return null;
 
         const Component = getComponent(query);
-        const { orientation } = useContext(OrientationContext);
 
-        if (orientation === 'landscape')
-          return (
-            <SafeAreaViewFlex>
-              <ScrollView>
-                <WrapperLandscape>
-                  <Component data={(data && data[query]) || details} navigation={navigation} />
-                </WrapperLandscape>
-              </ScrollView>
-            </SafeAreaViewFlex>
-          );
-        else
-          return (
-            <SafeAreaViewFlex>
-              <ScrollView>
+        return (
+          <SafeAreaViewFlex>
+            <ScrollView>
+              <WrapperWithOrientation orientation={orientation}>
                 <Component data={(data && data[query]) || details} navigation={navigation} />
-              </ScrollView>
-            </SafeAreaViewFlex>
-          );
+              </WrapperWithOrientation>
+            </ScrollView>
+          </SafeAreaViewFlex>
+        );
       }}
     </Query>
   );

--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -14,11 +14,13 @@ import {
   PointOfInterest,
   SafeAreaViewFlex,
   Tour,
-  WrapperRow
+  WrapperRow,
+  WrapperLandscape
 } from '../components';
 import { getQuery } from '../queries';
 import { arrowLeft, share } from '../icons';
 import { graphqlFetchPolicy, openShare, refreshTimeFor } from '../helpers';
+import { OrientationContext } from '../OrientationProvider';
 
 const getComponent = (query) => {
   switch (query) {
@@ -95,14 +97,26 @@ export const DetailScreen = ({ navigation }) => {
         if ((!data || !data[query]) && !details) return null;
 
         const Component = getComponent(query);
+        const { orientation } = useContext(OrientationContext);
 
-        return (
-          <SafeAreaViewFlex>
-            <ScrollView>
-              <Component data={(data && data[query]) || details} navigation={navigation} />
-            </ScrollView>
-          </SafeAreaViewFlex>
-        );
+        if (orientation === 'landscape')
+          return (
+            <SafeAreaViewFlex>
+              <ScrollView>
+                <WrapperLandscape>
+                  <Component data={(data && data[query]) || details} navigation={navigation} />
+                </WrapperLandscape>
+              </ScrollView>
+            </SafeAreaViewFlex>
+          );
+        else
+          return (
+            <SafeAreaViewFlex>
+              <ScrollView>
+                <Component data={(data && data[query]) || details} navigation={navigation} />
+              </ScrollView>
+            </SafeAreaViewFlex>
+          );
       }}
     </Query>
   );

--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -14,44 +14,41 @@ import {
   PointOfInterest,
   SafeAreaViewFlex,
   Tour,
-  WrapperRow,
-  WrapperWithOrientation
+  WrapperRow
 } from '../components';
 import { getQuery } from '../queries';
 import { arrowLeft, share } from '../icons';
 import { graphqlFetchPolicy, openShare, refreshTimeFor } from '../helpers';
-import { OrientationContext } from '../OrientationProvider';
 
 const getComponent = (query) => {
   switch (query) {
-    case 'newsItem':
-      return NewsItem;
-    case 'eventRecord':
-      return EventRecord;
-    case 'pointOfInterest':
-      return PointOfInterest;
-    case 'tour':
-      return Tour;
+  case 'newsItem':
+    return NewsItem;
+  case 'eventRecord':
+    return EventRecord;
+  case 'pointOfInterest':
+    return PointOfInterest;
+  case 'tour':
+    return Tour;
   }
 };
 
 const getRefreshInterval = (query) => {
   switch (query) {
-    case 'newsItem':
-      return consts.NEWS;
-    case 'eventRecord':
-      return consts.EVENTS;
-    case 'pointOfInterest':
-      return consts.POINTS_OF_INTEREST;
-    case 'tour':
-      return consts.TOURS;
+  case 'newsItem':
+    return consts.NEWS;
+  case 'eventRecord':
+    return consts.EVENTS;
+  case 'pointOfInterest':
+    return consts.POINTS_OF_INTEREST;
+  case 'tour':
+    return consts.TOURS;
   }
 };
 
 export const DetailScreen = ({ navigation }) => {
   const [refreshTime, setRefreshTime] = useState();
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
-  const { orientation } = useContext(OrientationContext);
   const query = navigation.getParam('query', '');
   const queryVariables = navigation.getParam('queryVariables', {});
 
@@ -102,9 +99,7 @@ export const DetailScreen = ({ navigation }) => {
         return (
           <SafeAreaViewFlex>
             <ScrollView>
-              <WrapperWithOrientation orientation={orientation}>
-                <Component data={(data && data[query]) || details} navigation={navigation} />
-              </WrapperWithOrientation>
+              <Component data={(data && data[query]) || details} navigation={navigation} />
             </ScrollView>
           </SafeAreaViewFlex>
         );

--- a/src/screens/FormScreen.js
+++ b/src/screens/FormScreen.js
@@ -1,13 +1,14 @@
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { Alert, ScrollView, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
 import { CheckBox } from 'react-native-elements';
 import { Mutation } from 'react-apollo';
 import { getQuery } from '../queries';
 
 import { colors, normalize } from '../config';
-import { BoldText, Button, Icon, SafeAreaViewFlex } from '../components';
+import { BoldText, Button, Icon, SafeAreaViewFlex, WrapperWithOrientation } from '../components';
 import { arrowLeft } from '../icons';
+import { OrientationContext } from '../OrientationProvider';
 
 export const FormScreen = () => {
   const [name, setName] = useState('');
@@ -15,6 +16,7 @@ export const FormScreen = () => {
   const [phone, setPhone] = useState('');
   const [message, setMessage] = useState('');
   const [consent, setConsent] = useState(false);
+  const { orientation } = useContext(OrientationContext);
 
   const resetForm = () => {
     setName('');
@@ -58,56 +60,58 @@ export const FormScreen = () => {
   return (
     <SafeAreaViewFlex>
       <ScrollView>
-        <Mutation mutation={getQuery('appUserContent')}>
-          {(createAppUserContent) => (
-            <View style={{ padding: normalize(14) }}>
-              <BoldText>Name</BoldText>
-              <TextInput
-                onChangeText={(text) => {
-                  setName(text);
-                }}
-                value={name}
-                style={styles.inputField}
-              />
-              <BoldText>E-Mail</BoldText>
-              <TextInput
-                onChangeText={(text) => {
-                  setEmail(text);
-                }}
-                value={email}
-                style={styles.inputField}
-                keyboardType="email-address"
-              />
-              <BoldText>Telefon</BoldText>
-              <TextInput
-                onChangeText={(text) => {
-                  setPhone(text);
-                }}
-                value={phone}
-                style={styles.inputField}
-              />
-              <BoldText>Ihre Mitteilung</BoldText>
-              <TextInput
-                onChangeText={(text) => {
-                  setMessage(text);
-                }}
-                value={message}
-                style={styles.textArea}
-                multiline
-                textAlignVertical="top"
-              />
-              <CheckBox
-                checked={consent}
-                onPress={() => setConsent(!consent)}
-                title="Ich bin mit dem Speichern meiner Daten einverstanden?"
-                checkedColor={colors.accent}
-                containerStyle={styles.checkboxContainerStyle}
-                textStyle={styles.checkboxTextStyle}
-              />
-              <Button title="Senden" onPress={() => submitForm(createAppUserContent)}></Button>
-            </View>
-          )}
-        </Mutation>
+        <WrapperWithOrientation orientation={orientation}>
+          <Mutation mutation={getQuery('appUserContent')}>
+            {(createAppUserContent) => (
+              <View style={{ padding: normalize(14) }}>
+                <BoldText>Name</BoldText>
+                <TextInput
+                  onChangeText={(text) => {
+                    setName(text);
+                  }}
+                  value={name}
+                  style={styles.inputField}
+                />
+                <BoldText>E-Mail</BoldText>
+                <TextInput
+                  onChangeText={(text) => {
+                    setEmail(text);
+                  }}
+                  value={email}
+                  style={styles.inputField}
+                  keyboardType="email-address"
+                />
+                <BoldText>Telefon</BoldText>
+                <TextInput
+                  onChangeText={(text) => {
+                    setPhone(text);
+                  }}
+                  value={phone}
+                  style={styles.inputField}
+                />
+                <BoldText>Ihre Mitteilung</BoldText>
+                <TextInput
+                  onChangeText={(text) => {
+                    setMessage(text);
+                  }}
+                  value={message}
+                  style={styles.textArea}
+                  multiline
+                  textAlignVertical="top"
+                />
+                <CheckBox
+                  checked={consent}
+                  onPress={() => setConsent(!consent)}
+                  title="Ich bin mit dem Speichern meiner Daten einverstanden?"
+                  checkedColor={colors.accent}
+                  containerStyle={styles.checkboxContainerStyle}
+                  textStyle={styles.checkboxTextStyle}
+                />
+                <Button title="Senden" onPress={() => submitForm(createAppUserContent)}></Button>
+              </View>
+            )}
+          </Mutation>
+        </WrapperWithOrientation>
       </ScrollView>
     </SafeAreaViewFlex>
   );

--- a/src/screens/HtmlScreen.js
+++ b/src/screens/HtmlScreen.js
@@ -13,7 +13,7 @@ import {
   LoadingContainer,
   SafeAreaViewFlex,
   Wrapper,
-  WrapperLandscape
+  WrapperWithOrientation
 } from '../components';
 import { graphqlFetchPolicy, refreshTimeFor, trimNewLines } from '../helpers';
 import { getQuery } from '../queries';
@@ -114,32 +114,7 @@ export const HtmlScreen = ({ navigation }) => {
         return (
           <SafeAreaViewFlex>
             <ScrollView>
-              {orientation === 'landscape' ? (
-                <WrapperLandscape>
-                  <HtmlView
-                    html={trimNewLines(data.publicHtmlFile.content)}
-                    openWebScreen={openWebScreen}
-                    navigation={navigation}
-                  />
-                  {!!subQuery && !!subQuery.routeName && !!subQuery.webUrl && (
-                    <Button
-                      title={subQuery.buttonTitle || `${title} öffnen`}
-                      onPress={() => openWebScreen()}
-                    />
-                  )}
-                  {!!subQuery &&
-                    !!subQuery.buttons &&
-                    subQuery.buttons.map((button, index) => (
-                      <Button
-                        key={`${index}-${button.webUrl}`}
-                        title={button.buttonTitle || `${title} öffnen`}
-                        onPress={() =>
-                          openWebScreen({ routeName: button.routeName, webUrl: button.webUrl })
-                        }
-                      />
-                    ))}
-                </WrapperLandscape>
-              ) : (
+              <WrapperWithOrientation orientation={orientation}>
                 <Wrapper>
                   <HtmlView
                     html={trimNewLines(data.publicHtmlFile.content)}
@@ -164,7 +139,7 @@ export const HtmlScreen = ({ navigation }) => {
                       />
                     ))}
                 </Wrapper>
-              )}
+              </WrapperWithOrientation>
             </ScrollView>
           </SafeAreaViewFlex>
         );

--- a/src/screens/HtmlScreen.js
+++ b/src/screens/HtmlScreen.js
@@ -6,10 +6,19 @@ import { Query } from 'react-apollo';
 import { NetworkContext } from '../NetworkProvider';
 import { auth } from '../auth';
 import { colors, consts, normalize } from '../config';
-import { Button, HtmlView, Icon, LoadingContainer, SafeAreaViewFlex, Wrapper } from '../components';
+import {
+  Button,
+  HtmlView,
+  Icon,
+  LoadingContainer,
+  SafeAreaViewFlex,
+  Wrapper,
+  WrapperLandscape
+} from '../components';
 import { graphqlFetchPolicy, refreshTimeFor, trimNewLines } from '../helpers';
 import { getQuery } from '../queries';
 import { arrowLeft } from '../icons';
+import { OrientationContext } from '../OrientationProvider';
 
 export const HtmlScreen = ({ navigation }) => {
   const [refreshTime, setRefreshTime] = useState();
@@ -45,6 +54,7 @@ export const HtmlScreen = ({ navigation }) => {
   const rootRouteName = navigation.getParam('rootRouteName', '');
   const subQuery = navigation.getParam('subQuery', '');
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp, refreshTime });
+  const { orientation } = useContext(OrientationContext);
 
   // action to open source urls
   const openWebScreen = (param) => {
@@ -83,6 +93,7 @@ export const HtmlScreen = ({ navigation }) => {
     });
   };
 
+  /* eslint-disable complexity */
   return (
     <Query
       query={getQuery(query)}
@@ -103,30 +114,57 @@ export const HtmlScreen = ({ navigation }) => {
         return (
           <SafeAreaViewFlex>
             <ScrollView>
-              <Wrapper>
-                <HtmlView
-                  html={trimNewLines(data.publicHtmlFile.content)}
-                  openWebScreen={openWebScreen}
-                  navigation={navigation}
-                />
-                {!!subQuery && !!subQuery.routeName && !!subQuery.webUrl && (
-                  <Button
-                    title={subQuery.buttonTitle || `${title} öffnen`}
-                    onPress={() => openWebScreen()}
+              {orientation === 'landscape' ? (
+                <WrapperLandscape>
+                  <HtmlView
+                    html={trimNewLines(data.publicHtmlFile.content)}
+                    openWebScreen={openWebScreen}
+                    navigation={navigation}
                   />
-                )}
-                {!!subQuery &&
-                  !!subQuery.buttons &&
-                  subQuery.buttons.map((button, index) => (
+                  {!!subQuery && !!subQuery.routeName && !!subQuery.webUrl && (
                     <Button
-                      key={`${index}-${button.webUrl}`}
-                      title={button.buttonTitle || `${title} öffnen`}
-                      onPress={() =>
-                        openWebScreen({ routeName: button.routeName, webUrl: button.webUrl })
-                      }
+                      title={subQuery.buttonTitle || `${title} öffnen`}
+                      onPress={() => openWebScreen()}
                     />
-                  ))}
-              </Wrapper>
+                  )}
+                  {!!subQuery &&
+                    !!subQuery.buttons &&
+                    subQuery.buttons.map((button, index) => (
+                      <Button
+                        key={`${index}-${button.webUrl}`}
+                        title={button.buttonTitle || `${title} öffnen`}
+                        onPress={() =>
+                          openWebScreen({ routeName: button.routeName, webUrl: button.webUrl })
+                        }
+                      />
+                    ))}
+                </WrapperLandscape>
+              ) : (
+                <Wrapper>
+                  <HtmlView
+                    html={trimNewLines(data.publicHtmlFile.content)}
+                    openWebScreen={openWebScreen}
+                    navigation={navigation}
+                  />
+                  {!!subQuery && !!subQuery.routeName && !!subQuery.webUrl && (
+                    <Button
+                      title={subQuery.buttonTitle || `${title} öffnen`}
+                      onPress={() => openWebScreen()}
+                    />
+                  )}
+                  {!!subQuery &&
+                    !!subQuery.buttons &&
+                    subQuery.buttons.map((button, index) => (
+                      <Button
+                        key={`${index}-${button.webUrl}`}
+                        title={button.buttonTitle || `${title} öffnen`}
+                        onPress={() =>
+                          openWebScreen({ routeName: button.routeName, webUrl: button.webUrl })
+                        }
+                      />
+                    ))}
+                </Wrapper>
+              )}
             </ScrollView>
           </SafeAreaViewFlex>
         );
@@ -134,7 +172,7 @@ export const HtmlScreen = ({ navigation }) => {
     </Query>
   );
 };
-
+/* eslint-enable complexity */
 HtmlScreen.navigationOptions = ({ navigation }) => {
   return {
     headerLeft: (

--- a/src/screens/HtmlScreen.js
+++ b/src/screens/HtmlScreen.js
@@ -23,7 +23,7 @@ import { OrientationContext } from '../OrientationProvider';
 export const HtmlScreen = ({ navigation }) => {
   const [refreshTime, setRefreshTime] = useState();
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
-  const { orientation } = useContext(OrientationContext);
+  const { orientation, dimensions } = useContext(OrientationContext);
   const query = navigation.getParam('query', '');
   const queryVariables = navigation.getParam('queryVariables', '');
 
@@ -120,6 +120,8 @@ export const HtmlScreen = ({ navigation }) => {
                     html={trimNewLines(data.publicHtmlFile.content)}
                     openWebScreen={openWebScreen}
                     navigation={navigation}
+                    orientation={orientation}
+                    dimensions={dimensions}
                   />
                   {!!subQuery && !!subQuery.routeName && !!subQuery.webUrl && (
                     <Button

--- a/src/screens/HtmlScreen.js
+++ b/src/screens/HtmlScreen.js
@@ -23,6 +23,7 @@ import { OrientationContext } from '../OrientationProvider';
 export const HtmlScreen = ({ navigation }) => {
   const [refreshTime, setRefreshTime] = useState();
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
+  const { orientation } = useContext(OrientationContext);
   const query = navigation.getParam('query', '');
   const queryVariables = navigation.getParam('queryVariables', '');
 
@@ -54,7 +55,6 @@ export const HtmlScreen = ({ navigation }) => {
   const rootRouteName = navigation.getParam('rootRouteName', '');
   const subQuery = navigation.getParam('subQuery', '');
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp, refreshTime });
-  const { orientation } = useContext(OrientationContext);
 
   // action to open source urls
   const openWebScreen = (param) => {


### PR DESCRIPTION
- created a ( possibly temporary ) style component to wrap around detail and html screens if on landscape mode
  - WrapperLandscape is increasing space left and right in order to center the text to improve rideability
- it's applied on Detail and HTML screens with necessary condition
  - if device is on landscape then content of this screens is wrapped

SVA-93

- on OrientationProvider just a small grammar correction on comment
- WrapperLandscape it's updated with percentage to fit bigger screens as well
- WrapperWithOrientation is a function component that carries WrapperLandscape and pass it to its children
   - this happens when orientation is landscape , which reach its children per prop
- wrapping detail and html screens with new component WrapperWithOrientation instead of WrapperLandscape
  - wrapping will be effective just when orientation prop is triggered , in this way we are avoid code repetition
- WrapperWithOrientation is implemented in formScreen es well

SVA-93

fix: position of OrientationContext

- moved useContext on top of the file in order to prevent future bugs and errors

SVA-93

feat(html view): size images in html views

- added calculation for image width depending on orientation
  in html views

SVA-93

feat(images carousel): center carousel on landscape

- centered the carousel in every case
- problem was with safe areas, where the device width does
  not equal the available area width

SVA-93

feat(detail screens): add landscape wrapper for everything except ImagesCarousel

- removed wrapper from `DetailScreen` around `Component` because
  it was also wrapping the inner `ImagesCarousel`
- added landscape wrapper in every detail component

SVA-93