### PR TITLE
Switch rendering of tours and points of interest

### DIFF
--- a/src/components/CategoryList.js
+++ b/src/components/CategoryList.js
@@ -30,12 +30,12 @@ export class CategoryList extends React.PureComponent {
 
     const sectionedData = [
       {
-        title: texts.categoryTitles.tours,
-        data: _filter(data, (category) => category.toursCount > 0)
-      },
-      {
         title: texts.categoryTitles.pointsOfInterest,
         data: _filter(data, (category) => category.pointsOfInterestCount > 0)
+      },
+      {
+        title: texts.categoryTitles.tours,
+        data: _filter(data, (category) => category.toursCount > 0)
       }
     ];
 

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -31,7 +31,7 @@ export const texts = {
     noBookmarksinCategory:
       'In dieser Kategorie wurden noch keine Einträge für die Lesezeichenliste markiert. Sobald etwas markiert wurde, wird es hier zu finden sein!',
     noBookmarksYet:
-      'Es wurden noch keine Beiträge, Touren oder Orte für die Lesezeichenliste markiert. Sobald etwas markiert wurde, wird es hier zu finden sein!',
+      'Es wurden noch keine Beiträge, Orte oder Touren für die Lesezeichenliste markiert. Sobald etwas markiert wurde, wird es hier zu finden sein!',
     showAll: 'Alle anzeigen'
   },
   categoryFilter: {
@@ -66,12 +66,12 @@ export const texts = {
   homeButtons: {
     events: 'Alle Veranstaltungen anzeigen',
     news: 'Alle Nachrichten anzeigen',
-    pointsOfInterest: 'Alle Touren und Orte anzeigen'
+    pointsOfInterest: 'Alle Orte und Touren anzeigen'
   },
   homeTitles: {
     about: 'Über die App',
     events: 'Veranstaltungen',
-    pointsOfInterest: 'Touren und Orte',
+    pointsOfInterest: 'Orte und Touren',
     service: 'Service',
     company: 'Städtische Unternehmen'
   },
@@ -128,7 +128,7 @@ export const texts = {
       eventRecordsTitle: 'Veranstaltungen',
       imageTextList: 'Liste mit kleinen Bildern',
       newsItemsTitle: 'Nachrichten',
-      pointsOfInterestAndToursTitle: 'Touren und Orte',
+      pointsOfInterestAndToursTitle: 'Orte und Touren',
       sectionTitle: 'Listen-Layouts',
       textList: 'Textliste'
     },

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -120,7 +120,7 @@ export const HomeScreen = ({ navigation }) => {
     CATEGORIES_INDEX: {
       routeName: 'Index',
       params: {
-        title: 'Touren und Orte',
+        title: 'Orte und Touren',
         query: QUERY_TYPES.CATEGORIES,
         queryVariables: {},
         rootRouteName: ROOT_ROUTE_NAMES.POINTS_OF_INTEREST_AND_TOURS


### PR DESCRIPTION
- switched the sections for the list on the category list screen, to have points of interest first and tours last
- renamed every "Touren und Orte" to "Orte und Touren" because we show them in that order on the category screen now