### PR TITLE
fix(parsing public json content): catch errors on JSON.parse

### DIFF
--- a/src/components/screens/About.js
+++ b/src/components/screens/About.js
@@ -40,8 +40,13 @@ export const About = ({ navigation, refreshing }) => {
         if (refreshing) refetch();
         if (loading) return null;
 
-        let publicJsonFileContent =
-          data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
+        let publicJsonFileContent = [];
+
+        try {
+          publicJsonFileContent = JSON.parse(data?.publicJsonFile?.content);
+        } catch (error) {
+          console.warn(error, data);
+        }
 
         if (!publicJsonFileContent || !publicJsonFileContent.length) return null;
 

--- a/src/components/screens/HomeCarousel.js
+++ b/src/components/screens/HomeCarousel.js
@@ -49,9 +49,15 @@ export const HomeCarousel = ({ navigation, refreshing }) => {
           );
         }
 
-        let carouselImages = data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
+        let carouselImages = [];
 
-        if (!carouselImages) return null;
+        try {
+          carouselImages = JSON.parse(data?.publicJsonFile?.content);
+        } catch (error) {
+          console.warn(error, data);
+        }
+
+        if (!carouselImages || !carouselImages.length) return null;
 
         return (
           <ImagesCarousel

--- a/src/components/screens/Service.js
+++ b/src/components/screens/Service.js
@@ -47,8 +47,13 @@ export const Service = ({ navigation, refreshing }) => {
         if (refreshing) refetch();
         if (loading) return null;
 
-        let publicJsonFileContent =
-          data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
+        let publicJsonFileContent = [];
+
+        try {
+          publicJsonFileContent = JSON.parse(data?.publicJsonFile?.content);
+        } catch (error) {
+          console.warn(error, data);
+        }
 
         if (!publicJsonFileContent || !publicJsonFileContent.length) return null;
 

--- a/src/index.js
+++ b/src/index.js
@@ -175,10 +175,13 @@ const MainAppWithApolloProvider = () => {
       }
     }
 
-    const globalSettingsPublicJsonFileContent =
-      globalSettingsData &&
-      globalSettingsData.publicJsonFile &&
-      JSON.parse(globalSettingsData.publicJsonFile.content);
+    let globalSettingsPublicJsonFileContent = [];
+
+    try {
+      globalSettingsPublicJsonFileContent = JSON.parse(globalSettingsData?.publicJsonFile?.content);
+    } catch (error) {
+      console.warn(error, globalSettingsData);
+    }
 
     if (!_isEmpty(globalSettingsPublicJsonFileContent)) {
       globalSettings = globalSettingsPublicJsonFileContent;
@@ -212,10 +215,13 @@ const MainAppWithApolloProvider = () => {
         console.warn('errors', errors);
       }
 
-      let navigationPublicJsonFileContent =
-        navigationData &&
-        navigationData.publicJsonFile &&
-        JSON.parse(navigationData.publicJsonFile.content);
+      let navigationPublicJsonFileContent = [];
+
+      try {
+        navigationPublicJsonFileContent = JSON.parse(navigationData?.publicJsonFile?.content);
+      } catch (error) {
+        console.warn(error, navigationData);
+      }
 
       if (!_isEmpty(navigationPublicJsonFileContent)) {
         setDrawerRoutes(

--- a/src/screens/AboutScreen.js
+++ b/src/screens/AboutScreen.js
@@ -68,8 +68,13 @@ export const AboutScreen = ({ navigation }) => {
             );
           }
 
-          let publicJsonFileContent =
-            data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
+          let publicJsonFileContent = [];
+
+          try {
+            publicJsonFileContent = JSON.parse(data?.publicJsonFile?.content);
+          } catch (error) {
+            console.warn(error, data);
+          }
 
           if (!publicJsonFileContent || !publicJsonFileContent.length) return <VersionNumber />;
 

--- a/src/screens/CompanyScreen.js
+++ b/src/screens/CompanyScreen.js
@@ -80,8 +80,13 @@ export const CompanyScreen = ({ navigation }) => {
             );
           }
 
-          let publicJsonFileContent =
-            data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
+          let publicJsonFileContent = [];
+
+          try {
+            publicJsonFileContent = JSON.parse(data?.publicJsonFile?.content);
+          } catch (error) {
+            console.warn(error, data);
+          }
 
           if (!publicJsonFileContent || !publicJsonFileContent.length) return null;
 

--- a/src/screens/ServiceScreen.js
+++ b/src/screens/ServiceScreen.js
@@ -80,8 +80,13 @@ export const ServiceScreen = ({ navigation }) => {
             );
           }
 
-          let publicJsonFileContent =
-            data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
+          let publicJsonFileContent = [];
+
+          try {
+            publicJsonFileContent = JSON.parse(data?.publicJsonFile?.content);
+          } catch (error) {
+            console.warn(error, data);
+          }
 
           if (!publicJsonFileContent || !publicJsonFileContent.length) return null;
 


### PR DESCRIPTION
- added try/catch for every `JSON.parse` of random public json content from main server, which can have format issues, to ensure that the app does not crash
- used optional chaining to reduce possibilities of types for the returned value
  - if one of `data` or `data.publicJsonFile` or `data.publicJsonFile.content` is undefined, `JSON.parse` errors with a SyntaxError as well and we land in the catch -> main variable stays `[]`

SVA-133