### PR TITLE
fix(image loading spinner android): update react-native-elements from 1.1.0 to 1.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react": "16.13.1",
     "react-apollo": "~3.1.5",
     "react-native": "https://github.com/expo/react-native/archive/sdk-40.0.0.tar.gz",
-    "react-native-elements": "1.1.0",
+    "react-native-elements": "~1.2.0",
     "react-native-expo-image-cache": "4.1.0",
     "react-native-gesture-handler": "~1.8.0",
     "react-native-get-random-values": "^1.5.0",

--- a/src/components/CardListItem.js
+++ b/src/components/CardListItem.js
@@ -31,6 +31,7 @@ export const CardListItem = memo(({ navigation, horizontal, item, orientation, d
             <Image
               source={{ uri: picture.url }}
               style={stylesWithProps({ horizontal, orientation, dimensions }).image}
+              borderRadius={5}
             />
           )}
           {!!subtitle && <RegularText small>{subtitle}</RegularText>}
@@ -93,7 +94,6 @@ const stylesWithProps = ({ horizontal, orientation, dimensions }) => {
       width: maxWidth
     },
     image: {
-      borderRadius: 5,
       marginBottom: normalize(7),
       height: imageHeight(maxWidth)
     }

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -9,7 +9,7 @@ import { imageHeight, imageWidth } from '../helpers';
 import { SettingsContext } from '../SettingsProvider';
 import { ImageRights } from './ImageRights';
 
-export const Image = ({ source, style, PlaceholderContent }) => {
+export const Image = ({ source, style, PlaceholderContent, resizeMode, borderRadius }) => {
   const [uri, setUri] = useState(null);
   const { globalSettings } = useContext(SettingsContext);
 
@@ -42,6 +42,8 @@ export const Image = ({ source, style, PlaceholderContent }) => {
         placeholderStyle={{ backgroundColor: colors.transparent }}
         accessible={!!source?.captionText}
         accessibilityLabel={source?.captionText}
+        resizeMode={resizeMode}
+        borderRadius={borderRadius}
       />
       {globalSettings?.showImageRights && source?.copyright && (
         <ImageRights imageRights={source.copyright} />
@@ -68,9 +70,13 @@ const stylesForImage = () =>
 Image.propTypes = {
   source: PropTypes.oneOfType([PropTypes.object, PropTypes.number]).isRequired,
   style: PropTypes.object,
-  PlaceholderContent: PropTypes.object
+  PlaceholderContent: PropTypes.object,
+  resizeMode: PropTypes.string,
+  borderRadius: PropTypes.number
 };
 
 Image.defaultProps = {
-  PlaceholderContent: <ActivityIndicator color={colors.accent} />
+  PlaceholderContent: <ActivityIndicator color={colors.accent} />,
+  resizeMode: 'cover',
+  borderRadius: 0
 };

--- a/src/components/Logo.js
+++ b/src/components/Logo.js
@@ -7,13 +7,14 @@ export const Logo = (props) => <Image {...props} />;
 
 Logo.propTypes = {
   source: PropTypes.oneOfType([PropTypes.object, PropTypes.number]).isRequired,
-  style: PropTypes.object
+  style: PropTypes.object,
+  resizeMode: PropTypes.string
 };
 
 Logo.defaultProps = {
   style: {
     height: 80,
-    resizeMode: 'contain',
     width: 'auto'
-  }
+  },
+  resizeMode: 'contain'
 };

--- a/src/components/screens/Service.js
+++ b/src/components/screens/Service.js
@@ -97,6 +97,7 @@ export const Service = ({ navigation, refreshing }) => {
                               source={{ uri: item.icon }}
                               style={styles.serviceImage}
                               PlaceholderContent={null}
+                              resizeMode="contain"
                             />
                           )}
                           <BoldText
@@ -130,7 +131,6 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     height: normalize(40),
     marginBottom: normalize(7),
-    resizeMode: 'contain',
     width: '100%'
   }
 });

--- a/src/components/weather/DailyWeather.tsx
+++ b/src/components/weather/DailyWeather.tsx
@@ -37,6 +37,7 @@ export const DailyWeather = ({ date, icon, temperatures }: Props) => {
               <Image
                 source={{ uri: `https://openweathermap.org/img/wn/${icon}@2x.png` }}
                 style={styles.icon}
+                resizeMode="contain"
               />
             </View>
             <View style={[styles.maxMinContainer, styles.dayTimeEntry]}>
@@ -79,7 +80,6 @@ const styles = StyleSheet.create({
   },
   icon: {
     aspectRatio: 1,
-    resizeMode: 'contain',
     width: normalize(64)
   },
   iconContainer: {

--- a/src/components/weather/HourlyWeather.tsx
+++ b/src/components/weather/HourlyWeather.tsx
@@ -21,6 +21,7 @@ export const HourlyWeather = ({ icon, temperature, time, isNow }: HourlyWeatherD
       <Image
         source={{ uri: `https://openweathermap.org/img/wn/${icon}@2x.png` }}
         style={styles.icon}
+        resizeMode="contain"
       />
       <RegularText>{temperature.toFixed(1)}°C</RegularText>
     </View>
@@ -30,7 +31,6 @@ export const HourlyWeather = ({ icon, temperature, time, isNow }: HourlyWeatherD
 const styles = StyleSheet.create({
   icon: {
     aspectRatio: 1,
-    resizeMode: 'contain',
     width: normalize(50)
   },
   container: {

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { useQuery } from 'react-apollo';
 import { StyleSheet, View } from 'react-native';
 import { NavigationScreenProp } from 'react-navigation';
+
 import { consts, normalize } from '../../config';
 import { graphqlFetchPolicy } from '../../helpers';
 import { NetworkContext } from '../../NetworkProvider';
@@ -36,6 +37,7 @@ export const WeatherWidget = ({ navigation }: { navigation: NavigationScreenProp
             <Image
               source={{ uri: `https://openweathermap.org/img/wn/${icon}@2x.png` }}
               style={styles.icon}
+              resizeMode="contain"
             />
           </View>
           <View>
@@ -55,7 +57,6 @@ export const WeatherWidget = ({ navigation }: { navigation: NavigationScreenProp
 const styles = StyleSheet.create({
   icon: {
     aspectRatio: 1,
-    resizeMode: 'contain',
     width: normalize(44)
   },
   iconContainer: {

--- a/src/screens/CompanyScreen.js
+++ b/src/screens/CompanyScreen.js
@@ -135,6 +135,7 @@ export const CompanyScreen = ({ navigation }) => {
                                   source={{ uri: item.icon }}
                                   style={styles.serviceImage}
                                   PlaceholderContent={null}
+                                  resizeMode="contain"
                                 />
                               )}
                               <BoldText
@@ -170,7 +171,6 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     height: normalize(40),
     marginBottom: normalize(7),
-    resizeMode: 'contain',
     width: '100%'
   }
 });

--- a/src/screens/ServiceScreen.js
+++ b/src/screens/ServiceScreen.js
@@ -135,13 +135,13 @@ export const ServiceScreen = ({ navigation }) => {
                                   source={{ uri: item.icon }}
                                   style={styles.serviceImage}
                                   PlaceholderContent={null}
+                                  resizeMode="contain"
                                 />
                               )}
                               <BoldText
                                 small
                                 primary
                                 center
-                                accessible
                                 accessibilityLabel={`${item.title} (Taste)`}
                               >
                                 {item.title}
@@ -171,7 +171,6 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     height: normalize(40),
     marginBottom: normalize(7),
-    resizeMode: 'contain',
     width: '100%'
   }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2975,6 +2975,21 @@
   dependencies:
     "@types/react" "^16"
 
+"@types/react-native-vector-icons@^6.4.4":
+  version "6.4.6"
+  resolved "https://registry.yarnpkg.com/@types/react-native-vector-icons/-/react-native-vector-icons-6.4.6.tgz#848e3b14572def56212cafbf5cb1254b445bfb41"
+  integrity sha512-lAyxNfMd5L1xZvXWsGcJmNegDf61TAp40uL6ashNNWj9W3IrDJO59L9+9inh0Y2MsEZpLTdxzVU8Unb4/0FQng==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-native" "*"
+
+"@types/react-native@*":
+  version "0.63.46"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.46.tgz#942df5af29046c6f22227495e00d5297cc1cea73"
+  integrity sha512-SnBnWRErpISIaWk4K8kAfIKqSPdZ8fdH6HIw7kVdz6jMl/5FAf6iXeIwRfVZg1bCMh+ymNPCpSENNNEVprxj/w==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-native@~0.63.2":
   version "0.63.37"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.37.tgz#c43df90c9d3cc082a97a49a53e989de26cb8ab45"
@@ -9044,7 +9059,7 @@ prompts@^2.2.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9182,16 +9197,17 @@ react-leaflet@^2.6.1:
     hoist-non-react-statics "^3.3.2"
     warning "^4.0.3"
 
-react-native-elements@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-native-elements/-/react-native-elements-1.1.0.tgz#f99bcda4459a886f3ab4591c684c099d37aedf2b"
-  integrity sha512-n1eOL0kUdlH01zX7bn1p7qhYXn7kquqxYQ0oWlxoAck9t5Db/KeK5ViOsAk8seYSvAG6Pe7OxgzRFnMfFhng0Q==
+react-native-elements@~1.2.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/react-native-elements/-/react-native-elements-1.2.7.tgz#1eca2db715c41722aeb67aea62bd2a4621adb134"
+  integrity sha512-0S+0R1cbItl15i64qrkWnyMztwpw60d0SUsZGVDKRAMf0Jvq9Clgyh/MzxJx2sr42mbedQP1sg5Et4fZM7Fp1w==
   dependencies:
+    "@types/react-native-vector-icons" "^6.4.4"
     color "^3.1.0"
     deepmerge "^3.1.0"
     hoist-non-react-statics "^3.1.0"
     opencollective-postinstall "^2.0.0"
-    prop-types "^15.5.8"
+    prop-types "^15.7.2"
     react-native-ratings "^6.3.0"
     react-native-status-bar-height "^2.2.0"
 


### PR DESCRIPTION
- problem: https://github.com/react-native-elements/react-native-elements/issues/2000
- latest v1 is 1.2.7: https://github.com/react-native-elements/react-native-elements/blob/next/CHANGELOG.md#v127
- when updating like this, we needed to make changes where using `Image`
  - not all styles will be applied anymore, you need to change styles to props
  - we had the need of moving `resizeMode` and `borderRadius` from inside of style prop
    to be props itself
    - default for `resizeMode` was `cover` before in the code of react-native-elements,
      as it is the default for React Native `Image` component https://reactnative.dev/docs/image#resizemode
  - refactored all occurrences

SVA-141