### PR TITLE
Render missing web urls

### DIFF
--- a/src/components/screens/InfoCard.js
+++ b/src/components/screens/InfoCard.js
@@ -175,8 +175,11 @@ export const InfoCard = ({ addresses, category, contact, contacts, webUrls, open
             } (Taste) (Öffnet Webseite in der aktuellen App)`}
             onPress={() => openLink(url, openWebScreen)}
           >
-            {!description && <RegularText primary>{url}</RegularText>}
-            {!!description && <RegularText primary>{description}</RegularText>}
+            {!description || !!description?.startsWith('url') ? (
+              <RegularText primary>{url}</RegularText>
+            ) : (
+              <RegularText primary>{description}</RegularText>
+            )}
           </TouchableOpacity>
         </InfoBox>
       );

--- a/src/components/screens/InfoCard.js
+++ b/src/components/screens/InfoCard.js
@@ -67,6 +67,24 @@ const contactView = (contact) => (
   </View>
 );
 
+const mergeWebUrls = ({ webUrls, contact, contacts }) => {
+  const mergedWebUrls = [...webUrls];
+
+  // merge a `contact`s `webUrls` to `webUrls`
+  if (contact?.webUrls?.length) {
+    mergedWebUrls.push(...contact.webUrls);
+  }
+
+  // iterate all `contacts` and merge every `contact`s `webUrls` to `webUrls`
+  contacts?.forEach((contact) => {
+    if (contact?.webUrls?.length) {
+      mergedWebUrls.push(...contact.webUrls);
+    }
+  });
+
+  return mergedWebUrls;
+};
+
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 /* TODO: add a logic to display info category and url that fit the screen even if long text
@@ -141,29 +159,28 @@ export const InfoCard = ({ addresses, category, contact, contacts, webUrls, open
         }
       })}
 
-    {!!webUrls &&
-      webUrls.map((item, index) => {
-        const { url, description } = item;
+    {mergeWebUrls({ webUrls, contact, contacts }).map((item, index) => {
+      const { url, description } = item;
 
-        if (!url) {
-          return null;
-        }
+      if (!url) {
+        return null;
+      }
 
-        return (
-          <InfoBox key={index}>
-            <Icon xml={urlIcon(colors.primary)} style={styles.margin} />
-            <TouchableOpacity
-              accessibilityLabel={`(Webseite) ${
-                description || url
-              } (Taste) (Öffnet Webseite in der aktuellen App)`}
-              onPress={() => openLink(url, openWebScreen)}
-            >
-              {!description && <RegularText primary>{url}</RegularText>}
-              {!!description && <RegularText primary>{description}</RegularText>}
-            </TouchableOpacity>
-          </InfoBox>
-        );
-      })}
+      return (
+        <InfoBox key={index}>
+          <Icon xml={urlIcon(colors.primary)} style={styles.margin} />
+          <TouchableOpacity
+            accessibilityLabel={`(Webseite) ${
+              description || url
+            } (Taste) (Öffnet Webseite in der aktuellen App)`}
+            onPress={() => openLink(url, openWebScreen)}
+          >
+            {!description && <RegularText primary>{url}</RegularText>}
+            {!!description && <RegularText primary>{description}</RegularText>}
+          </TouchableOpacity>
+        </InfoBox>
+      );
+    })}
   </View>
 );
 /* eslint-enable complexity */

--- a/src/components/screens/InfoCard.js
+++ b/src/components/screens/InfoCard.js
@@ -68,7 +68,7 @@ const contactView = (contact) => (
 );
 
 const mergeWebUrls = ({ webUrls, contact, contacts }) => {
-  const mergedWebUrls = [...webUrls];
+  const mergedWebUrls = webUrls ? [...webUrls] : [];
 
   // merge a `contact`s `webUrls` to `webUrls`
   if (contact?.webUrls?.length) {

--- a/src/queries/eventRecords.js
+++ b/src/queries/eventRecords.js
@@ -102,6 +102,22 @@ export const GET_EVENT_RECORDS_AND_CATEGORIES = gql`
         kind
         addition
       }
+      contacts {
+        id
+        firstName
+        lastName
+        phone
+        email
+        fax
+        webUrls {
+          url
+          description
+        }
+      }
+      webUrls: urls {
+        url
+        description
+      }
       priceInformations {
         name
         amount
@@ -154,10 +170,15 @@ export const GET_EVENT_RECORD = gql`
       }
       contacts {
         id
-        email
-        phone
-        lastName
         firstName
+        lastName
+        phone
+        email
+        fax
+        webUrls {
+          url
+          description
+        }
       }
       webUrls: urls {
         url

--- a/src/queries/pointsOfInterest.js
+++ b/src/queries/pointsOfInterest.js
@@ -34,12 +34,19 @@ export const GET_POINTS_OF_INTEREST = gql`
         }
       }
       contact {
-        email
-        phone
+        firstName
         lastName
+        phone
+        email
+        fax
+        webUrls {
+          url
+          description
+        }
       }
       webUrls {
         url
+        description
       }
     }
   }
@@ -80,12 +87,19 @@ export const GET_POINT_OF_INTEREST = gql`
         }
       }
       contact {
-        email
-        phone
+        firstName
         lastName
+        phone
+        email
+        fax
+        webUrls {
+          url
+          description
+        }
       }
       webUrls {
         url
+        description
       }
       priceInformations {
         category
@@ -123,6 +137,7 @@ export const GET_POINT_OF_INTEREST = gql`
           fax
           webUrls {
             url
+            description
           }
         }
       }

--- a/src/queries/pointsOfInterestAndTours.js
+++ b/src/queries/pointsOfInterestAndTours.js
@@ -30,12 +30,19 @@ export const GET_POINTS_OF_INTEREST_AND_TOURS = gql`
         kind
       }
       contact {
-        email
-        phone
+        firstName
         lastName
+        phone
+        email
+        fax
+        webUrls {
+          url
+          description
+        }
       }
       webUrls {
         url
+        description
       }
     }
 
@@ -59,6 +66,21 @@ export const GET_POINTS_OF_INTEREST_AND_TOURS = gql`
         street
         zip
         kind
+      }
+      contact {
+        firstName
+        lastName
+        phone
+        email
+        fax
+        webUrls {
+          url
+          description
+        }
+      }
+      webUrls {
+        url
+        description
       }
       dataProvider {
         logo {

--- a/src/queries/tours.js
+++ b/src/queries/tours.js
@@ -23,6 +23,21 @@ export const GET_TOURS = gql`
         zip
         kind
       }
+      contact {
+        firstName
+        lastName
+        phone
+        email
+        fax
+        webUrls {
+          url
+          description
+        }
+      }
+      webUrls {
+        url
+        description
+      }
       dataProvider {
         logo {
           url
@@ -61,12 +76,19 @@ export const GET_TOUR = gql`
         addition
       }
       contact {
-        email
-        phone
+        firstName
         lastName
+        phone
+        email
+        fax
+        webUrls {
+          url
+          description
+        }
       }
       webUrls {
         url
+        description
       }
       lengthKm
       dataProvider {
@@ -93,6 +115,7 @@ export const GET_TOUR = gql`
           fax
           webUrls {
             url
+            description
           }
         }
       }


### PR DESCRIPTION
feat(InfoCard): merge all available web urls to render

- added attributes to queries to request all necessary data
- created a method to merge all available web urls to render in `InfoCard` for events, points of interest and tours

feat(web urls): filter descriptions starting with "url"

- added a check for descriptions starting with "url" because we do not want to present web urls behind an "url" or "urlInformation" or "urlVideo" or "urlVideoPreview"
  - in that case, we render the just the `url` instead of the `description`

SVA-146 (_please see comment in the ticket for screenshots_)