### PR TITLE
Optimize images carousel

### DIFF
--- a/src/components/ImagesCarouselItem.js
+++ b/src/components/ImagesCarouselItem.js
@@ -1,0 +1,35 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+
+import { Image } from './Image';
+
+/**
+ * Smart item component for `ImagesCarousel`, that renders an image or an image wrapped in a
+ * touchable that can navigate to a given `routeName` with `params`.
+ *
+ * @return {ReactElement} `Image` or an `Image` wrapped in a `TouchableOpacity`
+ */
+export const ImagesCarouselItem = ({ navigation, source, containerStyle, aspectRatio }) => {
+  const { routeName, params } = source;
+
+  if (routeName && params) {
+    return (
+      <TouchableOpacity
+        onPress={() => navigation.navigate({ routeName, params })}
+        activeOpacity={0.8}
+      >
+        <Image {...{ source, containerStyle, aspectRatio }} />
+      </TouchableOpacity>
+    );
+  }
+
+  return <Image {...{ source, containerStyle, aspectRatio }} />;
+};
+
+ImagesCarouselItem.propTypes = {
+  navigation: PropTypes.object,
+  source: PropTypes.object.isRequired,
+  containerStyle: PropTypes.object,
+  aspectRatio: PropTypes.object
+};

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -17,6 +17,7 @@ export * from './HtmlView';
 export * from './Icon';
 export * from './Image';
 export * from './ImagesCarousel';
+export * from './ImagesCarouselItem';
 export * from './ImageTextList';
 export * from './Label';
 export * from './Link';

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -159,7 +159,7 @@ export const HomeScreen = ({ navigation }) => {
           />
         }
       >
-        <HomeCarousel navigation={navigation} />
+        <HomeCarousel navigation={navigation} refreshing={refreshing} />
         <Widgets navigation={navigation} widgets={widgets} />
 
         {showNews &&


### PR DESCRIPTION
chore(home carousel): add pull to refresh

- add missing `refreshing` prop from home screen to force refetch of data

refactor(images carousel): optimize code for carousel items

- created `ImagesCarouselItem` from `TouchableImage`, which returns a simple image or a touchable image that can navigate to a given `routeName` with `params`
- reduced the conditions for return of `renderItem` in `ImagesCarousel` with the result, that there is always a return of `ImagesCarouselItem` whether with extra query or not
  - added optional chaining for the remained condition to shorten the checks
- reduced the conditions in `renderItem` for `itemWidth` with using the  new `imageWidth()` helper method, that is taking care of the correct  size
- added `useCallback` for `renderItem` in `ImagesCarousel` to avoid unintended re-renders
- added early return of `null` if `item` is `undefined` to avoid errors in further context
- avoid rendering a carousel if there is just one element to show
  - if there is one entry in the data, we do not want to render a whole carousel, we than just need the one item to render

SVA-81