### PR TITLE
fix(detail screen): share icon for ios 

### DIFF
--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -12,7 +12,7 @@ import { Query } from 'react-apollo';
 
 import { NetworkContext } from '../NetworkProvider';
 import { auth } from '../auth';
-import { colors, consts, normalize } from '../config';
+import { colors, consts, device, normalize } from '../config';
 import {
   EventRecord,
   Icon,
@@ -165,10 +165,19 @@ DetailScreen.navigationOptions = ({ navigation, navigationOptions }) => {
             accessibilityLabel="Teilen Taste"
             accessibilityHint="Inhalte auf der Seite teilen"
           >
-            <Icon
-              xml={share(colors.lightestText)}
-              style={headerRight ? styles.iconLeft : styles.iconRight}
-            />
+            {device.platform === 'ios' ? (
+              <Icon
+                name="ios-share"
+                size={26}
+                iconColor={colors.lightestText}
+                style={headerRight ? styles.iconLeft : styles.iconRight}
+              />
+            ) : (
+              <Icon
+                xml={share(colors.lightestText)}
+                style={headerRight ? styles.iconLeft : styles.iconRight}
+              />
+            )}
           </TouchableOpacity>
         )}
         {!!headerRight && headerRight}


### PR DESCRIPTION
- if IOS device render font icon otherwise svg icon
- using same style logic as the icon setting
 #120

Current status of header in detail screen: 
![Image 27 11 20 at 13 32](https://user-images.githubusercontent.com/43641321/100449982-1daca680-30b5-11eb-94b8-0a7f8e52d620.jpg)
