### PR TITLE
Fix: dependencies of useEffect in Image component

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -31,7 +31,7 @@ export const Image = ({ source, style, PlaceholderContent }) => {
       : mounted && setUri(source);
 
     return () => (mounted = false);
-  }, []);
+  }, [source, setUri]);
 
   if (!globalSettings.showImageRights || !source.copyright) {
     return (


### PR DESCRIPTION
## Changes proposed in this PR:

Added source and setUri to dependencies of the useEffect within the `Image` component

This change causes the `Image` component to rerender as intended