### PR TITLE
fix(safe area insets): upgrade safe area view

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,5 +89,8 @@
     "react-test-renderer": "16.11.0",
     "set-value": "^2.0.1",
     "typescript": "~4.0.0"
+  },
+  "resolutions": {
+    "react-native-safe-area-view": "2.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import { InMemoryCache } from 'apollo-cache-inmemory';
 import { persistCache } from 'apollo-cache-persist';
 import _reduce from 'lodash/reduce';
 import _isEmpty from 'lodash/isEmpty';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { auth } from './auth';
 import { colors, consts, device, namespace, secrets, texts } from './config';
@@ -323,7 +324,9 @@ export const MainApp = () => (
     <OrientationProvider>
       <BookmarkProvider>
         <ConstructionSiteProvider>
-          <MainAppWithApolloProvider />
+          <SafeAreaProvider>
+            <MainAppWithApolloProvider />
+          </SafeAreaProvider>
         </ConstructionSiteProvider>
       </BookmarkProvider>
     </OrientationProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9304,10 +9304,10 @@ react-native-safe-area-context@3.1.9:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.1.9.tgz#48864ea976b0fa57142a2cc523e1fd3314e7247e"
   integrity sha512-wmcGbdyE/vBSL5IjDPReoJUEqxkZsywZw5gPwsVUV1NBpw5eTIdnL6Y0uNKHE25Z661moxPHQz6kwAkYQyorxA==
 
-react-native-safe-area-view@^0.14.8:
-  version "0.14.9"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.14.9.tgz#90ee8383037010d9a5055a97cf97e4c1da1f0c3d"
-  integrity sha512-WII/ulhpVyL/qbYb7vydq7dJAfZRBcEhg4/UWt6F6nAKpLa3gAceMOxBxI914ppwSP/TdUsandFy6lkJQE0z4A==
+react-native-safe-area-view@2.0.0, react-native-safe-area-view@^0.14.8:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-2.0.0.tgz#98fc9bb1bf3cb8c97ba684efb7dd897765afff3b"
+  integrity sha512-tGlGZwRoZpTQ0gEdSSRgbkeyyKC50ZsEv2H/LQKjXhc00IHffbU0BA5chSzTqNwDrs5MFXfTG1ooRQK+0FVTjw==
   dependencies:
     hoist-non-react-statics "^2.3.1"
 


### PR DESCRIPTION
forcefully upgraded react-native-safe-area-view to support iPhone 12

Before

![Screenshot 2021-01-21 at 16 24 26](https://user-images.githubusercontent.com/59824597/105371753-35139600-5c05-11eb-8cd1-3ee5dfd149ea.png)

After

![Screenshot 2021-01-21 at 16 23 19](https://user-images.githubusercontent.com/59824597/105371536-fed61680-5c04-11eb-9791-4a9e189aae13.png)


SVA-145