### PR TITLE
separation of news on category

### DIFF
--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -23,10 +23,14 @@ export const texts = {
   homeTitles: {
     about: 'Über die App',
     events: 'Veranstaltungen',
-    news: 'Nachrichten',
     pointsOfInterest: 'Touren und Orte',
     service: 'Service',
     company: 'Städtische Unternehmen'
+  },
+  homeCategoriesNews: {
+    categoryId: '47',
+    categoryTitle: 'Nachrichten',
+    categoryTitleDetail: 'Nachricht'
   },
   navigationTitles: {
     home: 'Übersicht'

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -28,7 +28,6 @@ export const texts = {
     company: 'Städtische Unternehmen'
   },
   homeCategoriesNews: {
-    categoryId: 77,
     categoryTitle: 'Nachrichten',
     categoryTitleDetail: 'Nachricht'
   },

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -28,7 +28,7 @@ export const texts = {
     company: 'Städtische Unternehmen'
   },
   homeCategoriesNews: {
-    categoryId: '47',
+    categoryId: 77,
     categoryTitle: 'Nachrichten',
     categoryTitleDetail: 'Nachricht'
   },

--- a/src/queries/newsItems.js
+++ b/src/queries/newsItems.js
@@ -1,7 +1,9 @@
 import gql from 'graphql-tag';
 
 export const GET_NEWS_ITEMS = gql`
-  query NewsItems($limit: Int, $offset: Int) {
+  query NewsItems($limit: Int, $offset: Int, $categoryId: ID) {
+    # TODO: ", categoryId: $categoryId" to filter on a category
+    #       main server PR necessary: https://github.com/ikuseiGmbH/smart-village-app-mainserver/pull/158
     newsItems(limit: $limit, skip: $offset) {
       id
       mainTitle: title
@@ -39,7 +41,9 @@ export const GET_NEWS_ITEMS = gql`
 `;
 
 export const GET_FILTERED_NEWS_ITEMS = gql`
-  query NewsItems($limit: Int, $offset: Int, $dataProvider: String) {
+  query NewsItems($limit: Int, $offset: Int, $dataProvider: String, $categoryId: ID) {
+    # TODO: ", categoryId: $categoryId" to filter on a category
+    #       main server PR necessary: https://github.com/ikuseiGmbH/smart-village-app-mainserver/pull/158
     newsItems(limit: $limit, skip: $offset, dataProvider: $dataProvider) {
       id
       mainTitle: title
@@ -77,7 +81,9 @@ export const GET_FILTERED_NEWS_ITEMS = gql`
 `;
 
 export const GET_FILTERED_NEWS_ITEMS_AND_DATA_PROVIDERS = gql`
-  query NewsItems($limit: Int, $offset: Int, $dataProvider: String) {
+  query NewsItems($limit: Int, $offset: Int, $dataProvider: String, $categoryId: ID) {
+    # TODO: ", categoryId: $categoryId" to filter on a category
+    #       main server PR necessary: https://github.com/ikuseiGmbH/smart-village-app-mainserver/pull/158
     newsItems(limit: $limit, skip: $offset, dataProvider: $dataProvider) {
       id
       mainTitle: title
@@ -111,7 +117,7 @@ export const GET_FILTERED_NEWS_ITEMS_AND_DATA_PROVIDERS = gql`
         onlySummaryLinkText
       }
     }
-    dataProviders: newsItemsDataProviders {
+    dataProviders: newsItemsDataProviders(categoryId: $categoryId) {
       name
     }
   }

--- a/src/queries/newsItems.js
+++ b/src/queries/newsItems.js
@@ -2,9 +2,7 @@ import gql from 'graphql-tag';
 
 export const GET_NEWS_ITEMS = gql`
   query NewsItems($limit: Int, $offset: Int, $categoryId: ID) {
-    # TODO: ", categoryId: $categoryId" to filter on a category
-    #       main server PR necessary: https://github.com/ikuseiGmbH/smart-village-app-mainserver/pull/158
-    newsItems(limit: $limit, skip: $offset) {
+    newsItems(limit: $limit, skip: $offset, categoryId: $categoryId) {
       id
       mainTitle: title
       publishedAt
@@ -42,9 +40,7 @@ export const GET_NEWS_ITEMS = gql`
 
 export const GET_FILTERED_NEWS_ITEMS = gql`
   query NewsItems($limit: Int, $offset: Int, $dataProvider: String, $categoryId: ID) {
-    # TODO: ", categoryId: $categoryId" to filter on a category
-    #       main server PR necessary: https://github.com/ikuseiGmbH/smart-village-app-mainserver/pull/158
-    newsItems(limit: $limit, skip: $offset, dataProvider: $dataProvider) {
+    newsItems(limit: $limit, skip: $offset, dataProvider: $dataProvider, categoryId: $categoryId) {
       id
       mainTitle: title
       publishedAt
@@ -82,9 +78,7 @@ export const GET_FILTERED_NEWS_ITEMS = gql`
 
 export const GET_FILTERED_NEWS_ITEMS_AND_DATA_PROVIDERS = gql`
   query NewsItems($limit: Int, $offset: Int, $dataProvider: String, $categoryId: ID) {
-    # TODO: ", categoryId: $categoryId" to filter on a category
-    #       main server PR necessary: https://github.com/ikuseiGmbH/smart-village-app-mainserver/pull/158
-    newsItems(limit: $limit, skip: $offset, dataProvider: $dataProvider) {
+    newsItems(limit: $limit, skip: $offset, dataProvider: $dataProvider, categoryId: $categoryId) {
       id
       mainTitle: title
       publishedAt

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -48,7 +48,6 @@ export const HomeScreen = ({ navigation }) => {
     showEvents = true,
     categoriesNews = [
       {
-        categoryId: texts.homeCategoriesNews.categoryId,
         categoryTitle: texts.homeCategoriesNews.categoryTitle,
         categoryTitleDetail: texts.homeCategoriesNews.categoryTitleDetail,
         categoryButton: texts.homeButtons.news
@@ -96,12 +95,12 @@ export const HomeScreen = ({ navigation }) => {
         rootRouteName: 'EventRecords'
       }
     },
-    NEWS_ITEMS_INDEX: (categoryId, categoryTitle) => ({
+    NEWS_ITEMS_INDEX: ({ categoryId, categoryTitle }) => ({
       routeName: 'Index',
       params: {
         title: categoryTitle,
         query: QUERY_TYPES.NEWS_ITEMS,
-        queryVariables: { limit: 15, categoryId },
+        queryVariables: { limit: 15, ...{ categoryId } },
         rootRouteName: 'NewsItems'
       }
     })
@@ -124,11 +123,13 @@ export const HomeScreen = ({ navigation }) => {
         {showNews &&
           categoriesNews.map(
             ({ categoryId, categoryTitle, categoryTitleDetail, categoryButton }, index) => (
-              <Fragment key={`${index}-${categoryId}`}>
+              <Fragment key={`${index}-${categoryTitle}`}>
                 <TitleContainer>
                   <Touchable
                     onPress={() =>
-                      navigation.navigate(NAVIGATION.NEWS_ITEMS_INDEX(categoryId, categoryTitle))
+                      navigation.navigate(
+                        NAVIGATION.NEWS_ITEMS_INDEX({ categoryId, categoryTitle })
+                      )
                     }
                   >
                     <Title accessibilityLabel={`${categoryTitle} (Überschrift) (Taste)`}>
@@ -139,7 +140,7 @@ export const HomeScreen = ({ navigation }) => {
                 {device.platform === 'ios' && <TitleShadow />}
                 <Query
                   query={getQuery(QUERY_TYPES.NEWS_ITEMS)}
-                  variables={{ limit: 3, categoryId }}
+                  variables={{ limit: 3, ...{ categoryId } }}
                   fetchPolicy={fetchPolicy}
                 >
                   {({ data, loading }) => {
@@ -190,7 +191,7 @@ export const HomeScreen = ({ navigation }) => {
                             title={categoryButton}
                             onPress={() =>
                               navigation.navigate(
-                                NAVIGATION.NEWS_ITEMS_INDEX(categoryId, categoryTitle)
+                                NAVIGATION.NEWS_ITEMS_INDEX({ categoryId, categoryTitle })
                               )
                             }
                           />


### PR DESCRIPTION
feat(multiple news sections): dynamic news on home screen

- refactored news on home screen
- removed hard coded news section and texts
- added map over multiple news categories to
  create multiple news sections
- `categoriesNews` array needs to be added on the
  main server in `sections` with objects containing
  a `categoryId` to filter, `categoryTitle` to show as
  headlines, `categoryTitleDetail` to show in header
  on details screens and `categoryButton` to show as
  button text

SVA-32

feat(news filter): consider category for data providers

- when filtered news on category, the data provider selection
  on news index also needs to take care of that
- added parameter for category id for data provider query
  in news items
- added TODOs for parts, where the main server is not ready yet
  - ikuseiGmbH/smart-village-app-mainserver#158
    needs to be merge and tested before

SVA-32