### PR TITLE
Show just in time slider items

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,7 @@
-module.exports = function(api) {
+module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
+    plugins: ['@babel/plugin-proposal-logical-assignment-operators']
   };
 };

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "styled-components": "~4.3.2"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-logical-assignment-operators": "^7.12.1",
     "@types/lodash": "^4.14.165",
     "@types/react": "~16.9.35",
     "@types/react-dom": "~16.9.8",

--- a/src/components/ImagesCarousel.js
+++ b/src/components/ImagesCarousel.js
@@ -5,7 +5,7 @@ import { ActivityIndicator, StyleSheet } from 'react-native';
 import { Query } from 'react-apollo';
 
 import { colors } from '../config';
-import { imageWidth, shareMessage } from '../helpers';
+import { imageWidth, isActive, shareMessage } from '../helpers';
 import { getQuery } from '../queries';
 import { ImagesCarouselItem } from './ImagesCarouselItem';
 import { LoadingContainer } from './LoadingContainer';
@@ -17,8 +17,6 @@ export const ImagesCarousel = ({ data, navigation, fetchPolicy, aspectRatio }) =
 
   const renderItem = useCallback(
     ({ item }) => {
-      if (!item) return null;
-
       const { routeName, params } = item.picture || {};
 
       // params are available, but missing `shareContent` and `details`
@@ -80,15 +78,18 @@ export const ImagesCarousel = ({ data, navigation, fetchPolicy, aspectRatio }) =
     [navigation, fetchPolicy, aspectRatio]
   );
 
+  // filter data for present items and items with active date/time periods
+  const carouselData = data.filter((item) => item && isActive(item));
+
   // if there is one entry in the data, we do not want to render a whole carousel, we than just
   // need the one item to render
-  if (data.length === 1) {
-    return renderItem({ item: data[0] });
+  if (carouselData.length === 1) {
+    return renderItem({ item: carouselData[0] });
   }
 
   return (
     <Carousel
-      data={data}
+      data={carouselData}
       renderItem={renderItem}
       sliderWidth={dimensions.width}
       itemWidth={itemWidth}

--- a/src/components/screens/HomeCarousel.js
+++ b/src/components/screens/HomeCarousel.js
@@ -51,20 +51,20 @@ export const HomeCarousel = ({ navigation, refreshing }) => {
           );
         }
 
-        let carouselImages = [];
+        let homeCarouselData = [];
 
         try {
-          carouselImages = JSON.parse(data?.publicJsonFile?.content);
+          homeCarouselData = JSON.parse(data?.publicJsonFile?.content);
         } catch (error) {
           console.warn(error, data);
         }
 
-        if (!carouselImages || !carouselImages.length) return null;
+        if (!homeCarouselData || !homeCarouselData.length) return null;
 
         return (
           <ImagesCarousel
             navigation={navigation}
-            data={_shuffle(carouselImages)}
+            data={_shuffle(homeCarouselData)}
             fetchPolicy={fetchPolicy}
             aspectRatio={parsedImageAspectRatio(globalSettings?.homeCarousel?.imageAspectRatio)}
           />

--- a/yarn.lock
+++ b/yarn.lock
@@ -819,6 +819,14 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-json-strings" "^7.8.0"
 
+"@babel/plugin-proposal-logical-assignment-operators@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.1.tgz#f2c490d36e1b3c9659241034a5d2cd50263a2751"
+  integrity sha512-k8ZmVv0JU+4gcUGeCDZOGd0lCIamU/sMtIiX3UWnUc5yzgq6YUGyEolNYD+MLYKfSzgECPcqetVcJP9Afe/aCA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
+
 "@babel/plugin-proposal-nullish-coalescing-operator@^7.0.0":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.4.4.tgz#41c360d59481d88e0ce3a3f837df10121a769b39"
@@ -1000,6 +1008,13 @@
   integrity sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-logical-assignment-operators@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz#ca91ef46303530448b906652bac2e9fe9941f699"
+  integrity sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-syntax-logical-assignment-operators@^7.8.3":
   version "7.8.3"


### PR DESCRIPTION
- created date and time helper methods to identify items to show based on their `dates` object with or without given date and/or time periods
  - used `moment` for easier working with date and time values
- added a filter for `carouselData` in `ImagesCarousel` for present items and items with active date/time periods
  - this made the check for a present `item` in `renderItem` superfluous
- renamed `carouselImages` to `homeCarouselData` in `HomeCarousel`, because it is more on point as the data is not only about images anymore

SVA-81

---

Any ideas on optimizing logics or readability of the date and time conditions?