### PR TITLE
fix(matomo): no alert on startup if disabled

### DIFF
--- a/src/hooks/matomoHooks.js
+++ b/src/hooks/matomoHooks.js
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from 'react';
-import { useMatomo } from 'matomo-tracker-react-native';
+import { MatomoContext, useMatomo } from 'matomo-tracker-react-native';
 
 import { texts } from '../config';
 import { NetworkContext } from '../NetworkProvider';
@@ -24,6 +24,8 @@ export const useMatomoTrackScreenView = (name) => {
 };
 
 export const useMatomoAlertOnStartUp = () => {
+  const { disabled } = useContext(MatomoContext);
+
   useEffect(() => {
     const showMatomoAlert = async () => {
       const settings = await storageHelper.matomoSettings();
@@ -49,6 +51,6 @@ export const useMatomoAlertOnStartUp = () => {
       }
     };
 
-    showMatomoAlert();
+    !disabled && showMatomoAlert();
   }, []);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7351,9 +7351,9 @@ map-visit@^1.0.0:
     object-visit "^1.0.0"
 
 matomo-tracker-react-native@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/matomo-tracker-react-native/-/matomo-tracker-react-native-0.2.2.tgz#7b01fa9d1ebd0dda005a9d3544b33ac717453764"
-  integrity sha512-fdJWeKM52zw79eEjNriraAwx2ODIdqOg3RTAvv6YqN0pS1R9RhGjulrN88B0eGRMtI0Zu6Izr9I1mKym+/UcsA==
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/matomo-tracker-react-native/-/matomo-tracker-react-native-0.2.3.tgz#ce800bf5e31fc1099460f5c212cc54fb192edc32"
+  integrity sha512-VV1izaajMDAiEGMVdmyjvr2anqB98FycZBKhWYRLLt4T8wxL+O+bbHweHPmC41Bma/u5bHzXJPe5MSve107UfA==
 
 md5-file@^3.2.3:
   version "3.2.3"


### PR DESCRIPTION
- updated matomo-tracker-react-native to be able to use `MatomoContext`
- added condition to not show the first matomo alert on startup if matomo is disabled generally