### PR TITLE
fix(images): correct rendering of images

### DIFF
--- a/src/components/BB-BUS/Authority.js
+++ b/src/components/BB-BUS/Authority.js
@@ -15,15 +15,7 @@ import { Wrapper, WrapperWithOrientation } from '../Wrapper';
 
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
-export const Authority = ({
-  data,
-  accordion,
-  onPress,
-  bottomDivider,
-  openWebScreen,
-  orientation,
-  dimensions
-}) => {
+export const Authority = ({ data, accordion, onPress, bottomDivider, openWebScreen }) => {
   const {
     id,
     name,
@@ -122,12 +114,7 @@ export const Authority = ({
               {!!openingHours && (
                 <View>
                   <BoldText>{texts.bbBus.authority.openingTime}:</BoldText>
-                  <HtmlView
-                    html={trimNewLines(openingHours)}
-                    openWebScreen={openWebScreen}
-                    orientation={orientation}
-                    dimensions={dimensions}
-                  />
+                  <HtmlView html={trimNewLines(openingHours)} openWebScreen={openWebScreen} />
                 </View>
               )}
               {elevator !== undefined && (
@@ -171,7 +158,5 @@ Authority.propTypes = {
   accordion: PropTypes.object.isRequired,
   onPress: PropTypes.func.isRequired,
   bottomDivider: PropTypes.bool.isRequired,
-  openWebScreen: PropTypes.func.isRequired,
-  orientation: PropTypes.string.isRequired,
-  dimensions: PropTypes.object.isRequired
+  openWebScreen: PropTypes.func.isRequired
 };

--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -38,13 +38,7 @@ export const CardList = ({
         keyExtractor={keyExtractor}
         data={data}
         renderItem={({ item }) => (
-          <CardListItem
-            navigation={navigation}
-            horizontal={horizontal}
-            item={item}
-            orientation={orientation}
-            dimensions={dimensions}
-          />
+          <CardListItem navigation={navigation} horizontal={horizontal} item={item} />
         )}
         showsHorizontalScrollIndicator={false}
         horizontal
@@ -58,13 +52,7 @@ export const CardList = ({
       keyExtractor={keyExtractor}
       data={data}
       renderItem={({ item }) => (
-        <CardListItem
-          navigation={navigation}
-          horizontal={horizontal}
-          item={item}
-          orientation={orientation}
-          dimensions={dimensions}
-        />
+        <CardListItem navigation={navigation} horizontal={horizontal} item={item} />
       )}
       ListFooterComponent={
         data.length > 10 &&

--- a/src/components/CardListItem.js
+++ b/src/components/CardListItem.js
@@ -9,7 +9,7 @@ import { Image } from './Image';
 import { RegularText, BoldText } from './Text';
 import { Touchable } from './Touchable';
 
-export const CardListItem = memo(({ navigation, horizontal, item, orientation, dimensions }) => {
+export const CardListItem = memo(({ navigation, horizontal, item }) => {
   const { routeName, params, picture, subtitle, title } = item;
 
   // TODO: count articles logic could to be implemented
@@ -26,11 +26,11 @@ export const CardListItem = memo(({ navigation, horizontal, item, orientation, d
       disabled={!navigation}
     >
       <Card containerStyle={styles.container}>
-        <View style={stylesWithProps({ horizontal, orientation, dimensions }).contentContainer}>
+        <View style={stylesWithProps({ horizontal }).contentContainer}>
           {!!picture && !!picture.url && (
             <Image
               source={{ uri: picture.url }}
-              style={stylesWithProps({ horizontal, orientation, dimensions }).image}
+              style={stylesWithProps({ horizontal }).image}
               containerStyle={styles.imageContainer}
               borderRadius={5}
             />
@@ -69,8 +69,8 @@ const styles = StyleSheet.create({
 
 /* eslint-disable react-native/no-unused-styles */
 /* this works properly, we do not want that warning */
-const stylesWithProps = ({ horizontal, orientation, dimensions }) => {
-  let width = imageWidth(orientation, dimensions);
+const stylesWithProps = ({ horizontal }) => {
+  let width = imageWidth();
 
   if (horizontal || width > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH) {
     // image width should be only 70% when rendering horizontal cards or on wider screens,

--- a/src/components/CardListItem.js
+++ b/src/components/CardListItem.js
@@ -31,6 +31,7 @@ export const CardListItem = memo(({ navigation, horizontal, item, orientation, d
             <Image
               source={{ uri: picture.url }}
               style={stylesWithProps({ horizontal, orientation, dimensions }).image}
+              containerStyle={styles.imageContainer}
               borderRadius={5}
             />
           )}
@@ -60,30 +61,21 @@ const styles = StyleSheet.create({
         shadowColor: colors.transparent
       }
     })
+  },
+  imageContainer: {
+    alignSelf: 'center'
   }
 });
 
 /* eslint-disable react-native/no-unused-styles */
 /* this works properly, we do not want that warning */
 const stylesWithProps = ({ horizontal, orientation, dimensions }) => {
-  let width = imageWidth();
+  let width = imageWidth(orientation, dimensions);
 
-  if (horizontal || dimensions.width > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH) {
+  if (horizontal || width > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH) {
     // image width should be only 70% when rendering horizontal cards or on wider screens,
     // as there are 15% padding on each side
     width = width * 0.7;
-  }
-
-  if (orientation === 'landscape') {
-    // image width should be smaller than full width on landscape, so take the device height,
-    // which is the same as the device width in portrait
-    width = dimensions.height;
-
-    // if the device is in landscape mode but the device height is larger than our max for full
-    // screen, we want to also apply 70% to have not too large images
-    if (dimensions.height > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH) {
-      width = dimensions.height * 0.7;
-    }
   }
 
   const maxWidth = width - 2 * normalize(14); // width of an image minus paddings

--- a/src/components/CardListItem.js
+++ b/src/components/CardListItem.js
@@ -87,7 +87,8 @@ const stylesWithProps = ({ horizontal }) => {
     },
     image: {
       marginBottom: normalize(7),
-      height: imageHeight(maxWidth)
+      height: imageHeight(maxWidth),
+      width: maxWidth
     }
   });
 };

--- a/src/components/HtmlView.js
+++ b/src/components/HtmlView.js
@@ -11,7 +11,7 @@ import {
 import { WebView } from 'react-native-webview';
 
 import { colors, consts, normalize, styles } from '../config';
-import { openLink } from '../helpers';
+import { imageWidth, openLink } from '../helpers';
 
 const tableCssRules =
   cssRulesFromSpecs({
@@ -53,13 +53,10 @@ const htmlConfig = {
   ignoredTags: IGNORED_TAGS
 };
 
-export const HtmlView = memo(({ html, tagsStyles, openWebScreen, orientation, dimensions }) => {
-  let width = dimensions.width;
+export const HtmlView = memo(({ html, tagsStyles, openWebScreen }) => {
+  let width = imageWidth();
 
-  const needLandscapeWidth =
-    orientation === 'landscape' || dimensions.width > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH;
-
-  if (needLandscapeWidth) {
+  if (width > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH) {
     // image width should be only 70% on wider screens, as there are 15% padding on each side
     width = width * 0.7;
   }
@@ -94,9 +91,7 @@ HtmlView.displayName = 'HtmlView';
 HtmlView.propTypes = {
   html: PropTypes.string,
   tagsStyles: PropTypes.object,
-  openWebScreen: PropTypes.func,
-  orientation: PropTypes.string.isRequired,
-  dimensions: PropTypes.object.isRequired
+  openWebScreen: PropTypes.func
 };
 
 HtmlView.defaultProps = {

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -7,11 +7,21 @@ import { Image as RNEImage } from 'react-native-elements';
 import { colors } from '../config';
 import { imageHeight, imageWidth } from '../helpers';
 import { SettingsContext } from '../SettingsProvider';
+import { OrientationContext } from '../OrientationProvider';
 import { ImageRights } from './ImageRights';
 
-export const Image = ({ source, style, PlaceholderContent, resizeMode, borderRadius }) => {
+export const Image = ({
+  source,
+  style,
+  containerStyle,
+  PlaceholderContent,
+  aspectRatio,
+  resizeMode,
+  borderRadius
+}) => {
   const [uri, setUri] = useState(null);
   const { globalSettings } = useContext(SettingsContext);
+  const { orientation, dimensions } = useContext(OrientationContext);
 
   // if there is a source.uri to fetch, do it with the CacheManager and set the local path to show.
   // if there is no uri, the source itself should be already a local path, so set it immediately.
@@ -37,7 +47,8 @@ export const Image = ({ source, style, PlaceholderContent, resizeMode, borderRad
     <View>
       <RNEImage
         source={uri ? (source.uri ? { uri } : uri) : null}
-        style={style || stylesForImage().defaultStyle}
+        style={style || stylesForImage(orientation, dimensions, aspectRatio).defaultStyle}
+        containerStyle={containerStyle}
         PlaceholderContent={PlaceholderContent}
         placeholderStyle={{ backgroundColor: colors.transparent }}
         accessible={!!source?.captionText}
@@ -57,20 +68,24 @@ export const Image = ({ source, style, PlaceholderContent, resizeMode, borderRad
 // we need to call the default styles in a method to ensure correct defaults for image aspect ratio,
 // which could be overwritten bei server global settings. otherwise (as default prop) the style
 // would be set before the overwriting occurred.
-const stylesForImage = () =>
-  StyleSheet.create({
+const stylesForImage = (orientation, dimensions, aspectRatio) => {
+  const width = imageWidth(orientation, dimensions);
+
+  return StyleSheet.create({
     defaultStyle: {
-      alignSelf: 'center',
-      height: imageHeight(imageWidth()),
-      width: imageWidth()
+      height: imageHeight(width, aspectRatio),
+      width
     }
   });
+};
 /* eslint-enable react-native/no-unused-styles */
 
 Image.propTypes = {
   source: PropTypes.oneOfType([PropTypes.object, PropTypes.number]).isRequired,
+  containerStyle: PropTypes.object,
   style: PropTypes.object,
   PlaceholderContent: PropTypes.object,
+  aspectRatio: PropTypes.object,
   resizeMode: PropTypes.string,
   borderRadius: PropTypes.number
 };

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -7,7 +7,6 @@ import { Image as RNEImage } from 'react-native-elements';
 import { colors } from '../config';
 import { imageHeight, imageWidth } from '../helpers';
 import { SettingsContext } from '../SettingsProvider';
-import { OrientationContext } from '../OrientationProvider';
 import { ImageRights } from './ImageRights';
 
 export const Image = ({
@@ -21,7 +20,6 @@ export const Image = ({
 }) => {
   const [uri, setUri] = useState(null);
   const { globalSettings } = useContext(SettingsContext);
-  const { orientation, dimensions } = useContext(OrientationContext);
 
   // if there is a source.uri to fetch, do it with the CacheManager and set the local path to show.
   // if there is no uri, the source itself should be already a local path, so set it immediately.
@@ -47,7 +45,7 @@ export const Image = ({
     <View>
       <RNEImage
         source={uri ? (source.uri ? { uri } : uri) : null}
-        style={style || stylesForImage(orientation, dimensions, aspectRatio).defaultStyle}
+        style={style || stylesForImage(aspectRatio).defaultStyle}
         containerStyle={containerStyle}
         PlaceholderContent={PlaceholderContent}
         placeholderStyle={{ backgroundColor: colors.transparent }}
@@ -68,8 +66,8 @@ export const Image = ({
 // we need to call the default styles in a method to ensure correct defaults for image aspect ratio,
 // which could be overwritten bei server global settings. otherwise (as default prop) the style
 // would be set before the overwriting occurred.
-const stylesForImage = (orientation, dimensions, aspectRatio) => {
-  const width = imageWidth(orientation, dimensions);
+const stylesForImage = (aspectRatio) => {
+  const width = imageWidth();
 
   return StyleSheet.create({
     defaultStyle: {

--- a/src/components/ImagesCarousel.js
+++ b/src/components/ImagesCarousel.js
@@ -5,7 +5,7 @@ import { ActivityIndicator, StyleSheet, TouchableOpacity } from 'react-native';
 import { Query } from 'react-apollo';
 
 import { colors } from '../config';
-import { imageHeight, shareMessage } from '../helpers';
+import { shareMessage } from '../helpers';
 import { getQuery } from '../queries';
 import { Image } from './Image';
 import { LoadingContainer } from './LoadingContainer';
@@ -88,7 +88,8 @@ export const ImagesCarousel = ({ data, navigation, fetchPolicy, aspectRatio }) =
                 <TouchableImage navigation={navigation} item={item}>
                   <Image
                     source={item.picture}
-                    style={stylesForImage(itemWidth, aspectRatio).size}
+                    containerStyle={styles.imageContainer}
+                    aspectRatio={aspectRatio}
                   />
                 </TouchableImage>
               );
@@ -98,12 +99,22 @@ export const ImagesCarousel = ({ data, navigation, fetchPolicy, aspectRatio }) =
       } else {
         return (
           <TouchableImage navigation={navigation} item={item}>
-            <Image source={item.picture} style={stylesForImage(itemWidth, aspectRatio).size} />
+            <Image
+              source={item.picture}
+              containerStyle={styles.imageContainer}
+              aspectRatio={aspectRatio}
+            />
           </TouchableImage>
         );
       }
     } else {
-      return <Image source={item.picture} style={stylesForImage(itemWidth, aspectRatio).size} />;
+      return (
+        <Image
+          source={item.picture}
+          containerStyle={styles.imageContainer}
+          aspectRatio={aspectRatio}
+        />
+      );
     }
   };
 
@@ -126,19 +137,11 @@ export const ImagesCarousel = ({ data, navigation, fetchPolicy, aspectRatio }) =
 const styles = StyleSheet.create({
   center: {
     alignSelf: 'center'
+  },
+  imageContainer: {
+    alignSelf: 'center'
   }
 });
-
-/* eslint-disable react-native/no-unused-styles */
-/* this works properly, we do not want that eslint warning */
-const stylesForImage = (width, aspectRatio) =>
-  StyleSheet.create({
-    size: {
-      height: imageHeight(width, aspectRatio),
-      width
-    }
-  });
-/* eslint-enable react-native/no-unused-styles */
 
 ImagesCarousel.propTypes = {
   data: PropTypes.array.isRequired,

--- a/src/components/TextListItem.js
+++ b/src/components/TextListItem.js
@@ -26,7 +26,13 @@ export const TextListItem = memo(({ navigation, item, noSubtitle, leftImage }) =
       leftIcon={
         leftImage &&
         !!picture &&
-        !!picture.url && <Image style={styles.smallImage} source={{ uri: picture.url }} />
+        !!picture.url && (
+          <Image
+            source={{ uri: picture.url }}
+            style={styles.smallImage}
+            containerStyle={styles.smallImageContainer}
+          />
+        )
       }
       onPress={() =>
         navigation &&
@@ -49,9 +55,11 @@ const styles = StyleSheet.create({
     paddingVertical: normalize(12)
   },
   smallImage: {
-    alignSelf: 'flex-start',
     height: normalize(33),
     width: normalize(66)
+  },
+  smallImageContainer: {
+    alignSelf: 'flex-start'
   }
 });
 

--- a/src/components/map/WebViewMap.tsx
+++ b/src/components/map/WebViewMap.tsx
@@ -1,10 +1,9 @@
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback } from 'react';
 import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 import { MapMarker, WebViewLeaflet, WebviewLeafletMessage } from 'react-native-webview-leaflet';
 
 import { colors } from '../../config';
 import { imageHeight, imageWidth } from '../../helpers';
-import { OrientationContext } from '../../OrientationProvider';
 
 type Props = {
   locations?: MapMarker[];
@@ -24,7 +23,6 @@ export const WebViewMap = ({
   style,
   zoom
 }: Props) => {
-  const { orientation, dimensions } = useContext(OrientationContext);
   const messageHandler = useCallback(
     (message) => {
       onMessageReceived?.(message);
@@ -33,7 +31,7 @@ export const WebViewMap = ({
   );
 
   return (
-    <View style={style || stylesForMap(orientation, dimensions).defaultStyle}>
+    <View style={style || stylesForMap().defaultStyle}>
       <WebViewLeaflet
         backgroundColor={colors.lightestText}
         onMessageReceived={messageHandler}
@@ -59,8 +57,8 @@ export const WebViewMap = ({
 // we need to call the default styles in a method to ensure correct defaults for image aspect ratio,
 // which could be overwritten bei server global settings. otherwise (as default prop) the style
 // would be set before the overwriting occurred.
-const stylesForMap = (orientation: any, dimensions: any) => {
-  const width = imageWidth(orientation, dimensions);
+const stylesForMap = () => {
+  const width = imageWidth();
 
   return StyleSheet.create({
     defaultStyle: {

--- a/src/components/map/WebViewMap.tsx
+++ b/src/components/map/WebViewMap.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useContext } from 'react';
 import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 import { MapMarker, WebViewLeaflet, WebviewLeafletMessage } from 'react-native-webview-leaflet';
 
 import { colors } from '../../config';
 import { imageHeight, imageWidth } from '../../helpers';
+import { OrientationContext } from '../../OrientationProvider';
 
 type Props = {
   locations?: MapMarker[];
@@ -23,6 +24,7 @@ export const WebViewMap = ({
   style,
   zoom
 }: Props) => {
+  const { orientation, dimensions } = useContext(OrientationContext);
   const messageHandler = useCallback(
     (message) => {
       onMessageReceived?.(message);
@@ -31,7 +33,7 @@ export const WebViewMap = ({
   );
 
   return (
-    <View style={style || stylesForMap().defaultStyle}>
+    <View style={style || stylesForMap(orientation, dimensions).defaultStyle}>
       <WebViewLeaflet
         backgroundColor={colors.lightestText}
         onMessageReceived={messageHandler}
@@ -57,12 +59,15 @@ export const WebViewMap = ({
 // we need to call the default styles in a method to ensure correct defaults for image aspect ratio,
 // which could be overwritten bei server global settings. otherwise (as default prop) the style
 // would be set before the overwriting occurred.
-const stylesForMap = () =>
-  StyleSheet.create({
+const stylesForMap = (orientation: any, dimensions: any) => {
+  const width = imageWidth(orientation, dimensions);
+
+  return StyleSheet.create({
     defaultStyle: {
       alignSelf: 'center',
-      height: imageHeight(imageWidth()),
-      width: imageWidth()
+      height: imageHeight(width),
+      width
     }
   });
+};
 /* eslint-enable react-native/no-unused-styles */

--- a/src/components/screens/EventRecord.js
+++ b/src/components/screens/EventRecord.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useContext } from 'react';
+import React from 'react';
 import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 import _filter from 'lodash/filter';
@@ -18,7 +18,6 @@ import { OperatingCompanyInfo } from './OperatingCompanyInfo';
 import { OpeningTimesCard } from './OpeningTimesCard';
 import { ImagesCarousel } from '../ImagesCarousel';
 import { matomoTrackingString, trimNewLines } from '../../helpers';
-import { OrientationContext } from '../../OrientationProvider';
 import { useMatomoTrackScreenView } from '../../hooks';
 
 // necessary hacky way of implementing iframe in webview with correct zoom level
@@ -36,7 +35,6 @@ const { MATOMO_TRACKING } = consts;
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const EventRecord = ({ data, navigation }) => {
-  const { orientation, dimensions } = useContext(OrientationContext);
   const {
     addresses,
     category,
@@ -194,12 +192,7 @@ export const EventRecord = ({ data, navigation }) => {
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <Wrapper>
-              <HtmlView
-                html={description}
-                openWebScreen={openWebScreen}
-                orientation={orientation}
-                dimensions={dimensions}
-              />
+              <HtmlView html={description} openWebScreen={openWebScreen} />
             </Wrapper>
           </View>
         )}

--- a/src/components/screens/EventRecord.js
+++ b/src/components/screens/EventRecord.js
@@ -130,7 +130,9 @@ export const EventRecord = ({ data, navigation }) => {
       {!!images && images.length > 1 && <ImagesCarousel data={images} />}
 
       <WrapperWithOrientation>
-        {!!images && images.length === 1 && <Image source={images[0].picture} />}
+        {!!images && images.length === 1 && (
+          <Image source={images[0].picture} containerStyle={styles.imageContainer} />
+        )}
 
         {!!title && !!link ? (
           <TitleContainer>
@@ -231,6 +233,9 @@ const styles = StyleSheet.create({
   iframeWebView: {
     height: normalize(210),
     width: '100%'
+  },
+  imageContainer: {
+    alignSelf: 'center'
   }
 });
 

--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useContext } from 'react';
+import React from 'react';
 import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 import _filter from 'lodash/filter';
@@ -16,7 +16,6 @@ import { ImagesCarousel } from '../ImagesCarousel';
 import { containsHtml, matomoTrackingString, momentFormat, trimNewLines } from '../../helpers';
 import { BoldText, RegularText } from '../Text';
 import { Button } from '../Button';
-import { OrientationContext } from '../../OrientationProvider';
 import { useMatomoTrackScreenView } from '../../hooks';
 
 // necessary hacky way of implementing iframe in webview with correct zoom level
@@ -34,7 +33,6 @@ const { MATOMO_TRACKING } = consts;
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const NewsItem = ({ data, navigation }) => {
-  const { orientation, dimensions } = useContext(OrientationContext);
   const {
     dataProvider,
     mainTitle,
@@ -127,8 +125,6 @@ export const NewsItem = ({ data, navigation }) => {
               )}
               tagsStyles={{ div: { fontFamily: 'titillium-web-bold' } }}
               openWebScreen={openWebScreen}
-              orientation={orientation}
-              dimensions={dimensions}
             />
           </WrapperHorizontal>
         );
@@ -174,12 +170,7 @@ export const NewsItem = ({ data, navigation }) => {
         !!contentBlock.body &&
         section.push(
           <WrapperHorizontal key={`${index}-${contentBlock.id}-body`}>
-            <HtmlView
-              html={trimNewLines(contentBlock.body)}
-              openWebScreen={openWebScreen}
-              orientation={orientation}
-              dimensions={dimensions}
-            />
+            <HtmlView html={trimNewLines(contentBlock.body)} openWebScreen={openWebScreen} />
           </WrapperHorizontal>
         );
 

--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -162,7 +162,11 @@ export const NewsItem = ({ data, navigation }) => {
       !!sectionImages &&
         sectionImages.length === 1 &&
         section.push(
-          <Image source={sectionImages[0].picture} key={`${index}-${contentBlock.id}-image`} />
+          <Image
+            source={sectionImages[0].picture}
+            containerStyle={styles.imageContainer}
+            key={`${index}-${contentBlock.id}-image`}
+          />
         );
 
       (!settings ||
@@ -226,7 +230,9 @@ export const NewsItem = ({ data, navigation }) => {
       {!!mainImages && mainImages.length > 1 && <ImagesCarousel data={mainImages} />}
 
       <WrapperWithOrientation>
-        {!!mainImages && mainImages.length === 1 && <Image source={mainImages[0].picture} />}
+        {!!mainImages && mainImages.length === 1 && (
+          <Image source={mainImages[0].picture} containerStyle={styles.imageContainer} />
+        )}
 
         {!!title && !!link ? (
           <TitleContainer>
@@ -262,6 +268,9 @@ const styles = StyleSheet.create({
   iframeWebView: {
     height: normalize(210),
     width: '100%'
+  },
+  imageContainer: {
+    alignSelf: 'center'
   }
 });
 

--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -13,7 +13,6 @@ import { InfoCard } from './InfoCard';
 import { OperatingCompanyInfo } from './OperatingCompanyInfo';
 import { OpeningTimesCard } from './OpeningTimesCard';
 import { ImagesCarousel } from '../ImagesCarousel';
-import { OrientationContext } from '../../OrientationProvider';
 import { useMatomoTrackScreenView } from '../../hooks';
 import { matomoTrackingString } from '../../helpers';
 import { WebViewMap } from '../map/WebViewMap';
@@ -26,7 +25,6 @@ const { MATOMO_TRACKING } = consts;
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const PointOfInterest = ({ data, hideMap, navigation }) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
-  const { orientation, dimensions } = useContext(OrientationContext);
   const {
     addresses,
     category,
@@ -142,12 +140,7 @@ export const PointOfInterest = ({ data, hideMap, navigation }) => {
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <Wrapper>
-              <HtmlView
-                html={description}
-                openWebScreen={openWebScreen}
-                orientation={orientation}
-                dimensions={dimensions}
-              />
+              <HtmlView html={description} openWebScreen={openWebScreen} />
             </Wrapper>
           </View>
         )}

--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
-import { View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import _filter from 'lodash/filter';
 
 import { colors, consts, device, texts } from '../../config';
@@ -92,7 +92,9 @@ export const PointOfInterest = ({ data, hideMap, navigation }) => {
       {!!images && images.length > 1 && <ImagesCarousel data={images} />}
 
       <WrapperWithOrientation>
-        {!!images && images.length === 1 && <Image source={images[0].picture} />}
+        {!!images && images.length === 1 && (
+          <Image source={images[0].picture} containerStyle={styles.imageContainer} />
+        )}
 
         {!!title && (
           <View>
@@ -203,6 +205,12 @@ export const PointOfInterest = ({ data, hideMap, navigation }) => {
   );
 };
 /* eslint-enable complexity */
+
+const styles = StyleSheet.create({
+  imageContainer: {
+    alignSelf: 'center'
+  }
+});
 
 PointOfInterest.propTypes = {
   data: PropTypes.object.isRequired,

--- a/src/components/screens/Tour.js
+++ b/src/components/screens/Tour.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useContext } from 'react';
+import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import _filter from 'lodash/filter';
 
@@ -13,7 +13,6 @@ import { InfoCard } from './InfoCard';
 import { TourCard } from './TourCard';
 import { OperatingCompanyInfo } from './OperatingCompanyInfo';
 import { ImagesCarousel } from '../ImagesCarousel';
-import { OrientationContext } from '../../OrientationProvider';
 import { useMatomoTrackScreenView } from '../../hooks';
 import { matomoTrackingString } from '../../helpers';
 
@@ -22,7 +21,6 @@ const { MATOMO_TRACKING } = consts;
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const Tour = ({ data, navigation }) => {
-  const { orientation, dimensions } = useContext(OrientationContext);
   const {
     addresses,
     category,
@@ -116,12 +114,7 @@ export const Tour = ({ data, navigation }) => {
             </TitleContainer>
             {device.platform === 'ios' && <TitleShadow />}
             <Wrapper>
-              <HtmlView
-                html={description}
-                openWebScreen={openWebScreen}
-                orientation={orientation}
-                dimensions={dimensions}
-              />
+              <HtmlView html={description} openWebScreen={openWebScreen} />
             </Wrapper>
           </View>
         )}

--- a/src/components/screens/Tour.js
+++ b/src/components/screens/Tour.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
-import { View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import _filter from 'lodash/filter';
 
 import { consts, device, texts } from '../../config';
@@ -86,7 +86,9 @@ export const Tour = ({ data, navigation }) => {
       {!!images && images.length > 1 && <ImagesCarousel data={images} />}
 
       <WrapperWithOrientation>
-        {!!images && images.length === 1 && <Image source={images[0].picture} />}
+        {!!images && images.length === 1 && (
+          <Image source={images[0].picture} containerStyle={styles.imageContainer} />
+        )}
 
         {!!title && (
           <View>
@@ -146,6 +148,12 @@ export const Tour = ({ data, navigation }) => {
   );
 };
 /* eslint-enable complexity */
+
+const styles = StyleSheet.create({
+  imageContainer: {
+    alignSelf: 'center'
+  }
+});
 
 Tour.propTypes = {
   data: PropTypes.object.isRequired,

--- a/src/config/styles/html.js
+++ b/src/config/styles/html.js
@@ -1,6 +1,7 @@
 import { colors } from '../colors';
 import { normalize } from '../normalize';
-import { imageHeight, imageWidth } from '../../helpers/imageHelper';
+import { imageHeight } from '../../helpers/imageHelper';
+import { Dimensions } from 'react-native';
 
 export const html = {
   p: {
@@ -69,6 +70,6 @@ export const html = {
   },
   iframe: {
     alignSelf: 'center',
-    height: imageHeight(imageWidth())
+    height: imageHeight(Dimensions.get('window').width)
   }
 };

--- a/src/helpers/imageHelper.js
+++ b/src/helpers/imageHelper.js
@@ -4,24 +4,15 @@ import _isString from 'lodash/isString';
 import _isInteger from 'lodash/isInteger';
 import { Dimensions } from 'react-native';
 
-import { consts } from '../config';
+import { consts } from '../config/consts';
 
-export const imageWidth = (orientation, dimensions) => {
-  if (orientation && dimensions) {
-    let width = dimensions.width;
+export const imageWidth = () => {
+  // image width should be smaller than full width on landscape, so take the device height,
+  // which is the same as the device width in portrait.
+  // this can be done implicitly with using the lower value of dimensions height and width.
+  const { height, width } = Dimensions.get('window');
 
-    const needLandscapeWidth = orientation === 'landscape';
-
-    if (needLandscapeWidth) {
-      // image width should be smaller than full width on landscape, so take the device height,
-      // which is the same as the device width in portrait
-      width = dimensions.height;
-    }
-
-    return width;
-  }
-
-  return Dimensions.get('window').width;
+  return Math.min(height, width);
 };
 
 export const imageHeight = (width, aspectRatio) => {

--- a/src/helpers/imageHelper.js
+++ b/src/helpers/imageHelper.js
@@ -6,7 +6,23 @@ import { Dimensions } from 'react-native';
 
 import { consts } from '../config';
 
-export const imageWidth = () => Dimensions.get('window').width;
+export const imageWidth = (orientation, dimensions) => {
+  if (orientation && dimensions) {
+    let width = dimensions.width;
+
+    const needLandscapeWidth = orientation === 'landscape';
+
+    if (needLandscapeWidth) {
+      // image width should be smaller than full width on landscape, so take the device height,
+      // which is the same as the device width in portrait
+      width = dimensions.height;
+    }
+
+    return width;
+  }
+
+  return Dimensions.get('window').width;
+};
 
 export const imageHeight = (width, aspectRatio) => {
   const { IMAGE_ASPECT_RATIO } = consts;

--- a/src/screens/BB-BUS/DetailScreen.js
+++ b/src/screens/BB-BUS/DetailScreen.js
@@ -256,14 +256,7 @@ export const DetailScreen = ({ navigation }) => {
               {isOpenSection(type.id, isKurztext) && (
                 <WrapperWithOrientation noFlex>
                   <Wrapper>
-                    {!!text && (
-                      <HtmlView
-                        html={trimNewLines(text)}
-                        openWebScreen={openWebScreen}
-                        orientation={orientation}
-                        dimensions={dimensions}
-                      />
-                    )}
+                    {!!text && <HtmlView html={trimNewLines(text)} openWebScreen={openWebScreen} />}
                     {!!externalLinks?.length &&
                       externalLinks.map((externalLink) => {
                         // fix for multi nested result form Directus API
@@ -338,8 +331,6 @@ export const DetailScreen = ({ navigation }) => {
                       !!accordion[authority.authority.id] || index == authorities.length - 1
                     }
                     openWebScreen={openWebScreen}
-                    orientation={orientation}
-                    dimensions={dimensions}
                   />
                 ))}
 

--- a/src/screens/ConstructionSiteDetailScreen.js
+++ b/src/screens/ConstructionSiteDetailScreen.js
@@ -71,7 +71,9 @@ export const ConstructionSiteDetailScreen = ({ navigation }) => {
     <SafeAreaViewFlex>
       <ScrollView keyboardShouldPersistTaps="handled">
         <WrapperWithOrientation>
-          {!!imageUri && <Image source={{ uri: imageUri }} />}
+          {!!imageUri && (
+            <Image source={{ uri: imageUri }} containerStyle={styles.imageContainer} />
+          )}
           <TitleContainer>
             <Title>{extendedTitle}</Title>
           </TitleContainer>
@@ -152,6 +154,9 @@ const styles = StyleSheet.create({
   },
   verticalPadding: {
     paddingTop: normalize(14)
+  },
+  imageContainer: {
+    alignSelf: 'center'
   }
 });
 

--- a/src/screens/HtmlScreen.js
+++ b/src/screens/HtmlScreen.js
@@ -26,14 +26,12 @@ import {
 import { graphqlFetchPolicy, trimNewLines } from '../helpers';
 import { getQuery } from '../queries';
 import { arrowLeft } from '../icons';
-import { OrientationContext } from '../OrientationProvider';
 import { useRefreshTime } from '../hooks';
 
 const { MATOMO_TRACKING } = consts;
 
 export const HtmlScreen = ({ navigation }) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
-  const { orientation, dimensions } = useContext(OrientationContext);
   const query = navigation.getParam('query', '');
   const queryVariables = navigation.getParam('queryVariables', '');
   const title = navigation.getParam('title', '');
@@ -146,8 +144,6 @@ export const HtmlScreen = ({ navigation }) => {
                     html={trimNewLines(data.publicHtmlFile.content)}
                     openWebScreen={openWebScreen}
                     navigation={navigation}
-                    orientation={orientation}
-                    dimensions={dimensions}
                   />
                   {!!subQuery && !!subQuery.routeName && !!subQuery.webUrl && (
                     <Button


### PR DESCRIPTION
- image sizes depend on orientation of the device,
  therefore we already had a method to set correct widths
  - this logics are now placed in `imageWidth` to be used elsewhere
    if necessary
- with updated react-native-elements image component the `alignSelf` was
  missing in some cases
  - this needs to be a `containerStyle` with the newer version
- adjusted every usage of `Image`
- the map also needed adjustments concerning height & width

---

i hope i reached every code.
i think it behaves again like expected and in versions before 1.5.1.

![Simulator Screen Shot - iPhone 11 Pro Max - 2021-01-21 at 18 45 43-side](https://user-images.githubusercontent.com/1942953/105393629-da863400-5c1c-11eb-9382-0f22b3c401c7.png)

![Simulator Screen Shot - iPhone 11 Pro Max - 2021-01-21 at 18 45 48-down](https://user-images.githubusercontent.com/1942953/105393636-dc4ff780-5c1c-11eb-865b-6fe832004c8c.png)

---

refactor(image width): use min of dimensions height and width

- we could simplify the logic for correct image width with using the min value of dimensions height and width
  - this made it possible to get rid of `orientation` and `dimensions` props in several components without changing render results
  - this also made it possible to get rid of `OrientationContext` in some components