### PR TITLE
fix(map): hide POI map in offline

### DIFF
--- a/src/components/map/LocationOverview.tsx
+++ b/src/components/map/LocationOverview.tsx
@@ -50,12 +50,13 @@ export const LocationOverview = ({ navigation, category }: Props) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const [selectedPointOfInterest, setSelectedPointOfInterest] = useState<string>();
 
-  const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp, refreshTime: undefined});
+  const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp, refreshTime: undefined });
 
   const overviewQuery = getQuery(QUERY_TYPES.POINTS_OF_INTEREST);
-  const { data: overviewData, loading } = useQuery(
-    overviewQuery, { fetchPolicy, variables: { category } }
-  );
+  const { data: overviewData, loading } = useQuery(overviewQuery, {
+    fetchPolicy,
+    variables: { category }
+  });
 
   const detailsQuery = getQuery(QUERY_TYPES.POINT_OF_INTEREST);
   const { data: detailsData, loading: detailsLoading } = useQuery(detailsQuery, {

--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -18,12 +18,14 @@ import { useMatomoTrackScreenView } from '../../hooks';
 import { matomoTrackingString } from '../../helpers';
 import { WebViewMap } from '../map/WebViewMap';
 import { location, locationIconAnchor } from '../../icons';
+import { NetworkContext } from '../../NetworkProvider';
 
 const { MATOMO_TRACKING } = consts;
 
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const PointOfInterest = ({ data, hideMap, navigation }) => {
+  const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const { orientation, dimensions } = useContext(OrientationContext);
   const {
     addresses,
@@ -148,7 +150,18 @@ export const PointOfInterest = ({ data, hideMap, navigation }) => {
           </View>
         )}
 
-        {!hideMap && !!latitude && !!longitude && (
+        {/* There are several connection states that can happen
+         * a) We are connected to a wifi and our mainserver is up (and reachable)
+         *   a.1) OSM is reachable -> everything is fine
+         *   a.2) OSM is not reachable -> white rectangle is shown
+         * b) We are connected to a wifi and our mainserver is not reachable
+         *   b.1) OSM is reachable -> we don't know and do not show the map for the cached data
+         *   b.2) OSM is not reachable -> everything is fine
+         *
+         * we can also not check for isMainserverUp here, but then we would only verify that we are
+         * connected to a network with no information of internet connectivity.
+         */}
+        {!hideMap && !!latitude && !!longitude && isConnected && isMainserverUp && (
           <View>
             <TitleContainer>
               <Title accessibilityLabel={`${texts.pointOfInterest.location} (Überschrift)`}>


### PR DESCRIPTION
## Changes proposed in this PR:

- linting changes in LocationOverview.tsx
- hide the map for pois in offline mode, to prevent rendering a white rectangle

