### PR TITLE
fix(share icon and settings icon) removed paddingVertical

### DIFF
--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -16,7 +16,7 @@ export const Icon = ({ xml, width, height, name, size, focused, iconColor, style
   const color = iconColor || (focused ? colors.accent : colors.primary);
 
   return (
-    <View style={style}>
+    <View style={style} hitSlop={{ top: 12, bottom: 12 }}>
       {xml && <SvgXml xml={xml} width={width} height={height} style={iconStyle} />}
       {name && <Ionicons name={name} size={size} color={color} style={iconStyle} />}
     </View>

--- a/src/screens/BB-BUS/DetailScreen.js
+++ b/src/screens/BB-BUS/DetailScreen.js
@@ -385,13 +385,11 @@ const styles = StyleSheet.create({
   },
   iconLeft: {
     paddingLeft: normalize(14),
-    paddingRight: normalize(7),
-    paddingVertical: normalize(4)
+    paddingRight: normalize(7)
   },
   iconRight: {
     paddingLeft: normalize(7),
-    paddingRight: normalize(14),
-    paddingVertical: normalize(4)
+    paddingRight: normalize(14)
   },
   sectionTitle: {
     backgroundColor: colors.transparent,

--- a/src/screens/BookmarkScreen.js
+++ b/src/screens/BookmarkScreen.js
@@ -121,13 +121,11 @@ const styles = StyleSheet.create({
   },
   iconLeft: {
     paddingLeft: normalize(14),
-    paddingRight: normalize(7),
-    paddingVertical: normalize(4)
+    paddingRight: normalize(7)
   },
   iconRight: {
     paddingLeft: normalize(7),
-    paddingRight: normalize(14),
-    paddingVertical: normalize(4)
+    paddingRight: normalize(14)
   }
 });
 

--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -134,13 +134,11 @@ const styles = StyleSheet.create({
   },
   iconLeft: {
     paddingLeft: normalize(14),
-    paddingRight: normalize(7),
-    paddingVertical: normalize(4)
+    paddingRight: normalize(7)
   },
   iconRight: {
     paddingLeft: normalize(7),
-    paddingRight: normalize(14),
-    paddingVertical: normalize(4)
+    paddingRight: normalize(14)
   }
 });
 


### PR DESCRIPTION
On IOS devices : 
- paddingVertical was apparently unnecessary and created a bug
- without it the bug does not occur and there is no break in all other devices
- added a new prop hitSlop. As the removed paddings hitSlop defines how far a touch event can start away from the view
  - resulting in a "smooth touch" experience
 
#167



Has to be tested on Android devices 
