### PR TITLE
Show message on slider item

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -7,10 +7,12 @@ import { Image as RNEImage } from 'react-native-elements';
 import { colors } from '../config';
 import { imageHeight, imageWidth } from '../helpers';
 import { SettingsContext } from '../SettingsProvider';
+import { ImageMessage } from './ImageMessage';
 import { ImageRights } from './ImageRights';
 
 export const Image = ({
   source,
+  message,
   style,
   containerStyle,
   PlaceholderContent,
@@ -54,6 +56,7 @@ export const Image = ({
         resizeMode={resizeMode}
         borderRadius={borderRadius}
       />
+      {!!message && <ImageMessage message={message} />}
       {globalSettings?.showImageRights && source?.copyright && (
         <ImageRights imageRights={source.copyright} />
       )}
@@ -80,6 +83,7 @@ const stylesForImage = (aspectRatio) => {
 
 Image.propTypes = {
   source: PropTypes.oneOfType([PropTypes.object, PropTypes.number]).isRequired,
+  message: PropTypes.string,
   containerStyle: PropTypes.object,
   style: PropTypes.object,
   PlaceholderContent: PropTypes.object,

--- a/src/components/ImageMessage.js
+++ b/src/components/ImageMessage.js
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { normalize } from '../config';
+import { HtmlView } from './HtmlView';
+
+export const ImageMessage = ({ message }) => (
+  <View style={styles.containerStyle}>
+    <HtmlView html={message} />
+  </View>
+);
+
+const styles = StyleSheet.create({
+  containerStyle: {
+    bottom: normalize(24),
+    position: 'absolute',
+    left: normalize(14)
+  }
+});
+
+ImageMessage.propTypes = {
+  message: PropTypes.string.isRequired
+};

--- a/src/components/ImagesCarousel.js
+++ b/src/components/ImagesCarousel.js
@@ -57,6 +57,7 @@ export const ImagesCarousel = ({ data, navigation, fetchPolicy, aspectRatio }) =
                 <ImagesCarouselItem
                   navigation={navigation}
                   source={item.picture}
+                  message={item.message}
                   containerStyle={styles.imageContainer}
                   aspectRatio={aspectRatio}
                 />
@@ -70,6 +71,7 @@ export const ImagesCarousel = ({ data, navigation, fetchPolicy, aspectRatio }) =
         <ImagesCarouselItem
           navigation={navigation}
           source={item.picture}
+          message={item.message}
           containerStyle={styles.imageContainer}
           aspectRatio={aspectRatio}
         />

--- a/src/components/ImagesCarouselItem.js
+++ b/src/components/ImagesCarouselItem.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { memo } from 'react';
 import { TouchableOpacity } from 'react-native';
 
 import { Image } from './Image';
@@ -10,26 +10,31 @@ import { Image } from './Image';
  *
  * @return {ReactElement} `Image` or an `Image` wrapped in a `TouchableOpacity`
  */
-export const ImagesCarouselItem = ({ navigation, source, containerStyle, aspectRatio }) => {
-  const { routeName, params } = source;
+export const ImagesCarouselItem = memo(
+  ({ navigation, source, message, containerStyle, aspectRatio }) => {
+    const { routeName, params } = source;
 
-  if (routeName && params) {
-    return (
-      <TouchableOpacity
-        onPress={() => navigation.navigate({ routeName, params })}
-        activeOpacity={0.8}
-      >
-        <Image {...{ source, containerStyle, aspectRatio }} />
-      </TouchableOpacity>
-    );
+    if (routeName && params) {
+      return (
+        <TouchableOpacity
+          onPress={() => navigation.navigate({ routeName, params })}
+          activeOpacity={0.8}
+        >
+          <Image {...{ source, message, containerStyle, aspectRatio }} />
+        </TouchableOpacity>
+      );
+    }
+
+    return <Image {...{ source, message, containerStyle, aspectRatio }} />;
   }
+);
 
-  return <Image {...{ source, containerStyle, aspectRatio }} />;
-};
+ImagesCarouselItem.displayName = 'ImagesCarouselItem';
 
 ImagesCarouselItem.propTypes = {
   navigation: PropTypes.object,
   source: PropTypes.object.isRequired,
+  message: PropTypes.string,
   containerStyle: PropTypes.object,
   aspectRatio: PropTypes.object
 };


### PR DESCRIPTION
feat(images carousel): render an items message onto an image

- created `ImageMessage` for rendering a `message` in a `HtmlView` absolutely positioned on the bottom left with some spacing to the container edge
- added `message` prop to `ImagesCarouselItem` to pass through to `Image`
- wrapped `ImagesCarouselItem` with `memo` to reduce re-renderings
  - tested it with console logs, that were decreased
- added `message` prop to `Image` and render `ImageMessage` if `message` is present

SVA-81

---

1. `"message": "<h1 style=\"color: #ffffff; margin-bottom: 0\">nur Januar</h1><h2 style=\"color: #ffffff\">ganztägig</h2>"`
2. `"message": "<div style=\"background-color: rgba(20, 20, 20, 0.4); padding: 4px\"><p style=\"background-color: transparent; margin-bottom: 0px; color: #ffffff\">immer, 10:00 - 12:00 und 14:00 - 16:00</p></div>"`

![Simulator Screen Shot - iPhone 11 Pro Max - 2021-01-28 at 13 55 53-side](https://user-images.githubusercontent.com/1942953/106141592-9f31bb00-6170-11eb-824f-f0c97df75f25.png)
