### PR TITLE
combine settings and matomo

### DIFF
--- a/App.js
+++ b/App.js
@@ -11,9 +11,9 @@ const AppWithFonts = () => {
   const [fontLoaded, setFontLoaded] = useState(false);
   const { trackAppStart } = useMatomo();
 
-  trackAppStart();
-
   useEffect(() => {
+    trackAppStart();
+
     Font.loadAsync({
       'titillium-web-bold': require('./assets/fonts/TitilliumWeb-Bold.ttf'),
       'titillium-web-bold-italic': require('./assets/fonts/TitilliumWeb-BoldItalic.ttf'),

--- a/src/components/ToggleListItem.js
+++ b/src/components/ToggleListItem.js
@@ -16,15 +16,15 @@ export const ToggleListItem = ({ item, index, section }) => {
   const [loading, setLoading] = useState(false);
   const [switchValue, setSwitchValue] = useState(value);
 
-  const toggleSwitch = async (newSwitchValue) => {
+  const toggleSwitch = (newSwitchValue) => {
     setLoading(true);
 
     setSwitchValue(newSwitchValue);
 
     if (newSwitchValue && onActivate) {
-      await onActivate(() => setSwitchValue(false));
+      onActivate(() => setSwitchValue(false));
     } else if (!newSwitchValue && onDeactivate) {
-      await onDeactivate(() => setSwitchValue(true));
+      onDeactivate(() => setSwitchValue(true));
     }
 
     // imitate a short duration of toggling taking action

--- a/src/config/consts.js
+++ b/src/config/consts.js
@@ -33,7 +33,8 @@ export const consts = {
       WEB: 'Web',
       FEEDBACK: 'Feedback',
       HTML: 'Content',
-      MORE: 'More'
+      MORE: 'More',
+      SETTINGS: 'Settings'
     }
   },
 

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -57,8 +57,7 @@ export const texts = {
     }
   },
   settingsScreen: {
-    intro:
-      'Enim veniam exercitation elit excepteur ullamco dolore nisi sit ad irure cillum ut velit nulla. Dolore ex consequat id ex magna amet nostrud tempor cupidatat laboris est voluptate.'
+    intro: ''
   },
   settingsTitles: {
     analytics: 'Matomo Analytics',

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -50,10 +50,12 @@ export const texts = {
   },
   settingsContents: {
     analytics: {
+      no: 'Nein',
       onActivate:
         'Soll Matomo Analytics aktiviert werden? Dies trägt zur Verbesserung der App bei. Matomo Analytics wird nach der Aktivierung mit dem nächsten Neustart der App wirksam.',
       onDeactivate:
-        'Soll Matomo Analytics deaktiviert werden? Die Deaktivierung von Matomo Analytics wird mit dem nächsten Neustart der App wirksam.'
+        'Soll Matomo Analytics deaktiviert werden? Die Deaktivierung von Matomo Analytics wird mit dem nächsten Neustart der App wirksam.',
+      yes: 'Ja'
     }
   },
   settingsScreen: {

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -48,6 +48,14 @@ export const texts = {
     about: appJson.expo.name,
     settings: 'Einstellungen'
   },
+  settingsContents: {
+    analytics: {
+      onActivate:
+        'Soll Matomo Analytics aktiviert werden? Dies trägt zur Verbesserung der App bei. Matomo Analytics wird nach der Aktivierung mit dem nächsten Neustart der App wirksam.',
+      onDeactivate:
+        'Soll Matomo Analytics deaktiviert werden? Die Deaktivierung von Matomo Analytics wird mit dem nächsten Neustart der App wirksam.'
+    }
+  },
   settingsScreen: {
     intro:
       'Enim veniam exercitation elit excepteur ullamco dolore nisi sit ad irure cillum ut velit nulla. Dolore ex consequat id ex magna amet nostrud tempor cupidatat laboris est voluptate.'

--- a/src/helpers/matomoHelper.js
+++ b/src/helpers/matomoHelper.js
@@ -27,6 +27,9 @@ export const matomoSettings = async () => {
   return settings;
 };
 
+/**
+ * Create a Matomo user id and add the consent to be tracked.
+ */
 export const createMatomoUserId = async () => {
   const settings = await storageHelper.matomoSettings();
 
@@ -37,12 +40,28 @@ export const createMatomoUserId = async () => {
   }
 };
 
+/**
+ * Remove a Matomo user id and the consent to be tracked.
+ */
 export const removeMatomoUserId = async () => {
   const settings = await storageHelper.matomoSettings();
 
   if (settings && settings.userId) {
     delete settings.userId;
     settings.consent = false;
+    storageHelper.setMatomoSettings(settings);
+  }
+};
+
+/**
+ * Save the user interaction with the Matomo alert on app startup, because the alert should only
+ * be shown once.
+ */
+export const setMatomoHandledOnStartup = async () => {
+  const settings = await storageHelper.matomoSettings();
+
+  if (settings) {
+    settings.matomoHandledOnStartup = true;
     storageHelper.setMatomoSettings(settings);
   }
 };

--- a/src/helpers/matomoHelper.js
+++ b/src/helpers/matomoHelper.js
@@ -28,19 +28,21 @@ export const matomoSettings = async () => {
 };
 
 export const createMatomoUserId = async () => {
-  let settings = await storageHelper.matomoSettings();
+  const settings = await storageHelper.matomoSettings();
 
   if (settings) {
     settings.userId = uuid();
+    settings.consent = true;
     storageHelper.setMatomoSettings(settings);
   }
 };
 
 export const removeMatomoUserId = async () => {
-  let settings = await storageHelper.matomoSettings();
+  const settings = await storageHelper.matomoSettings();
 
   if (settings && settings.userId) {
     delete settings.userId;
+    settings.consent = false;
     storageHelper.setMatomoSettings(settings);
   }
 };

--- a/src/hooks/matomoHooks.js
+++ b/src/hooks/matomoHooks.js
@@ -1,7 +1,10 @@
 import { useContext, useEffect } from 'react';
 import { useMatomo } from 'matomo-tracker-react-native';
 
+import { texts } from '../config';
 import { NetworkContext } from '../NetworkProvider';
+import { createMatomoUserId, setMatomoHandledOnStartup, storageHelper } from '../helpers';
+import { Alert } from 'react-native';
 
 /**
  * Tracks screen view as action with prefixed 'Screen' category on mounting the component, which
@@ -17,5 +20,35 @@ export const useMatomoTrackScreenView = (name) => {
 
   useEffect(() => {
     isConnected && trackScreenView(name);
+  }, []);
+};
+
+export const useMatomoAlertOnStartUp = () => {
+  useEffect(() => {
+    const showMatomoAlert = async () => {
+      const settings = await storageHelper.matomoSettings();
+
+      if (!settings.matomoHandledOnStartup) {
+        Alert.alert(
+          texts.settingsTitles.analytics,
+          texts.settingsContents.analytics.onActivate,
+          [
+            {
+              text: texts.settingsContents.analytics.no,
+              style: 'cancel'
+            },
+            {
+              text: texts.settingsContents.analytics.yes,
+              onPress: createMatomoUserId
+            }
+          ],
+          { cancelable: false }
+        );
+
+        setMatomoHandledOnStartup();
+      }
+    };
+
+    showMatomoAlert();
   }, []);
 };

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -45,7 +45,7 @@ import {
   shareMessage,
   subtitle
 } from '../helpers';
-import { useMatomoTrackScreenView } from '../hooks';
+import { useMatomoAlertOnStartUp, useMatomoTrackScreenView } from '../hooks';
 
 const { DRAWER, LIST_TYPES, MATOMO_TRACKING } = consts;
 
@@ -82,6 +82,7 @@ export const HomeScreen = ({ navigation }) => {
   } = sections;
   const [refreshing, setRefreshing] = useState(false);
 
+  useMatomoAlertOnStartUp();
   useMatomoTrackScreenView(MATOMO_TRACKING.SCREEN_VIEW.HOME);
 
   useEffect(() => {

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -98,7 +98,7 @@ export const SettingsScreen = () => {
                     [
                       {
                         text: 'Nein',
-                        onPress: () => revert(),
+                        onPress: revert,
                         style: 'cancel'
                       },
                       { text: 'Ja', onPress: createMatomoUserId }
@@ -114,7 +114,7 @@ export const SettingsScreen = () => {
                     [
                       {
                         text: 'Nein',
-                        onPress: () => revert(),
+                        onPress: revert,
                         style: 'cancel'
                       },
                       { text: 'Ja', onPress: removeMatomoUserId }

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -2,7 +2,7 @@ import React, { useContext, useState } from 'react';
 import { RefreshControl, SectionList, StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { OrientationContext } from '../OrientationProvider';
-import { colors, device, normalize, texts } from '../config';
+import { colors, consts, device, normalize, texts } from '../config';
 import {
   Icon,
   RegularText,
@@ -18,6 +18,9 @@ import { arrowLeft } from '../icons';
 import { QUERY_TYPES } from '../queries';
 import { SettingsContext } from '../SettingsProvider';
 import { storageHelper } from '../helpers';
+import { useMatomoTrackScreenView } from '../hooks';
+
+const { MATOMO_TRACKING } = consts;
 
 const keyExtractor = (item, index) => `index${index}-id${item.id}`;
 
@@ -42,6 +45,8 @@ export const SettingsScreen = () => {
   const { orientation, dimensions } = useContext(OrientationContext);
   const { listTypesSettings, setListTypesSettings } = useContext(SettingsContext);
   const [refreshing, setRefreshing] = useState(false);
+
+  useMatomoTrackScreenView(MATOMO_TRACKING.SCREEN_VIEW.SETTINGS);
 
   const refresh = () => {
     setRefreshing(true);

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import {
+  ActivityIndicator,
   Alert,
   RefreshControl,
   SectionList,
@@ -13,6 +14,7 @@ import { SettingsContext } from '../SettingsProvider';
 import { colors, consts, device, normalize, texts } from '../config';
 import {
   Icon,
+  LoadingContainer,
   RegularText,
   SafeAreaViewFlex,
   SettingsListItem,
@@ -52,19 +54,7 @@ export const SettingsScreen = () => {
   const { orientation, dimensions } = useContext(OrientationContext);
   const { globalSettings, listTypesSettings, setListTypesSettings } = useContext(SettingsContext);
   const [refreshing, setRefreshing] = useState(false);
-  // settings should always contain push notifications
-  const [sectionedData, setSectionedData] = useState([
-    {
-      data: [
-        {
-          title: texts.settingsTitles.pushNotifications,
-          topDivider: true,
-          type: 'toggle',
-          value: false
-        }
-      ]
-    }
-  ]);
+  const [sectionedData, setSectionedData] = useState([]);
 
   useMatomoTrackScreenView(MATOMO_TRACKING.SCREEN_VIEW.SETTINGS);
 
@@ -86,8 +76,19 @@ export const SettingsScreen = () => {
       const { consent: matomoValue } = await storageHelper.matomoSettings();
 
       setSectionedData((initialSectionedData) => {
-        const additionalSectionedData = [];
-
+        // settings should always contain push notifications
+        const additionalSectionedData = [
+          {
+            data: [
+              {
+                title: texts.settingsTitles.pushNotifications,
+                topDivider: true,
+                type: 'toggle',
+                value: false
+              }
+            ]
+          }
+        ];
         // settings should sometimes contain matomo analytics next, depending on server settings
         if (settings.matomo) {
           additionalSectionedData.push({
@@ -179,6 +180,14 @@ export const SettingsScreen = () => {
       setRefreshing(false);
     }, 500);
   };
+
+  if (!sectionedData.length) {
+    return (
+      <LoadingContainer>
+        <ActivityIndicator color={colors.accent} />
+      </LoadingContainer>
+    );
+  }
 
   return (
     <SafeAreaViewFlex>

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -103,11 +103,14 @@ export const SettingsScreen = () => {
                     texts.settingsContents.analytics.onActivate,
                     [
                       {
-                        text: 'Nein',
+                        text: texts.settingsContents.analytics.no,
                         onPress: revert,
                         style: 'cancel'
                       },
-                      { text: 'Ja', onPress: createMatomoUserId }
+                      {
+                        text: texts.settingsContents.analytics.yes,
+                        onPress: createMatomoUserId
+                      }
                     ],
                     { cancelable: false }
                   ),
@@ -117,11 +120,14 @@ export const SettingsScreen = () => {
                     texts.settingsContents.analytics.onDeactivate,
                     [
                       {
-                        text: 'Nein',
+                        text: texts.settingsContents.analytics.no,
                         onPress: revert,
                         style: 'cancel'
                       },
-                      { text: 'Ja', onPress: removeMatomoUserId }
+                      {
+                        text: texts.settingsContents.analytics.yes,
+                        onPress: removeMatomoUserId
+                      }
                     ],
                     { cancelable: false }
                   )


### PR DESCRIPTION
This PR is a first version of combining Matomo analytics with the settings screen.
When toggling the switch for Matomo an Alert is asking the user and pointing out, that an app restart is necessary for changes to take effect.

For testing locally, the `__DEV__` const needs to be removed or inverted to `!__DEV__` in App.js.

activation alert | deactivation alert
-------------- | --------------
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-11-24 at 19 34 50](https://user-images.githubusercontent.com/1942953/100137064-2ec69f00-2e8c-11eb-9ade-6a68c1d0b4b2.png) |  ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-11-24 at 19 34 43](https://user-images.githubusercontent.com/1942953/100137072-325a2600-2e8c-11eb-8d15-19bc75f093e9.png)

Also added tracking of navigation to the settings screen.