### PR TITLE
fix(location overview): crash at null value

### DIFF
--- a/src/components/map/LocationOverview.tsx
+++ b/src/components/map/LocationOverview.tsx
@@ -28,7 +28,8 @@ const mapToMapMarkers = (data: any): MapMarker[] | undefined => {
     data?.[QUERY_TYPES.POINTS_OF_INTEREST]
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ?.map((item: any) => {
-        const { latitude, longitude } = item.addresses?.[0]?.geoLocation;
+        const latitude = item.addresses?.[0]?.geoLocation?.latitude;
+        const longitude = item.addresses?.[0]?.geoLocation?.longitude;
 
         if (!latitude || !longitude) return undefined;
         return {


### PR DESCRIPTION
## Changes proposed in this PR:

Took the optional chaining one step further to ensure that their is no longer destructuring of props of undefined values.
