### PR TITLE
customizable image component format

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
-import { ActivityIndicator, View } from 'react-native';
+import { ActivityIndicator, StyleSheet } from 'react-native';
 import { CacheManager } from 'react-native-expo-image-cache';
 import { Image as RNEImage } from 'react-native-elements';
 
@@ -33,33 +33,37 @@ export const Image = ({ source, style, PlaceholderContent }) => {
     return () => (mounted = false);
   }, [source, setUri]);
 
-  if (!globalSettings.showImageRights || !source.copyright) {
-    return (
-      <RNEImage
-        source={uri ? (source.uri ? { uri } : uri) : null}
-        style={style}
-        PlaceholderContent={PlaceholderContent}
-        placeholderStyle={{ backgroundColor: colors.transparent }}
-        accessible={!!source.captionText}
-        accessibilityLabel={source.captionText}
-      />
-    );
-  }
-
   return (
-    <View>
+    <>
       <RNEImage
         source={uri ? (source.uri ? { uri } : uri) : null}
-        style={style}
+        style={style || stylesForImage().defaultStyle}
         PlaceholderContent={PlaceholderContent}
         placeholderStyle={{ backgroundColor: colors.transparent }}
-        accessible={!!source.captionText}
-        accessibilityLabel={source.captionText}
+        accessible={!!source?.captionText}
+        accessibilityLabel={source?.captionText}
       />
-      <ImageRights imageRights={source.copyright} />
-    </View>
+      {globalSettings?.showImageRights && source?.copyright && (
+        <ImageRights imageRights={source.copyright} />
+      )}
+    </>
   );
 };
+
+/* eslint-disable react-native/no-unused-styles */
+/* this works properly, we do not want that eslint warning */
+// we need to call the default styles in a method to ensure correct defaults for image aspect ratio,
+// which could be overwritten bei server global settings. otherwise (as default prop) the style
+// would be set before the overwriting occurred.
+const stylesForImage = () =>
+  StyleSheet.create({
+    defaultStyle: {
+      alignSelf: 'center',
+      height: imageHeight(imageWidth()),
+      width: imageWidth()
+    }
+  });
+/* eslint-enable react-native/no-unused-styles */
 
 Image.propTypes = {
   source: PropTypes.oneOfType([PropTypes.object, PropTypes.number]).isRequired,
@@ -68,10 +72,5 @@ Image.propTypes = {
 };
 
 Image.defaultProps = {
-  style: {
-    alignSelf: 'center',
-    height: imageHeight(imageWidth()),
-    width: imageWidth()
-  },
   PlaceholderContent: <ActivityIndicator color={colors.accent} />
 };

--- a/src/components/ImagesCarousel.js
+++ b/src/components/ImagesCarousel.js
@@ -35,7 +35,7 @@ TouchableImage.propTypes = {
   children: PropTypes.object.isRequired
 };
 
-export const ImagesCarousel = ({ data, navigation, fetchPolicy }) => {
+export const ImagesCarousel = ({ data, navigation, fetchPolicy, aspectRatio }) => {
   const { orientation, dimensions } = useContext(OrientationContext);
 
   // special image width for carousel, to be not full width on landscape
@@ -86,7 +86,10 @@ export const ImagesCarousel = ({ data, navigation, fetchPolicy }) => {
 
               return (
                 <TouchableImage navigation={navigation} item={item}>
-                  <Image source={item.picture} style={stylesForImage(itemWidth).size} />
+                  <Image
+                    source={item.picture}
+                    style={stylesForImage(itemWidth, aspectRatio).size}
+                  />
                 </TouchableImage>
               );
             }}
@@ -95,12 +98,12 @@ export const ImagesCarousel = ({ data, navigation, fetchPolicy }) => {
       } else {
         return (
           <TouchableImage navigation={navigation} item={item}>
-            <Image source={item.picture} style={stylesForImage(itemWidth).size} />
+            <Image source={item.picture} style={stylesForImage(itemWidth, aspectRatio).size} />
           </TouchableImage>
         );
       }
     } else {
-      return <Image source={item.picture} style={stylesForImage(itemWidth).size} />;
+      return <Image source={item.picture} style={stylesForImage(itemWidth, aspectRatio).size} />;
     }
   };
 
@@ -127,11 +130,11 @@ const styles = StyleSheet.create({
 });
 
 /* eslint-disable react-native/no-unused-styles */
-/* this works properly, we do not want that warning */
-const stylesForImage = (width) =>
+/* this works properly, we do not want that eslint warning */
+const stylesForImage = (width, aspectRatio) =>
   StyleSheet.create({
     size: {
-      height: imageHeight(width),
+      height: imageHeight(width, aspectRatio),
       width
     }
   });
@@ -140,5 +143,6 @@ const stylesForImage = (width) =>
 ImagesCarousel.propTypes = {
   data: PropTypes.array.isRequired,
   navigation: PropTypes.object,
-  fetchPolicy: PropTypes.string
+  fetchPolicy: PropTypes.string,
+  aspectRatio: PropTypes.object
 };

--- a/src/components/map/WebViewMap.tsx
+++ b/src/components/map/WebViewMap.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback } from 'react';
-import { Dimensions, StyleProp, View, ViewStyle } from 'react-native';
+import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 import { MapMarker, WebViewLeaflet, WebviewLeafletMessage } from 'react-native-webview-leaflet';
 
 import { colors } from '../../config';
+import { imageHeight, imageWidth } from '../../helpers';
 
 type Props = {
   locations?: MapMarker[];
@@ -30,7 +31,7 @@ export const WebViewMap = ({
   );
 
   return (
-    <View style={style}>
+    <View style={style || stylesForMap().defaultStyle}>
       <WebViewLeaflet
         backgroundColor={colors.lightestText}
         onMessageReceived={messageHandler}
@@ -50,15 +51,18 @@ export const WebViewMap = ({
   );
 };
 
-// this will only be set at the start of the app, so this will be the width of portrait mode
-// needs to be done due to react native 0.63 bug for android
-// https://github.com/facebook/react-native/issues/29451
-const width = Dimensions.get('window').width;
-
-WebViewMap.defaultProps = {
-  style: {
-    alignSelf: 'center',
-    height: (9 / 16) * width,
-    width
-  }
-};
+/* eslint-disable react-native/no-unused-styles */
+/* this works properly, we do not want that eslint warning */
+// the map should have the same aspect ratio as images.
+// we need to call the default styles in a method to ensure correct defaults for image aspect ratio,
+// which could be overwritten bei server global settings. otherwise (as default prop) the style
+// would be set before the overwriting occurred.
+const stylesForMap = () =>
+  StyleSheet.create({
+    defaultStyle: {
+      alignSelf: 'center',
+      height: imageHeight(imageWidth()),
+      width: imageWidth()
+    }
+  });
+/* eslint-enable react-native/no-unused-styles */

--- a/src/components/screens/HomeCarousel.js
+++ b/src/components/screens/HomeCarousel.js
@@ -5,15 +5,17 @@ import { Query } from 'react-apollo';
 import _shuffle from 'lodash/shuffle';
 
 import { NetworkContext } from '../../NetworkProvider';
+import { SettingsContext } from '../../SettingsProvider';
 import { colors } from '../../config';
 import { ImagesCarousel } from '../ImagesCarousel';
 import { LoadingContainer } from '../LoadingContainer';
 import { getQuery, QUERY_TYPES } from '../../queries';
-import { graphqlFetchPolicy } from '../../helpers';
+import { graphqlFetchPolicy, parsedImageAspectRatio } from '../../helpers';
 import { useRefreshTime } from '../../hooks';
 
 export const HomeCarousel = ({ navigation, refreshing }) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
+  const { globalSettings } = useContext(SettingsContext);
 
   const refreshTime = useRefreshTime('publicJsonFile-homeCarousel');
 
@@ -64,6 +66,7 @@ export const HomeCarousel = ({ navigation, refreshing }) => {
             navigation={navigation}
             data={_shuffle(carouselImages)}
             fetchPolicy={fetchPolicy}
+            aspectRatio={parsedImageAspectRatio(globalSettings?.homeCarousel?.imageAspectRatio)}
           />
         );
       }}

--- a/src/config/consts.js
+++ b/src/config/consts.js
@@ -25,6 +25,12 @@ export const consts = {
     FULL_SCREEN_MAX_WIDTH: 414
   },
 
+  IMAGE_ASPECT_RATIO: {
+    // default image aspect ratio is 2:1
+    HEIGHT: 1,
+    WIDTH: 2
+  },
+
   MATOMO_TRACKING: {
     SCREEN_VIEW: {
       BOOKMARK_CATEGORY: 'Bookmark category',

--- a/src/config/consts.js
+++ b/src/config/consts.js
@@ -25,6 +25,8 @@ export const consts = {
     FULL_SCREEN_MAX_WIDTH: 414
   },
 
+  // the image aspect ratio can be overwritten by a global setting `imageAspectRatio`
+  // from the server in src/index.js
   IMAGE_ASPECT_RATIO: {
     // default image aspect ratio is 2:1
     HEIGHT: 1,

--- a/src/helpers/imageHelper.js
+++ b/src/helpers/imageHelper.js
@@ -1,14 +1,18 @@
 import _filter from 'lodash/filter';
 import { Dimensions } from 'react-native';
 
+import { consts } from '../config';
+
+const { IMAGE_ASPECT_RATIO } = consts;
+
 export const imageWidth = () => Dimensions.get('window').width;
 
 export const imageHeight = (width) => {
-  // image aspect ratio is 360x180, so for accurate ratio in our view we need to calculate
-  // a factor with our current device width for the image, to set a correct height
-  const factor = width / 360;
+  // for accurate ratio in our view we need to calculate a factor with our current device
+  // width for the image, to set a correct height
+  const factor = width / IMAGE_ASPECT_RATIO.WIDTH;
 
-  return 180 * factor;
+  return IMAGE_ASPECT_RATIO.HEIGHT * factor;
 };
 
 export const mainImageOfMediaContents = (mediaContents) => {

--- a/src/helpers/imageHelper.js
+++ b/src/helpers/imageHelper.js
@@ -8,14 +8,16 @@ import { consts } from '../config';
 
 export const imageWidth = () => Dimensions.get('window').width;
 
-export const imageHeight = (width) => {
+export const imageHeight = (width, aspectRatio) => {
   const { IMAGE_ASPECT_RATIO } = consts;
+
+  if (!aspectRatio) aspectRatio = IMAGE_ASPECT_RATIO;
 
   // for accurate ratio in our view we need to calculate a factor with our current device
   // width for the image, to set a correct height
-  const factor = width / IMAGE_ASPECT_RATIO.WIDTH;
+  const factor = width / aspectRatio.WIDTH;
 
-  return IMAGE_ASPECT_RATIO.HEIGHT * factor;
+  return aspectRatio.HEIGHT * factor;
 };
 
 export const mainImageOfMediaContents = (mediaContents) => {

--- a/src/helpers/imageHelper.js
+++ b/src/helpers/imageHelper.js
@@ -1,13 +1,16 @@
 import _filter from 'lodash/filter';
+import _isArray from 'lodash/isArray';
+import _isString from 'lodash/isString';
+import _isInteger from 'lodash/isInteger';
 import { Dimensions } from 'react-native';
 
 import { consts } from '../config';
 
-const { IMAGE_ASPECT_RATIO } = consts;
-
 export const imageWidth = () => Dimensions.get('window').width;
 
 export const imageHeight = (width) => {
+  const { IMAGE_ASPECT_RATIO } = consts;
+
   // for accurate ratio in our view we need to calculate a factor with our current device
   // width for the image, to set a correct height
   const factor = width / IMAGE_ASPECT_RATIO.WIDTH;
@@ -31,4 +34,35 @@ export const mainImageOfMediaContents = (mediaContents) => {
   if (!images || !images.length) return null;
 
   return images[0].sourceUrl.url;
+};
+
+/**
+ * Parses a string with an image aspect ratio with 'width:height' format and returns
+ * and object with both values. If the value cannot be parsed, the default `IMAGE_ASPECT_RATIO`
+ * will be returned.
+ *
+ * @param {string} imageAspectRatio two values divided by a colon, something like '1:1'
+ *
+ * @return {object} both parsed values as an object, like { HEIGHT: 1, WIDTH: 1}
+ */
+export const parsedImageAspectRatio = (imageAspectRatio) => {
+  const { IMAGE_ASPECT_RATIO } = consts;
+
+  const splitImageAspectRatio =
+    imageAspectRatio && _isString(imageAspectRatio) && imageAspectRatio.split(':');
+
+  if (
+    splitImageAspectRatio &&
+    _isArray(splitImageAspectRatio) &&
+    splitImageAspectRatio.length === 2
+  ) {
+    const imageAspectRatioHeight = parseInt(splitImageAspectRatio[1], 10);
+    const imageAspectRatioWidth = parseInt(splitImageAspectRatio[0], 10);
+
+    if (_isInteger(imageAspectRatioHeight) && _isInteger(imageAspectRatioWidth)) {
+      return { HEIGHT: imageAspectRatioHeight, WIDTH: imageAspectRatioWidth };
+    }
+  }
+
+  return IMAGE_ASPECT_RATIO;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ import _isEmpty from 'lodash/isEmpty';
 
 import { auth } from './auth';
 import { colors, consts, device, namespace, secrets, texts } from './config';
-import { graphqlFetchPolicy, storageHelper } from './helpers';
+import { graphqlFetchPolicy, parsedImageAspectRatio, storageHelper } from './helpers';
 import { getQuery, QUERY_TYPES } from './queries';
 import { NetworkProvider } from './NetworkProvider';
 import NetInfo from './NetInfo';
@@ -297,6 +297,10 @@ const MainAppWithApolloProvider = () => {
 
   if (initialGlobalSettings.navigation === consts.TABS) {
     AppContainer = createAppContainer(MainTabNavigator);
+  }
+
+  if (initialGlobalSettings.imageAspectRatio) {
+    consts.IMAGE_ASPECT_RATIO = parsedImageAspectRatio(initialGlobalSettings.imageAspectRatio);
   }
 
   return (


### PR DESCRIPTION
refactor(image aspect ratio): move default aspect ratio to consts

- changed the ratio to 2:1, because 360:180 is the same as 2:1
- having the image aspect ratio in a central place, we can edit the value on one place, instead of searching for the method

feat(image aspect ratio): set IMAGE_ASPECT_RATIO with value from global settings

- added setter for `IMAGE_ASPECT_RATIO` in src/index.js if `imageAspectRatio` is present in global settings
  - added method for parsing and checking the value with returning the defaults, if something is not expected
- added comment in `consts`, hinting that the value can differ
- moved reading the value from `consts` into `imageHeight` to get the correct updated value when calling the method

feat(image aspect ratio): add alternative for home carousel

- added param for `imageHeight` method to be able to pass an alternative aspect ratio
  - fallback is the default aspect ratio if none is given
- added prop `aspectRatio` for `ImagesCarousel` to pass an alternative aspect ratio
  - used `aspectRatio` to calculate the height per `imageHeight` method
- used the new prop in `HomeCarousel` to pass an alternative aspect ratio, that can be set per main server global settings
- refactored return in `Image` to reduce duplication with moving the condition for image rights in the render part
- refactored default image styles in `Image` to ensure the correct aspect ratio
  - we need to call the default styles in a method to ensure correct defaults for image aspect ratio, which could be overwritten bei server global settings. otherwise (as default prop) the style would be set before the overwriting occurred.

refactor(map aspect ratio): match given aspect ratio for images

- adjust aspect ratio for map, because it should have the same aspect ratio as images

SVA-135

---

On the main server there can be the following addition in the global settings:

```
"imageAspectRatio": "2:1",
"homeCarousel": {
  "imageAspectRatio": "1:1"
}
```

which will result in:

![Simulator Screen Shot - iPhone 11 Pro Max - 2021-01-19 at 15 19 39](https://user-images.githubusercontent.com/1942953/105049554-1084b600-5a6d-11eb-8cc0-8ace0a1f609f.png)

furthermore, here are examples for different aspect ratios for home and rest:

![Simulator Screen Shot - iPhone 11 Pro Max - 2021-01-19 at 19 06 04-side](https://user-images.githubusercontent.com/1942953/105075608-42f0dc00-5a8a-11eb-8c3f-7093df52f369.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2021-01-19 at 19 06 26-side](https://user-images.githubusercontent.com/1942953/105075614-45533600-5a8a-11eb-975b-6a7901540169.png)