### PR TITLE
feat(icon): dried out the logic for different devices

### DIFF
--- a/src/components/Radiobutton.js
+++ b/src/components/Radiobutton.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Platform, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { CheckBox as RNECheckbox, normalize } from 'react-native-elements';
 
-import { colors } from '../config';
+import { colors, device } from '../config';
 import { baseFontStyle } from '../config/styles/baseFontStyle';
 import { Icon } from './Icon';
 
@@ -21,10 +21,7 @@ export const Radiobutton = ({ title, disabled, selected, onPress }) => (
     ]}
     checkedIcon={
       <Icon
-        name={Platform.select({
-          android: 'md-radio-button-on',
-          ios: 'ios-radio-button-on'
-        })}
+        name={device.platform === 'ios' ? 'ios-radio-button-on' : 'md-radio-button-on'}
         size={22}
         iconColor={colors.primary}
         style={styles.rightContentContainer}
@@ -32,10 +29,7 @@ export const Radiobutton = ({ title, disabled, selected, onPress }) => (
     }
     uncheckedIcon={
       <Icon
-        name={Platform.select({
-          android: 'md-radio-button-off',
-          ios: 'ios-radio-button-off'
-        })}
+        name={device.platform === 'ios' ? 'ios-radio-button-off' : 'md-radio-button-off'}
         size={22}
         iconColor={colors.darkText}
         style={styles.rightContentContainer}

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { Fragment, useCallback, useContext, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
-  Platform,
   RefreshControl,
   ScrollView,
   StyleSheet,
@@ -493,10 +492,7 @@ HomeScreen.navigationOptions = ({ navigation, navigationOptions }) => {
           accessibilityHint="Zu den Einstellungen wechseln"
         >
           <Icon
-            name={Platform.select({
-              android: 'md-settings',
-              ios: 'ios-settings'
-            })}
+            name={device.platform === 'ios' ? 'ios-settings' : 'md-settings'}
             size={26}
             iconColor={colors.lightestText}
             style={headerRight ? styles.iconLeft : styles.iconRight}


### PR DESCRIPTION
- for better readability
- if using Platform we need to import an additional object from react native
  - which we don't need if we use just our device
  - this makes even more sense in Radiobutton where device is used multiple times in the file

(!) this change is not tested on android 