### PR TITLE
feat(cardListitem): new style condition for landscape mode

### DIFF
--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -5,7 +5,6 @@ import { ActivityIndicator, FlatList } from 'react-native';
 import { colors, normalize } from '../config';
 import { CardListItem } from './CardListItem';
 
-// TODO in order to implement landscape logic CardList needs to become a function component
 export class CardList extends React.PureComponent {
   state = {
     listEndReached: false

--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -1,41 +1,51 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useContext, useState } from 'react';
 import { ActivityIndicator, FlatList } from 'react-native';
 
 import { colors, normalize } from '../config';
 import { CardListItem } from './CardListItem';
+import { WrapperWithOrientation } from './Wrapper';
+import { OrientationContext } from '../OrientationProvider';
 
-export class CardList extends React.PureComponent {
-  state = {
-    listEndReached: false
-  };
+export const CardList = ({ data, navigation, horizontal }) => {
+  const [listEndReached, setListEndReached] = useState(false);
+  const { orientation, dimensions } = useContext(OrientationContext);
 
-  keyExtractor = (item, index) => `index${index}-id${item.id}`;
+  const keyExtractor = (item, index) => `index${index}-id${item.id}`;
 
-  render() {
-    const { listEndReached } = this.state;
-    const { data, navigation, horizontal } = this.props;
-
-    if (horizontal) {
-      return (
-        <FlatList
-          keyExtractor={this.keyExtractor}
-          data={data}
-          renderItem={({ item }) => (
-            <CardListItem navigation={navigation} horizontal={horizontal} item={item} />
-          )}
-          showsHorizontalScrollIndicator={false}
-          horizontal
-        />
-      );
-    }
-
+  if (horizontal) {
     return (
       <FlatList
-        keyExtractor={this.keyExtractor}
+        keyExtractor={keyExtractor}
         data={data}
         renderItem={({ item }) => (
-          <CardListItem navigation={navigation} horizontal={horizontal} item={item} />
+          <CardListItem
+            navigation={navigation}
+            horizontal={horizontal}
+            orientation={orientation}
+            dimensions={dimensions}
+            item={item}
+          />
+        )}
+        showsHorizontalScrollIndicator={false}
+        horizontal
+      />
+    );
+  }
+
+  return (
+    <WrapperWithOrientation orientation={orientation}>
+      <FlatList
+        keyExtractor={keyExtractor}
+        data={data}
+        renderItem={({ item }) => (
+          <CardListItem
+            navigation={navigation}
+            horizontal={horizontal}
+            item={item}
+            orientation={orientation}
+            dimensions={dimensions}
+          />
         )}
         ListFooterComponent={
           data.length > 10 &&
@@ -43,11 +53,11 @@ export class CardList extends React.PureComponent {
             <ActivityIndicator color={colors.accent} style={{ margin: normalize(14) }} />
           )
         }
-        onEndReached={() => this.setState({ listEndReached: true })}
+        onEndReached={() => setListEndReached(true)}
       />
-    );
-  }
-}
+    </WrapperWithOrientation>
+  );
+};
 
 CardList.propTypes = {
   navigation: PropTypes.object.isRequired,

--- a/src/components/CardListItem.js
+++ b/src/components/CardListItem.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useContext } from 'react';
+import React from 'react';
 import { Card } from 'react-native-elements';
 import { Platform, StyleSheet, View } from 'react-native';
 
@@ -8,12 +8,9 @@ import { imageHeight, imageWidth } from '../helpers';
 import { Image } from './Image';
 import { RegularText, BoldText } from './Text';
 import { Touchable } from './Touchable';
-import { WrapperWithOrientation } from './Wrapper';
-import { OrientationContext } from '../OrientationProvider';
 
-export const CardListItem = ({ navigation, horizontal, item }) => {
+export const CardListItem = ({ navigation, horizontal, item, orientation, dimensions }) => {
   const { routeName, params, image, category, name } = item;
-  const { orientation } = useContext(OrientationContext);
 
   return (
     <Touchable
@@ -24,31 +21,34 @@ export const CardListItem = ({ navigation, horizontal, item }) => {
         })
       }
     >
-      <WrapperWithOrientation orientation={orientation}>
-        <Card
-          containerStyle={[
-            Platform.select({
-              android: {
-                elevation: 0
-              },
-              ios: {
-                shadowColor: colors.transparent
-              }
-            }),
-            stylesWithProps(this.props).container
-          ]}
-        >
-          <View style={stylesWithProps(this.props).contentContainer}>
-            {!!image && <Image source={{ uri: image }} style={stylesWithProps(this.props).image} />}
-            {!!category && <RegularText small>{category}</RegularText>}
-            {!!name && (
-              <BoldText>
-                {horizontal ? (name.length > 60 ? name.substring(0, 60) + '...' : name) : name}
-              </BoldText>
-            )}
-          </View>
-        </Card>
-      </WrapperWithOrientation>
+      <Card
+        containerStyle={[
+          Platform.select({
+            android: {
+              elevation: 0,
+            },
+            ios: {
+              shadowColor: colors.transparent,
+            },
+          }),
+          stylesWithProps({ horizontal, orientation, dimensions }).container,
+        ]}
+      >
+        <View style={stylesWithProps({ horizontal, orientation, dimensions }).contentContainer}>
+          {!!image && (
+            <Image
+              source={{ uri: image }}
+              style={stylesWithProps({ horizontal, orientation, dimensions }).image}
+            />
+          )}
+          {!!category && <RegularText small>{category}</RegularText>}
+          {!!name && (
+            <BoldText>
+              {horizontal ? (name.length > 60 ? name.substring(0, 60) + '...' : name) : name}
+            </BoldText>
+          )}
+        </View>
+      </Card>
     </Touchable>
   );
 };
@@ -56,12 +56,14 @@ export const CardListItem = ({ navigation, horizontal, item }) => {
 /* eslint-disable react-native/no-unused-styles */
 /* this works properly, we do not want that warning */
 
-export const stylesWithProps = () => {
-  const { orientation, dimensions } = useContext(OrientationContext);
+const stylesWithProps = ({ horizontal, orientation, dimensions }) => {
   // image width should be only 70% when rendering horizontal cards, otherwise substract paddings
-  // deleted horizontal logic momentarily because gives a red screen "undefined it's not an object"
 
-  const width = orientation === 'landscape' ? dimensions.height : imageWidth() - 2 * normalize(14);
+  const width = horizontal
+    ? imageWidth() * 0.7
+    : orientation === 'landscape'
+    ? dimensions.height
+    : imageWidth() - 2 * normalize(14);
 
   return StyleSheet.create({
     container: {
@@ -86,7 +88,8 @@ CardListItem.propTypes = {
   navigation: PropTypes.object.isRequired,
   item: PropTypes.object.isRequired,
   horizontal: PropTypes.bool,
-  orientation: PropTypes.string
+  orientation: PropTypes.string.isRequired,
+  dimensions: PropTypes.object.isRequired,
 };
 
 CardListItem.defaultProps = {

--- a/src/components/CardListItem.js
+++ b/src/components/CardListItem.js
@@ -11,7 +11,7 @@ import { Touchable } from './Touchable';
 
 export class CardListItem extends React.PureComponent {
   render() {
-    const { navigation, horizontal, item } = this.props;
+    const { navigation, horizontal, item, orientation } = this.props;
     const { routeName, params, image, category, name } = item;
 
     return (
@@ -53,9 +53,14 @@ export class CardListItem extends React.PureComponent {
 
 /* eslint-disable react-native/no-unused-styles */
 /* this works properly, we do not want that warning */
-const stylesWithProps = ({ horizontal }) => {
+const stylesWithProps = ({ horizontal, orientation }) => {
   // image width should be only 70% when rendering horizontal cards, otherwise substract paddings
-  const width = horizontal ? imageWidth() * 0.7 : imageWidth() - 2 * normalize(14);
+  // when orientation image width should be device width + double padding TODO: need a fix
+  const width = horizontal
+    ? imageWidth() * 0.7
+    : orientation
+    ? imageWidth() - 2 * normalize(30)
+    : imageWidth() - 2 * normalize(14);
 
   return StyleSheet.create({
     container: {
@@ -79,7 +84,8 @@ const stylesWithProps = ({ horizontal }) => {
 CardListItem.propTypes = {
   navigation: PropTypes.object.isRequired,
   item: PropTypes.object.isRequired,
-  horizontal: PropTypes.bool
+  horizontal: PropTypes.bool,
+  orientation: PropTypes.string
 };
 
 CardListItem.defaultProps = {

--- a/src/components/CardListItem.js
+++ b/src/components/CardListItem.js
@@ -11,20 +11,20 @@ import { Touchable } from './Touchable';
 import { WrapperWithOrientation } from './Wrapper';
 import { OrientationContext } from '../OrientationProvider';
 
-export class CardListItem extends React.PureComponent {
-  render() {
-    const { navigation, horizontal, item, orientation } = this.props;
-    const { routeName, params, image, category, name } = item;
+export const CardListItem = ({ navigation, horizontal, item }) => {
+  const { routeName, params, image, category, name } = item;
+  const { orientation } = useContext(OrientationContext);
 
-    return (
-      <Touchable
-        onPress={() =>
-          navigation.navigate({
-            routeName,
-            params
-          })
-        }
-      >
+  return (
+    <Touchable
+      onPress={() =>
+        navigation.navigate({
+          routeName,
+          params
+        })
+      }
+    >
+      <WrapperWithOrientation orientation={orientation}>
         <Card
           containerStyle={[
             Platform.select({
@@ -39,35 +39,29 @@ export class CardListItem extends React.PureComponent {
           ]}
         >
           <View style={stylesWithProps(this.props).contentContainer}>
-            <WrapperWithOrientation orientation={orientation}>
-              {!!image && (
-                <Image source={{ uri: image }} style={stylesWithProps(this.props).image} />
-              )}
-              {!!category && <RegularText small>{category}</RegularText>}
-              {!!name && (
-                <BoldText>
-                  {horizontal ? (name.length > 60 ? name.substring(0, 60) + '...' : name) : name}
-                </BoldText>
-              )}
-            </WrapperWithOrientation>
+            {!!image && <Image source={{ uri: image }} style={stylesWithProps(this.props).image} />}
+            {!!category && <RegularText small>{category}</RegularText>}
+            {!!name && (
+              <BoldText>
+                {horizontal ? (name.length > 60 ? name.substring(0, 60) + '...' : name) : name}
+              </BoldText>
+            )}
           </View>
         </Card>
-      </Touchable>
-    );
-  }
-}
+      </WrapperWithOrientation>
+    </Touchable>
+  );
+};
 
 /* eslint-disable react-native/no-unused-styles */
 /* this works properly, we do not want that warning */
-export const stylesWithProps = ({ horizontal }) => {
-  const { orientation } = useContext(OrientationContext);
+
+export const stylesWithProps = () => {
+  const { orientation, dimensions } = useContext(OrientationContext);
   // image width should be only 70% when rendering horizontal cards, otherwise substract paddings
-  // when orientation image width should be device width + double padding TODO: need a fix
-  const width = horizontal
-    ? imageWidth() * 0.7
-    : orientation === 'landscape'
-    ? imageWidth() * 0.5
-    : imageWidth() - 2 * normalize(14);
+  // deleted horizontal logic momentarily because gives a red screen "undefined it's not an object"
+
+  const width = orientation === 'landscape' ? dimensions.height : imageWidth() - 2 * normalize(14);
 
   return StyleSheet.create({
     container: {

--- a/src/components/CardListItem.js
+++ b/src/components/CardListItem.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useContext } from 'react';
 import { Card } from 'react-native-elements';
 import { Platform, StyleSheet, View } from 'react-native';
 
@@ -8,6 +8,8 @@ import { imageHeight, imageWidth } from '../helpers';
 import { Image } from './Image';
 import { RegularText, BoldText } from './Text';
 import { Touchable } from './Touchable';
+import { WrapperWithOrientation } from './Wrapper';
+import { OrientationContext } from '../OrientationProvider';
 
 export class CardListItem extends React.PureComponent {
   render() {
@@ -37,13 +39,17 @@ export class CardListItem extends React.PureComponent {
           ]}
         >
           <View style={stylesWithProps(this.props).contentContainer}>
-            {!!image && <Image source={{ uri: image }} style={stylesWithProps(this.props).image} />}
-            {!!category && <RegularText small>{category}</RegularText>}
-            {!!name && (
-              <BoldText>
-                {horizontal ? (name.length > 60 ? name.substring(0, 60) + '...' : name) : name}
-              </BoldText>
-            )}
+            <WrapperWithOrientation orientation={orientation}>
+              {!!image && (
+                <Image source={{ uri: image }} style={stylesWithProps(this.props).image} />
+              )}
+              {!!category && <RegularText small>{category}</RegularText>}
+              {!!name && (
+                <BoldText>
+                  {horizontal ? (name.length > 60 ? name.substring(0, 60) + '...' : name) : name}
+                </BoldText>
+              )}
+            </WrapperWithOrientation>
           </View>
         </Card>
       </Touchable>
@@ -53,13 +59,14 @@ export class CardListItem extends React.PureComponent {
 
 /* eslint-disable react-native/no-unused-styles */
 /* this works properly, we do not want that warning */
-const stylesWithProps = ({ horizontal, orientation }) => {
+export const stylesWithProps = ({ horizontal }) => {
+  const { orientation } = useContext(OrientationContext);
   // image width should be only 70% when rendering horizontal cards, otherwise substract paddings
   // when orientation image width should be device width + double padding TODO: need a fix
   const width = horizontal
     ? imageWidth() * 0.7
-    : orientation
-    ? imageWidth() - 2 * normalize(30)
+    : orientation === 'landscape'
+    ? imageWidth() * 0.5
     : imageWidth() - 2 * normalize(14);
 
   return StyleSheet.create({

--- a/src/components/SafeAreaViewFlex.js
+++ b/src/components/SafeAreaViewFlex.js
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { SafeAreaView, StyleSheet } from 'react-native';
 
-export const SafeAreaViewFlex = ({ children }) => (
-  <SafeAreaView style={styles.flex}>{children}</SafeAreaView>
+export const SafeAreaViewFlex = ({ children, style }) => (
+  <SafeAreaView style={[styles.flex, style]}>{children}</SafeAreaView>
 );
 
 const styles = StyleSheet.create({
@@ -13,5 +13,6 @@ const styles = StyleSheet.create({
 });
 
 SafeAreaViewFlex.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.array, PropTypes.object])
+  children: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+  style: PropTypes.object,
 };

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -264,7 +264,7 @@ export const IndexScreen = ({ navigation }) => {
         }
 
         return (
-          <SafeAreaViewFlex>
+          <SafeAreaViewFlex style={styles.center}>
             <Component
               navigation={navigation}
               data={listItems}
@@ -281,8 +281,11 @@ export const IndexScreen = ({ navigation }) => {
 
 const styles = StyleSheet.create({
   icon: {
-    paddingHorizontal: normalize(14)
-  }
+    paddingHorizontal: normalize(14),
+  },
+  center: {
+    alignSelf: 'center',
+  },
 });
 
 IndexScreen.navigationOptions = ({ navigation }) => {


### PR DESCRIPTION
- passing orientation as prop
- created a condition for new style when orientation is triggered

SVA-93



- in Card List deleted a comment , there is not the place where to make changes
- WrapperWithOrientation is now implemented conditionally around cart item
- in addition imageWidth it should be on 50% when orientation is on landscape
  - attempt to implement OrientationContext based on ImagesCarousel
   - getting a red screen about an invalid hooks call

SVA-93

- refactored CardListItem into a functional component
- moved WrapperWithOrientation behind card component
  - that's where should stay in order to wrap the all card and made changes when orientation changes
- temporary deletion of horizontal logic for preview card list (which is visible on home screen only)
  -  it has been deleted due a error that comes up saying "undefined it's not an object"
- if landscape now we have a combo of:
  - dimensions.height which influences images width based on device window
  - and WrapperWithOrientation which centers the card within the screen ( adding padding left and right )

SVA-93

- refactored CardList in order to use hooks
- on CardListItem orientation and dimensions are required because the calculation of the width is depending their
  - in addition wrapper orientation is gone because passed to parent component CardList which takes care of orientation all at once and not every time for each cardList
- in SafeAreaView we have a style prop in order to use a different style when needed
 - this is applied on SafeAreaView in IndexScreen where we need to center the list
SVA-93