### PR TITLE
bug(text): increase line height

### DIFF
--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -12,7 +12,7 @@ export const RegularText = styled.Text`
     props.small &&
     css`
       font-size: ${normalize(14)};
-      line-height: ${normalize(16)};
+      line-height: ${normalize(18)};
     `};
 
   ${(props) =>


### PR DESCRIPTION
- regular text prop small line height 16 was not enough that's way text was cut in openingTimecard
- increased just a bit it solves with out breaking anything else

SVA-104

