### PR TITLE
Add a notice at the bottom of TMB contents

### DIFF
--- a/src/components/TMB/Notice.js
+++ b/src/components/TMB/Notice.js
@@ -1,0 +1,18 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { texts } from '../../config';
+import { HtmlView } from '../HtmlView';
+import { Wrapper } from '../Wrapper';
+
+export const TMBNotice = ({ dataProvider, openWebScreen }) =>
+  'Tourismus-Marketing Brandenburg' === dataProvider?.name && (
+    <Wrapper>
+      <HtmlView html={texts.tmb.notice} openWebScreen={openWebScreen} />
+    </Wrapper>
+  );
+
+TMBNotice.propTypes = {
+  dataProvider: PropTypes.object.isRequired,
+  openWebScreen: PropTypes.func.isRequired
+};

--- a/src/components/screens/EventRecord.js
+++ b/src/components/screens/EventRecord.js
@@ -19,6 +19,7 @@ import { OpeningTimesCard } from './OpeningTimesCard';
 import { ImagesCarousel } from '../ImagesCarousel';
 import { matomoTrackingString, trimNewLines } from '../../helpers';
 import { useMatomoTrackScreenView } from '../../hooks';
+import { TMBNotice } from '../TMB/Notice';
 
 // necessary hacky way of implementing iframe in webview with correct zoom level
 // thx to: https://stackoverflow.com/a/55780430
@@ -216,6 +217,8 @@ export const EventRecord = ({ data, navigation }) => {
             />
           </View>
         )}
+
+        <TMBNotice dataProvider={dataProvider} openWebScreen={openWebScreen} />
       </WrapperWithOrientation>
     </View>
   );

--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -18,6 +18,7 @@ import { matomoTrackingString } from '../../helpers';
 import { WebViewMap } from '../map/WebViewMap';
 import { location, locationIconAnchor } from '../../icons';
 import { NetworkContext } from '../../NetworkProvider';
+import { TMBNotice } from '../TMB/Notice';
 
 const { MATOMO_TRACKING } = consts;
 
@@ -193,6 +194,8 @@ export const PointOfInterest = ({ data, hideMap, navigation }) => {
             />
           </View>
         )}
+
+        <TMBNotice dataProvider={dataProvider} openWebScreen={openWebScreen} />
       </WrapperWithOrientation>
     </View>
   );

--- a/src/components/screens/Tour.js
+++ b/src/components/screens/Tour.js
@@ -15,6 +15,7 @@ import { OperatingCompanyInfo } from './OperatingCompanyInfo';
 import { ImagesCarousel } from '../ImagesCarousel';
 import { useMatomoTrackScreenView } from '../../hooks';
 import { matomoTrackingString } from '../../helpers';
+import { TMBNotice } from '../TMB/Notice';
 
 const { MATOMO_TRACKING } = consts;
 
@@ -136,6 +137,8 @@ export const Tour = ({ data, navigation }) => {
             />
           </View>
         )}
+
+        <TMBNotice dataProvider={dataProvider} openWebScreen={openWebScreen} />
       </WrapperWithOrientation>
     </View>
   );

--- a/src/config/styles/html.js
+++ b/src/config/styles/html.js
@@ -71,5 +71,8 @@ export const html = {
   iframe: {
     alignSelf: 'center',
     height: imageHeight(Dimensions.get('window').width)
+  },
+  em: {
+    fontFamily: 'titillium-web-italic'
   }
 };

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -140,6 +140,10 @@ export const texts = {
     company: 'Unternehmen',
     about: 'Mehr'
   },
+  tmb: {
+    notice:
+      '<p><br /><em>Dies ist ein Service der TMB Tourismus-Marketing Brandenburg GmbH und der regionalen Tourismuspartner. Mehr Informationen zu Reisen und Ausflügen ins Land Brandenburg erhalten sie auf <a href="https://www.reiseland-brandenburg.de" title="www.reiseland-brandenburg.de"><em>www.reiseland-brandenburg.de</em></a></em></p>'
+  },
   tour: {
     description: 'Beschreibung',
     end: 'Tourende',


### PR DESCRIPTION
- created new component `TMBNotice` that renders a text at the bottom of events, points of interest and tours, if the data provider is TMB
  - the check for the data provider can only be done on the string `name` because the corresponding `id` can differ across apps
- added the new component in detail components
- added the notice as html text to `texts`
- added a html style for emphasized texts to show the notice in italic style

SVA-118

|Event iOS|Event Android|
|---------|--------------|
|![Simulator Screen Shot - iPhone 11 Pro Max - 2021-01-27 at 13 21 16](https://user-images.githubusercontent.com/1942953/105992798-d12a1b00-60a5-11eb-841b-96fa1b79d682.png)|![Screenshot_20210127-133245](https://user-images.githubusercontent.com/1942953/105992681-b5bf1000-60a5-11eb-9493-a953abd62028.png)|

|Point of interest iOS|Tour iOS|
|---------|--------------|
|![Simulator Screen Shot - iPhone 11 Pro Max - 2021-01-27 at 13 34 26](https://user-images.githubusercontent.com/1942953/105992859-e606ae80-60a5-11eb-8b9a-31c29869e94d.png)|![Simulator Screen Shot - iPhone 11 Pro Max - 2021-01-27 at 13 34 15](https://user-images.githubusercontent.com/1942953/105992868-e8690880-60a5-11eb-9022-6cebc873c172.png)|