### PR TITLE
feat(service boxes): add sizing and positioning based on orientation

### DIFF
--- a/src/components/ServiceBox.js
+++ b/src/components/ServiceBox.js
@@ -1,9 +1,25 @@
-import styled from 'styled-components/native';
+import styled, { css } from 'styled-components/native';
 
-import { normalize } from '../config';
+import { consts, normalize } from '../config';
 
 export const ServiceBox = styled.View`
-  align-items: center;
-  flex-basis: ${100 / 3}%;
+  flex-basis: ${100 / 3.3}%;
   margin: ${normalize(14)}px 0;
+
+  ${(props) =>
+    props.dimensions.width > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH &&
+    css`
+      /*
+        need to add slightly more than 5.3 like on landscape in order to re-render
+        on orientation change. with the same values in this condition and for landscape,
+        it seems that the styled component is memoized and a re-rendering does not take place.
+      */
+      flex-basis: ${100 / 5.301}%;
+    `};
+
+  ${(props) =>
+    props.orientation === 'landscape' &&
+    css`
+      flex-basis: ${100 / 5.3}%;
+    `};
 `;

--- a/src/components/screens/Service.js
+++ b/src/components/screens/Service.js
@@ -4,6 +4,7 @@ import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Query } from 'react-apollo';
 
 import { NetworkContext } from '../../NetworkProvider';
+import { OrientationContext } from '../../OrientationProvider';
 import { GlobalSettingsContext } from '../../GlobalSettingsProvider';
 import { consts, device, normalize, texts } from '../../config';
 import { DiagonalGradient } from '../DiagonalGradient';
@@ -19,6 +20,7 @@ import { graphqlFetchPolicy, refreshTimeFor } from '../../helpers';
 export const Service = ({ navigation, refreshing }) => {
   const [refreshTime, setRefreshTime] = useState();
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
+  const { orientation, dimensions } = useContext(OrientationContext);
   const globalSettings = useContext(GlobalSettingsContext);
 
   useEffect(() => {
@@ -69,7 +71,11 @@ export const Service = ({ navigation, refreshing }) => {
               <WrapperWrap>
                 {publicJsonFileContent.map((item, index) => {
                   return (
-                    <ServiceBox key={index + item.title}>
+                    <ServiceBox
+                      key={index + item.title}
+                      orientation={orientation}
+                      dimensions={dimensions}
+                    >
                       <TouchableOpacity
                         onPress={() =>
                           navigation.navigate({

--- a/src/screens/CompanyScreen.js
+++ b/src/screens/CompanyScreen.js
@@ -11,6 +11,7 @@ import {
 import { Query } from 'react-apollo';
 
 import { NetworkContext } from '../NetworkProvider';
+import { OrientationContext } from '../OrientationProvider';
 import { GlobalSettingsContext } from '../GlobalSettingsProvider';
 import { colors, consts, device, normalize, texts } from '../config';
 import {
@@ -31,6 +32,7 @@ import { graphqlFetchPolicy, refreshTimeFor } from '../helpers';
 export const CompanyScreen = ({ navigation }) => {
   const [refreshTime, setRefreshTime] = useState();
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
+  const { orientation, dimensions } = useContext(OrientationContext);
   const globalSettings = useContext(GlobalSettingsContext);
   const [refreshing, setRefreshing] = useState(false);
 
@@ -57,7 +59,7 @@ export const CompanyScreen = ({ navigation }) => {
 
   const refresh = async (refetch) => {
     setRefreshing(true);
-    isConnected && await refetch();
+    isConnected && (await refetch());
     setRefreshing(false);
   };
 
@@ -108,7 +110,11 @@ export const CompanyScreen = ({ navigation }) => {
                   <WrapperWrap>
                     {publicJsonFileContent.map((item, index) => {
                       return (
-                        <ServiceBox key={index + item.title}>
+                        <ServiceBox
+                          key={index + item.title}
+                          orientation={orientation}
+                          dimensions={dimensions}
+                        >
                           <TouchableOpacity
                             onPress={() =>
                               navigation.navigate({
@@ -119,11 +125,7 @@ export const CompanyScreen = ({ navigation }) => {
                           >
                             <View>
                               {item.iconName ? (
-                                <Icon
-                                  name={item.iconName}
-                                  size={30}
-                                  style={styles.serviceIcon}
-                                />
+                                <Icon name={item.iconName} size={30} style={styles.serviceIcon} />
                               ) : (
                                 <Image
                                   source={{ uri: item.icon }}

--- a/src/screens/ServiceScreen.js
+++ b/src/screens/ServiceScreen.js
@@ -11,6 +11,7 @@ import {
 import { Query } from 'react-apollo';
 
 import { NetworkContext } from '../NetworkProvider';
+import { OrientationContext } from '../OrientationProvider';
 import { GlobalSettingsContext } from '../GlobalSettingsProvider';
 import { colors, consts, device, normalize, texts } from '../config';
 import {
@@ -31,6 +32,7 @@ import { graphqlFetchPolicy, refreshTimeFor } from '../helpers';
 export const ServiceScreen = ({ navigation }) => {
   const [refreshTime, setRefreshTime] = useState();
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
+  const { orientation, dimensions } = useContext(OrientationContext);
   const globalSettings = useContext(GlobalSettingsContext);
   const [refreshing, setRefreshing] = useState(false);
 
@@ -57,7 +59,7 @@ export const ServiceScreen = ({ navigation }) => {
 
   const refresh = async (refetch) => {
     setRefreshing(true);
-    isConnected && await refetch();
+    isConnected && (await refetch());
     setRefreshing(false);
   };
 
@@ -108,7 +110,11 @@ export const ServiceScreen = ({ navigation }) => {
                   <WrapperWrap>
                     {publicJsonFileContent.map((item, index) => {
                       return (
-                        <ServiceBox key={index + item.title}>
+                        <ServiceBox
+                          key={index + item.title}
+                          orientation={orientation}
+                          dimensions={dimensions}
+                        >
                           <TouchableOpacity
                             onPress={() =>
                               navigation.navigate({
@@ -119,11 +125,7 @@ export const ServiceScreen = ({ navigation }) => {
                           >
                             <View>
                               {item.iconName ? (
-                                <Icon
-                                  name={item.iconName}
-                                  size={30}
-                                  style={styles.serviceIcon}
-                                />
+                                <Icon name={item.iconName} size={30} style={styles.serviceIcon} />
                               ) : (
                                 <Image
                                   source={{ uri: item.icon }}


### PR DESCRIPTION
- removed `align-items: center` to always be full width inside the flex area
- added conditions for landscape mode and based on dimensions
  with re-rendering on orientation change

<img width="416" alt="Bildschirmfoto 2020-10-23 um 16 57 33" src="https://user-images.githubusercontent.com/1942953/97019718-f4967480-1550-11eb-8481-bc3ae67f454c.png">
