### PR TITLE
fix(push notification): navigation on interaction

### DIFF
--- a/src/components/screens/EventRecord.js
+++ b/src/components/screens/EventRecord.js
@@ -53,12 +53,13 @@ export const EventRecord = ({ data, navigation }) => {
   } = data;
   const link = webUrls && webUrls.length && webUrls[0].url;
   const rootRouteName = navigation.getParam('rootRouteName', '');
+  const headerTitle = navigation.getParam('title', '');
   // action to open source urls
   const openWebScreen = (webUrl) =>
     navigation.navigate({
       routeName: 'Web',
       params: {
-        title: 'Veranstaltung',
+        title: headerTitle,
         webUrl: !!webUrl && typeof webUrl === 'string' ? webUrl : link,
         rootRouteName
       }

--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -51,12 +51,13 @@ export const NewsItem = ({ data, navigation }) => {
   // the title of a news item is either a given main title or the title from the first content block
   const title = mainTitle || (!!contentBlocks && !!contentBlocks.length && contentBlocks[0].title);
   const rootRouteName = navigation.getParam('rootRouteName', '');
+  const headerTitle = navigation.getParam('title', '');
   // action to open source urls
   const openWebScreen = (webUrl) =>
     navigation.navigate({
       routeName: 'Web',
       params: {
-        title: 'Nachricht',
+        title: headerTitle,
         webUrl: !!webUrl && typeof webUrl === 'string' ? webUrl : link,
         rootRouteName
       }

--- a/src/components/screens/Tour.js
+++ b/src/components/screens/Tour.js
@@ -37,12 +37,13 @@ export const Tour = ({ data, navigation }) => {
     webUrls
   } = data;
   const rootRouteName = navigation.getParam('rootRouteName', '');
+  const headerTitle = navigation.getParam('title', '');
   // action to open source urls
   const openWebScreen = (webUrl) =>
     navigation.navigate({
       routeName: 'Web',
       params: {
-        title: 'Tour',
+        title: headerTitle,
         webUrl,
         rootRouteName
       }

--- a/src/config/consts.js
+++ b/src/config/consts.js
@@ -42,5 +42,13 @@ export const consts = {
     TEXT_LIST: 'textList',
     IMAGE_TEXT_LIST: 'imageTextList',
     CARD_LIST: 'cardList'
+  },
+
+  ROOT_ROUTE_NAMES: {
+    EVENT_RECORDS: 'EventRecords',
+    NEWS_ITEMS: 'NewsItems',
+    POINTS_OF_INTEREST_AND_TOURS: 'PointsOfInterestAndTours',
+    POINTS_OF_INTEREST: 'PointsOfInterest',
+    TOURS: 'Tours'
   }
 };

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -9,6 +9,12 @@ export const texts = {
     pointsOfInterest: 'Orte',
     tours: 'Touren'
   },
+  detailTitles: {
+    eventRecord: 'Veranstaltung',
+    newsItem: 'Nachricht',
+    pointOfInterest: 'Ort',
+    tour: 'Tour'
+  },
   eventRecord: {
     appointments: 'Termine',
     description: 'Beschreibung',

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -8,6 +8,7 @@ export * from './matomoHelper';
 export * from './momentHelper';
 export * from './priceHelper';
 export * from './queryDataParser';
+export * from './queryHelper';
 export * from './refreshIntervalHelper';
 export * from './shareHelper';
 export * from './storageHelper';

--- a/src/helpers/queryDataParser.js
+++ b/src/helpers/queryDataParser.js
@@ -1,11 +1,14 @@
 import _filter from 'lodash/filter';
 
+import { consts, texts } from '../config';
 import { QUERY_TYPES } from '../queries';
 import { eventDate } from './dateTimeHelper';
 import { mainImageOfMediaContents } from './imageHelper';
 import { momentFormat } from './momentHelper';
 import { shareMessage } from './shareHelper';
 import { subtitle } from './textHelper';
+
+const { ROOT_ROUTE_NAMES } = consts;
 
 export const parseEventRecords = (data, skipLastDivider) => {
   return data?.map((eventRecord, index) => ({
@@ -20,10 +23,10 @@ export const parseEventRecords = (data, skipLastDivider) => {
     },
     routeName: 'Detail',
     params: {
-      title: 'Veranstaltung',
+      title: texts.detailTitles.eventRecord,
       query: QUERY_TYPES.EVENT_RECORD,
       queryVariables: { id: `${eventRecord.id}` },
-      rootRouteName: 'EventRecords',
+      rootRouteName: ROOT_ROUTE_NAMES.EVENT_RECORDS,
       shareContent: {
         message: shareMessage(eventRecord, QUERY_TYPES.EVENT_RECORD)
       },
@@ -52,7 +55,7 @@ export const parseNewsItems = (data, skipLastDivider, titleDetail) => {
       title: titleDetail,
       query: QUERY_TYPES.NEWS_ITEM,
       queryVariables: { id: `${newsItem.id}` },
-      rootRouteName: 'NewsItems',
+      rootRouteName: ROOT_ROUTE_NAMES.NEWS_ITEMS,
       shareContent: {
         message: shareMessage(newsItem, QUERY_TYPES.NEWS_ITEM)
       },
@@ -72,10 +75,10 @@ export const parsePointOfInterest = (data, skipLastDivider) => {
     },
     routeName: 'Detail',
     params: {
-      title: 'Ort',
+      title: texts.detailTitles.pointOfInterest,
       query: QUERY_TYPES.POINT_OF_INTEREST,
       queryVariables: { id: `${pointOfInterest.id}` },
-      rootRouteName: 'PointsOfInterest',
+      rootRouteName: ROOT_ROUTE_NAMES.POINTS_OF_INTEREST_AND_TOURS,
       shareContent: {
         message: shareMessage(pointOfInterest, QUERY_TYPES.POINT_OF_INTEREST)
       },
@@ -98,10 +101,10 @@ export const parseTours = (data, skipLastDivider) => {
     },
     routeName: 'Detail',
     params: {
-      title: 'Tour',
+      title: texts.detailTitles.tour,
       query: QUERY_TYPES.TOUR,
       queryVariables: { id: `${tour.id}` },
-      rootRouteName: 'Tours',
+      rootRouteName: ROOT_ROUTE_NAMES.POINTS_OF_INTEREST_AND_TOURS,
       shareContent: {
         message: shareMessage(tour, QUERY_TYPES.TOUR)
       },
@@ -126,7 +129,7 @@ const parseCategories = (data, skipLastDivider) => {
       query:
         category.pointsOfInterestCount > 0 ? QUERY_TYPES.POINTS_OF_INTEREST : QUERY_TYPES.TOURS,
       queryVariables: { limit: 15, order: 'name_ASC', category: `${category.name}` },
-      rootRouteName: category.pointsOfInterestCount > 0 ? 'PointsOfInterest' : 'Tours'
+      rootRouteName: ROOT_ROUTE_NAMES.POINTS_OF_INTEREST_AND_TOURS
     },
     bottomDivider: skipLastDivider && index !== data.length - 1
   }));

--- a/src/helpers/queryHelper.js
+++ b/src/helpers/queryHelper.js
@@ -1,0 +1,19 @@
+import { consts } from '../config';
+import { QUERY_TYPES } from '../queries';
+
+const { ROOT_ROUTE_NAMES } = consts;
+
+/**
+ * Determines the root route name for data based on its query.
+ *
+ * @param {string} query query key for the data type
+ *
+ * @return {string} a root route representation for a query type
+ */
+export const rootRouteName = (query) =>
+  ({
+    [QUERY_TYPES.EVENT_RECORD]: ROOT_ROUTE_NAMES.EVENT_RECORDS,
+    [QUERY_TYPES.NEWS_ITEM]: ROOT_ROUTE_NAMES.NEWS_ITEMS,
+    [QUERY_TYPES.POINT_OF_INTEREST]: ROOT_ROUTE_NAMES.POINTS_OF_INTEREST_AND_TOURS,
+    [QUERY_TYPES.TOUR]: ROOT_ROUTE_NAMES.POINTS_OF_INTEREST_AND_TOURS
+  }[query]);

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -80,7 +80,7 @@ export const HomeScreen = ({ navigation }) => {
         navigation.navigate({
           routeName: 'Detail',
           params: {
-            query: QUERY_TYPES.NEWS_ITEM,
+            query: queryType,
             queryVariables: { id: data.id }
           }
         });

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -37,12 +37,13 @@ import {
   parseEventRecords,
   parseNewsItems,
   parsePointOfInterest,
-  parseTours
+  parseTours,
+  rootRouteName
 } from '../helpers';
 import { useMatomoAlertOnStartUp, useMatomoTrackScreenView, usePushNotifications } from '../hooks';
 import { getQuery, getQueryType, QUERY_TYPES } from '../queries';
 
-const { DRAWER, LIST_TYPES, MATOMO_TRACKING } = consts;
+const { DRAWER, LIST_TYPES, MATOMO_TRACKING, ROOT_ROUTE_NAMES } = consts;
 
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
@@ -80,8 +81,12 @@ export const HomeScreen = ({ navigation }) => {
         navigation.navigate({
           routeName: 'Detail',
           params: {
+            title: texts.detailTitles[queryType],
             query: queryType,
-            queryVariables: { id: data.id }
+            queryVariables: { id: data.id },
+            rootRouteName: rootRouteName(queryType),
+            shareContent: null,
+            details: null
           }
         });
       }
@@ -116,7 +121,7 @@ export const HomeScreen = ({ navigation }) => {
         title: 'Touren und Orte',
         query: QUERY_TYPES.CATEGORIES,
         queryVariables: {},
-        rootRouteName: 'PointsOfInterestAndTours'
+        rootRouteName: ROOT_ROUTE_NAMES.POINTS_OF_INTEREST_AND_TOURS
       }
     },
     EVENT_RECORDS_INDEX: {
@@ -125,7 +130,7 @@ export const HomeScreen = ({ navigation }) => {
         title: 'Veranstaltungen',
         query: QUERY_TYPES.EVENT_RECORDS,
         queryVariables: { limit: 15, order: 'listDate_ASC' },
-        rootRouteName: 'EventRecords'
+        rootRouteName: ROOT_ROUTE_NAMES.EVENT_RECORDS
       }
     },
     NEWS_ITEMS_INDEX: ({ categoryId, categoryTitle, categoryTitleDetail }) => ({
@@ -135,7 +140,7 @@ export const HomeScreen = ({ navigation }) => {
         titleDetail: categoryTitleDetail,
         query: QUERY_TYPES.NEWS_ITEMS,
         queryVariables: { limit: 15, ...{ categoryId } },
-        rootRouteName: 'NewsItems'
+        rootRouteName: ROOT_ROUTE_NAMES.NEWS_ITEMS
       }
     })
   };


### PR DESCRIPTION
## Changes proposed in this PR:

previously we always used `QUERY_TYPES.NEWS_ITEM` for the navigation triggered by a push notification.

This can cause errors if push notifications for other item types are sent out.
