### PR TITLE
show alternative list styles

### DIFF
--- a/src/components/CardListItem.js
+++ b/src/components/CardListItem.js
@@ -10,12 +10,12 @@ import { RegularText, BoldText } from './Text';
 import { Touchable } from './Touchable';
 
 export const CardListItem = memo(({ navigation, horizontal, item, orientation, dimensions }) => {
-  const { routeName, params, image, category, name } = item;
+  const { routeName, params, picture, subtitle, title } = item;
 
   // TODO: count articles logic could to be implemented
   return (
     <Touchable
-      accessibilityLabel={`(${category}) ${name} (Taste)`}
+      accessibilityLabel={`(${subtitle}) ${title} (Taste)`}
       onPress={() =>
         navigation.navigate({
           routeName,
@@ -25,16 +25,16 @@ export const CardListItem = memo(({ navigation, horizontal, item, orientation, d
     >
       <Card containerStyle={styles.container}>
         <View style={stylesWithProps({ horizontal, orientation, dimensions }).contentContainer}>
-          {!!image && (
+          {!!picture && !!picture.url && (
             <Image
-              source={{ uri: image }}
+              source={{ uri: picture.url }}
               style={stylesWithProps({ horizontal, orientation, dimensions }).image}
             />
           )}
-          {!!category && <RegularText small>{category}</RegularText>}
-          {!!name && (
+          {!!subtitle && <RegularText small>{subtitle}</RegularText>}
+          {!!title && (
             <BoldText>
-              {horizontal ? (name.length > 60 ? name.substring(0, 60) + '...' : name) : name}
+              {horizontal ? (title.length > 60 ? title.substring(0, 60) + '...' : title) : title}
             </BoldText>
           )}
         </View>

--- a/src/components/TextListItem.js
+++ b/src/components/TextListItem.js
@@ -1,10 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import { ListItem } from 'react-native-elements';
 
 import { colors, normalize } from '../config';
 import { arrowRight } from '../icons';
 import { Icon } from './Icon';
+import { Image } from './Image';
+
 import { RegularText, BoldText } from './Text';
 import { Touchable } from './Touchable';
 import { trimNewLines } from '../helpers';
@@ -12,7 +15,7 @@ import { trimNewLines } from '../helpers';
 export class TextListItem extends React.PureComponent {
   render() {
     const { navigation, noSubtitle, item } = this.props;
-    const { routeName, params, subtitle, title, bottomDivider, topDivider } = item;
+    const { routeName, params, subtitle, title, bottomDivider, topDivider, picture } = item;
 
     return (
       <ListItem
@@ -25,6 +28,7 @@ export class TextListItem extends React.PureComponent {
           paddingVertical: normalize(12)
         }}
         rightIcon={<Icon xml={arrowRight(colors.primary)} />}
+        leftIcon={!!picture && <Image style={styles.smallImage} source={picture.url} />}
         onPress={() =>
           navigation.navigate({
             routeName,
@@ -38,6 +42,14 @@ export class TextListItem extends React.PureComponent {
     );
   }
 }
+
+const styles = StyleSheet.create({
+  smallImage: {
+    alignSelf: 'flex-start',
+    height: normalize(30),
+    width: normalize(30),
+  },
+});
 
 TextListItem.propTypes = {
   navigation: PropTypes.object.isRequired,

--- a/src/components/TextListItem.js
+++ b/src/components/TextListItem.js
@@ -29,7 +29,7 @@ export class TextListItem extends React.PureComponent {
         topDivider={topDivider !== undefined ? topDivider : false}
         containerStyle={{
           backgroundColor: colors.transparent,
-          paddingVertical: normalize(12),
+          paddingVertical: normalize(12)
         }}
         rightIcon={<Icon xml={arrowRight(colors.primary)} />}
         leftIcon={
@@ -40,7 +40,7 @@ export class TextListItem extends React.PureComponent {
         onPress={() =>
           navigation.navigate({
             routeName,
-            params,
+            params
           })
         }
         delayPressIn={0}
@@ -55,16 +55,16 @@ const styles = StyleSheet.create({
   smallImage: {
     alignSelf: 'flex-start',
     height: normalize(33),
-    width: normalize(66),
-  },
+    width: normalize(66)
+  }
 });
 
 TextListItem.propTypes = {
   navigation: PropTypes.object.isRequired,
   item: PropTypes.object.isRequired,
-  noSubtitle: PropTypes.bool,
+  noSubtitle: PropTypes.bool
 };
 
 TextListItem.defaultProps = {
-  noSubtitle: false,
+  noSubtitle: false
 };

--- a/src/components/TextListItem.js
+++ b/src/components/TextListItem.js
@@ -17,7 +17,10 @@ export class TextListItem extends React.PureComponent {
     const { navigation, noSubtitle, item } = this.props;
     const { routeName, params, subtitle, title, bottomDivider, topDivider, picture } = item;
 
-    let leftImage = false;
+    // temporary boolean variable, information for showing the left image needs to come from props,
+    // which will be based on the user preference.
+    const leftImage = false;
+
     return (
       <ListItem
         title={noSubtitle || !subtitle ? null : <RegularText small>{subtitle}</RegularText>}

--- a/src/components/TextListItem.js
+++ b/src/components/TextListItem.js
@@ -17,6 +17,7 @@ export class TextListItem extends React.PureComponent {
     const { navigation, noSubtitle, item } = this.props;
     const { routeName, params, subtitle, title, bottomDivider, topDivider, picture } = item;
 
+    let leftImage = false;
     return (
       <ListItem
         title={noSubtitle || !subtitle ? null : <RegularText small>{subtitle}</RegularText>}
@@ -29,6 +30,7 @@ export class TextListItem extends React.PureComponent {
         }}
         rightIcon={<Icon xml={arrowRight(colors.primary)} />}
         leftIcon={
+          leftImage &&
           !!picture &&
           !!picture.url && <Image style={styles.smallImage} source={{ uri: picture.url }} />
         }

--- a/src/components/TextListItem.js
+++ b/src/components/TextListItem.js
@@ -25,14 +25,17 @@ export class TextListItem extends React.PureComponent {
         topDivider={topDivider !== undefined ? topDivider : false}
         containerStyle={{
           backgroundColor: colors.transparent,
-          paddingVertical: normalize(12)
+          paddingVertical: normalize(12),
         }}
         rightIcon={<Icon xml={arrowRight(colors.primary)} />}
-        leftIcon={!!picture && <Image style={styles.smallImage} source={picture.url} />}
+        leftIcon={
+          !!picture &&
+          !!picture.url && <Image style={styles.smallImage} source={{ uri: picture.url }} />
+        }
         onPress={() =>
           navigation.navigate({
             routeName,
-            params
+            params,
           })
         }
         delayPressIn={0}
@@ -46,17 +49,17 @@ export class TextListItem extends React.PureComponent {
 const styles = StyleSheet.create({
   smallImage: {
     alignSelf: 'flex-start',
-    height: normalize(30),
-    width: normalize(30),
+    height: normalize(33),
+    width: normalize(66),
   },
 });
 
 TextListItem.propTypes = {
   navigation: PropTypes.object.isRequired,
   item: PropTypes.object.isRequired,
-  noSubtitle: PropTypes.bool
+  noSubtitle: PropTypes.bool,
 };
 
 TextListItem.defaultProps = {
-  noSubtitle: false
+  noSubtitle: false,
 };

--- a/src/helpers/imageHelper.js
+++ b/src/helpers/imageHelper.js
@@ -12,11 +12,6 @@ export const imageHeight = (width) => {
   return 180 * factor;
 };
 
-// TODO: image aspect ratio based on image height
-// export const imageWidtht = (height) => { const factor = height / 360;
-// return 180 * factor;
-// };
-
 export const mainImageOfMediaContents = (mediaContents) => {
   if (!mediaContents || !mediaContents.length) return null;
 

--- a/src/helpers/imageHelper.js
+++ b/src/helpers/imageHelper.js
@@ -12,6 +12,11 @@ export const imageHeight = (width) => {
   return 180 * factor;
 };
 
+// TODO: image aspect ratio based on image height
+// export const imageWidtht = (height) => { const factor = height / 360;
+// return 180 * factor;
+// };
+
 export const mainImageOfMediaContents = (mediaContents) => {
   if (!mediaContents || !mediaContents.length) return null;
 

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -337,16 +337,7 @@ export const HomeScreen = ({ navigation }) => {
                     ),
                     title: eventRecord.title,
                     picture: {
-                      url:
-                        !!eventRecord.mediaContents &&
-                        !!eventRecord.mediaContents.length &&
-                        _filter(
-                          eventRecord.mediaContents,
-                          (mediaContent) =>
-                            mediaContent.contentType === 'image' ||
-                            mediaContent.contentType === 'thumbnail'
-                        ).sourceUrl &&
-                        !!eventRecord.mediaContents.sourceUrl.url,
+                      url: mainImageOfMediaContents(eventRecord.mediaContents),
                     },
                     routeName: 'Detail',
                     params: {

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -3,6 +3,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { ActivityIndicator, RefreshControl, ScrollView, View } from 'react-native';
 import { Query } from 'react-apollo';
 import _shuffle from 'lodash/shuffle';
+import _filter from 'lodash/filter';
 
 import { NetworkContext } from '../NetworkProvider';
 import { GlobalSettingsContext } from '../GlobalSettingsProvider';
@@ -152,6 +153,19 @@ export const HomeScreen = ({ navigation }) => {
                       !!newsItem.contentBlocks &&
                       !!newsItem.contentBlocks.length &&
                       newsItem.contentBlocks[0].title,
+                    picture: {
+                      url:
+                        !!newsItem.contentBlocks &&
+                        !!newsItem.contentBlocks.length &&
+                        !!newsItem.contentBlocks[0].mediaContents &&
+                        !!newsItem.contentBlocks[0].mediaContents.length &&
+                        _filter(
+                          newsItem.contentBlocks[0].mediaContents,
+                          (mediaContent) =>
+                            mediaContent.contentType === 'image' ||
+                            mediaContent.contentType === 'thumbnail'
+                        )[0].sourceUrl.url,
+                    },
                     routeName: 'Detail',
                     params: {
                       title: 'Nachricht',

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -230,9 +230,11 @@ export const HomeScreen = ({ navigation }) => {
                   data.pointsOfInterest &&
                   data.pointsOfInterest.map((pointOfInterest) => ({
                     id: pointOfInterest.id,
-                    name: pointOfInterest.name,
-                    category: !!pointOfInterest.category && pointOfInterest.category.name,
-                    image: mainImageOfMediaContents(pointOfInterest.mediaContents),
+                    title: pointOfInterest.name,
+                    subtitle: !!pointOfInterest.category && pointOfInterest.category.name,
+                    picture: {
+                      url: mainImageOfMediaContents(pointOfInterest.mediaContents),
+                    },
                     routeName: 'Detail',
                     params: {
                       title: 'Ort',
@@ -255,9 +257,11 @@ export const HomeScreen = ({ navigation }) => {
                   data.tours &&
                   data.tours.map((tour) => ({
                     id: tour.id,
-                    name: tour.name,
-                    category: !!tour.category && tour.category.name,
-                    image: mainImageOfMediaContents(tour.mediaContents),
+                    title: tour.name,
+                    subtitle: !!tour.category && tour.category.name,
+                    picture: {
+                      url: mainImageOfMediaContents(tour.mediaContents),
+                    },
                     routeName: 'Detail',
                     params: {
                       title: 'Tour',
@@ -341,8 +345,8 @@ export const HomeScreen = ({ navigation }) => {
                           (mediaContent) =>
                             mediaContent.contentType === 'image' ||
                             mediaContent.contentType === 'thumbnail'
-                        )[0].sourceUrl &&
-                        !!eventRecord.mediaContents[0].sourceUrl.url,
+                        ).sourceUrl &&
+                        !!eventRecord.mediaContents.sourceUrl.url,
                     },
                     routeName: 'Detail',
                     params: {

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -155,8 +155,7 @@ export const HomeScreen = ({ navigation }) => {
                       newsItem.contentBlocks[0].title,
                     picture: {
                       url:
-                        !!newsItem.contentBlocks &&
-                        !!newsItem.contentBlocks.length &&
+                        !!newsItem.contentBlocks[0] &&
                         !!newsItem.contentBlocks[0].mediaContents &&
                         !!newsItem.contentBlocks[0].mediaContents.length &&
                         _filter(
@@ -333,6 +332,19 @@ export const HomeScreen = ({ navigation }) => {
                         (eventRecord.addresses[0].addition || eventRecord.addresses[0].city)
                     ),
                     title: eventRecord.title,
+                    picture: {
+                      url:
+                        !!eventRecord.mediaContents &&
+                        !!eventRecord.mediaContents.length &&
+                        _filter(
+                          eventRecord.mediaContents,
+                          (mediaContent) =>
+                            mediaContent.contentType === 'image' ||
+                            mediaContent.contentType === 'thumbnail'
+                        )[0] &&
+                        !!eventRecord.mediaContents[0].sourceUrl &&
+                        !!eventRecord.mediaContents[0].sourceUrl.url,
+                    },
                     routeName: 'Detail',
                     params: {
                       title: 'Veranstaltung',

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -163,7 +163,7 @@ export const HomeScreen = ({ navigation }) => {
                           (mediaContent) =>
                             mediaContent.contentType === 'image' ||
                             mediaContent.contentType === 'thumbnail'
-                        )[0].sourceUrl.url,
+                        )[0].sourceUrl.url
                     },
                     routeName: 'Detail',
                     params: {
@@ -233,7 +233,7 @@ export const HomeScreen = ({ navigation }) => {
                     title: pointOfInterest.name,
                     subtitle: !!pointOfInterest.category && pointOfInterest.category.name,
                     picture: {
-                      url: mainImageOfMediaContents(pointOfInterest.mediaContents),
+                      url: mainImageOfMediaContents(pointOfInterest.mediaContents)
                     },
                     routeName: 'Detail',
                     params: {
@@ -260,7 +260,7 @@ export const HomeScreen = ({ navigation }) => {
                     title: tour.name,
                     subtitle: !!tour.category && tour.category.name,
                     picture: {
-                      url: mainImageOfMediaContents(tour.mediaContents),
+                      url: mainImageOfMediaContents(tour.mediaContents)
                     },
                     routeName: 'Detail',
                     params: {
@@ -337,7 +337,7 @@ export const HomeScreen = ({ navigation }) => {
                     ),
                     title: eventRecord.title,
                     picture: {
-                      url: mainImageOfMediaContents(eventRecord.mediaContents),
+                      url: mainImageOfMediaContents(eventRecord.mediaContents)
                     },
                     routeName: 'Detail',
                     params: {

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -341,8 +341,7 @@ export const HomeScreen = ({ navigation }) => {
                           (mediaContent) =>
                             mediaContent.contentType === 'image' ||
                             mediaContent.contentType === 'thumbnail'
-                        )[0] &&
-                        !!eventRecord.mediaContents[0].sourceUrl &&
+                        )[0].sourceUrl &&
                         !!eventRecord.mediaContents[0].sourceUrl.url,
                     },
                     routeName: 'Detail',

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -8,6 +8,7 @@ import {
   View
 } from 'react-native';
 import { Query } from 'react-apollo';
+import _filter from 'lodash/filter';
 
 import { NetworkContext } from '../NetworkProvider';
 import { GlobalSettingsContext } from '../GlobalSettingsProvider';
@@ -77,6 +78,17 @@ const getListItems = (query, data) => {
             !!newsItem.contentBlocks &&
             !!newsItem.contentBlocks.length &&
             newsItem.contentBlocks[0].title,
+          picture: {
+            url:
+              !!newsItem.contentBlocks[0] &&
+              !!newsItem.contentBlocks[0].mediaContents &&
+              !!newsItem.contentBlocks[0].mediaContents.length &&
+              _filter(
+                newsItem.contentBlocks[0].mediaContents,
+                (mediaContent) =>
+                  mediaContent.contentType === 'image' || mediaContent.contentType === 'thumbnail'
+              )[0].sourceUrl.url,
+          },
           routeName: 'Detail',
           params: {
             title: 'Nachricht',

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -51,6 +51,17 @@ const getListItems = (query, data) => {
               (eventRecord.addresses[0].addition || eventRecord.addresses[0].city)
           ),
           title: eventRecord.title,
+          picture: {
+            url:
+              !!eventRecord.mediaContents &&
+              !!eventRecord.mediaContents.length &&
+              _filter(
+                eventRecord.mediaContents,
+                (mediaContent) =>
+                  mediaContent.contentType === 'image' || mediaContent.contentType === 'thumbnail'
+              )[0].sourceUrl &&
+              !!eventRecord.mediaContents[0].sourceUrl.url,
+          },
           routeName: 'Detail',
           params: {
             title: 'Veranstaltung',
@@ -70,15 +81,15 @@ const getListItems = (query, data) => {
         data[query] &&
         data[query].map((newsItem) => ({
           id: newsItem.id,
-          subtitle: subtitle(
+          category: subtitle(
             momentFormat(newsItem.publishedAt),
             !!newsItem.dataProvider && newsItem.dataProvider.name
           ),
-          title:
+          name:
             !!newsItem.contentBlocks &&
             !!newsItem.contentBlocks.length &&
             newsItem.contentBlocks[0].title,
-          picture: {
+          image: {
             url:
               !!newsItem.contentBlocks[0] &&
               !!newsItem.contentBlocks[0].mediaContents &&
@@ -182,10 +193,10 @@ const getListItems = (query, data) => {
 const getComponent = (query) => {
   const COMPONENTS = {
     [QUERY_TYPES.EVENT_RECORDS]: TextList,
-    [QUERY_TYPES.NEWS_ITEMS]: TextList,
+    [QUERY_TYPES.NEWS_ITEMS]: CardList,
     [QUERY_TYPES.POINTS_OF_INTEREST]: CardList,
     [QUERY_TYPES.TOURS]: CardList,
-    [QUERY_TYPES.CATEGORIES]: CategoryList
+    [QUERY_TYPES.CATEGORIES]: CategoryList,
   };
 
   return COMPONENTS[query];

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -81,15 +81,15 @@ const getListItems = (query, data) => {
         data[query] &&
         data[query].map((newsItem) => ({
           id: newsItem.id,
-          category: subtitle(
+          subtitle: subtitle(
             momentFormat(newsItem.publishedAt),
             !!newsItem.dataProvider && newsItem.dataProvider.name
           ),
-          name:
+          title:
             !!newsItem.contentBlocks &&
             !!newsItem.contentBlocks.length &&
             newsItem.contentBlocks[0].title,
-          image: {
+          picture: {
             url:
               !!newsItem.contentBlocks[0] &&
               !!newsItem.contentBlocks[0].mediaContents &&
@@ -144,9 +144,11 @@ const getListItems = (query, data) => {
         data[query] &&
         data[query].map((tour) => ({
           id: tour.id,
-          name: tour.name,
-          category: !!tour.category && tour.category.name,
-          image: mainImageOfMediaContents(tour.mediaContents),
+          title: tour.name,
+          subtitle: !!tour.category && tour.category.name,
+          picture: {
+            url: mainImageOfMediaContents(tour.mediaContents),
+          },
           routeName: 'Detail',
           params: {
             title: 'Tour',
@@ -193,7 +195,7 @@ const getListItems = (query, data) => {
 const getComponent = (query) => {
   const COMPONENTS = {
     [QUERY_TYPES.EVENT_RECORDS]: TextList,
-    [QUERY_TYPES.NEWS_ITEMS]: CardList,
+    [QUERY_TYPES.NEWS_ITEMS]: TextList,
     [QUERY_TYPES.POINTS_OF_INTEREST]: CardList,
     [QUERY_TYPES.TOURS]: CardList,
     [QUERY_TYPES.CATEGORIES]: CategoryList,

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -52,15 +52,7 @@ const getListItems = (query, data) => {
           ),
           title: eventRecord.title,
           picture: {
-            url:
-              !!eventRecord.mediaContents &&
-              !!eventRecord.mediaContents.length &&
-              _filter(
-                eventRecord.mediaContents,
-                (mediaContent) =>
-                  mediaContent.contentType === 'image' || mediaContent.contentType === 'thumbnail'
-              )[0].sourceUrl &&
-              !!eventRecord.mediaContents[0].sourceUrl.url,
+            url: mainImageOfMediaContents(eventRecord.mediaContents),
           },
           routeName: 'Detail',
           params: {
@@ -119,9 +111,11 @@ const getListItems = (query, data) => {
         data[query] &&
         data[query].map((pointOfInterest) => ({
           id: pointOfInterest.id,
-          name: pointOfInterest.name,
-          category: !!pointOfInterest.category && pointOfInterest.category.name,
-          image: mainImageOfMediaContents(pointOfInterest.mediaContents),
+          title: pointOfInterest.name,
+          subtitle: !!pointOfInterest.category && pointOfInterest.category.name,
+          picture: {
+            url: mainImageOfMediaContents(pointOfInterest.mediaContents),
+          },
           routeName: 'Detail',
           params: {
             title: 'Ort',

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -52,7 +52,7 @@ const getListItems = (query, data) => {
           ),
           title: eventRecord.title,
           picture: {
-            url: mainImageOfMediaContents(eventRecord.mediaContents),
+            url: mainImageOfMediaContents(eventRecord.mediaContents)
           },
           routeName: 'Detail',
           params: {
@@ -90,7 +90,7 @@ const getListItems = (query, data) => {
                 newsItem.contentBlocks[0].mediaContents,
                 (mediaContent) =>
                   mediaContent.contentType === 'image' || mediaContent.contentType === 'thumbnail'
-              )[0].sourceUrl.url,
+              )[0].sourceUrl.url
           },
           routeName: 'Detail',
           params: {
@@ -114,7 +114,7 @@ const getListItems = (query, data) => {
           title: pointOfInterest.name,
           subtitle: !!pointOfInterest.category && pointOfInterest.category.name,
           picture: {
-            url: mainImageOfMediaContents(pointOfInterest.mediaContents),
+            url: mainImageOfMediaContents(pointOfInterest.mediaContents)
           },
           routeName: 'Detail',
           params: {
@@ -141,7 +141,7 @@ const getListItems = (query, data) => {
           title: tour.name,
           subtitle: !!tour.category && tour.category.name,
           picture: {
-            url: mainImageOfMediaContents(tour.mediaContents),
+            url: mainImageOfMediaContents(tour.mediaContents)
           },
           routeName: 'Detail',
           params: {
@@ -192,7 +192,7 @@ const getComponent = (query) => {
     [QUERY_TYPES.NEWS_ITEMS]: TextList,
     [QUERY_TYPES.POINTS_OF_INTEREST]: CardList,
     [QUERY_TYPES.TOURS]: CardList,
-    [QUERY_TYPES.CATEGORIES]: CategoryList,
+    [QUERY_TYPES.CATEGORIES]: CategoryList
   };
 
   return COMPONENTS[query];
@@ -221,7 +221,7 @@ export const IndexScreen = ({ navigation }) => {
 
   const refresh = async (refetch) => {
     setRefreshing(true);
-    isConnected && await refetch();
+    isConnected && (await refetch());
     setRefreshing(false);
   };
 


### PR DESCRIPTION
feat(TextListItem): first attempt to show alternative list
- in TextListItem using leftIcon from react-native-elements to render a small image on the left
  - style is just for testing, definitiv image size will come afterwords
- in HomeScreen trying to get image url, which is currently undefined

SVA-61

feat(TextList leftPhoto) now visible on News text list

- in TextList leftIcon it's for now always there
 - it wasn't imported properly before , it requires to be value of uri
 - increased size a bit for fitting title and subtitle height
 - later a proper aspect ratio logic can be implemented in imageHelper
- Home screen getting picture data for News and Events
 -  Events are not jet showing an image , on terminal I get "true" instead of the url
- implemented picture data for news case in Index screen as well

SVA- 61

feat(TextList leftPhoto) present in events …

- textListItem as a dummy boolean to test a conditional rendering of leftIcon
- implemented picture in index screen for events as well
- getting picture data for events
  - just a loading spinner is visible and warning " uri.lastIndexOf' is undefined "
- Index screen testing switch of list type for news (for example)

SVA-61

feat(alternative lists): renaming properties

- in CardList renamed all the properties image to picture.url , category to subtitle and name to title
  - same in home and index screen with additional  url property for picture
- in home screen for eventRecord mediaContents is not index 0
  - still getting same warning " uri.lastIndexOf' is undefined "

SVA-61

feat(alternative lists): using mainImageOfMediaContents for eventRecord

- mainImageOfMediaContents is used where we need to get picture dato for events
  - this method is getting images[0].sourceUrl.url which is what is necessary to pass to leftIcon on textList in order to see the picture
- picture is now visible for events as well
- updated correct properties for POI

SVA-61
