### PR TITLE
Fix/sva 172 homescreen refreshing

### DIFF
--- a/src/components/HomeSection.tsx
+++ b/src/components/HomeSection.tsx
@@ -16,9 +16,9 @@ import { Touchable } from './Touchable';
 import { Wrapper } from './Wrapper';
 
 type Props = {
-  categoryTitle: string;
-  categoryTitleDetail?: string;
-  categoryButton: string;
+  title: string;
+  titleDetail?: string;
+  buttonTitle: string;
   fetchPolicy:
     | 'cache-first'
     | 'network-only'
@@ -26,7 +26,7 @@ type Props = {
     | 'no-cache'
     | 'standby'
     | 'cache-and-network';
-  navigateToCategory: () => void;
+  navigate: () => void;
   navigation: NavigationScreenProp<never>;
   query: string;
   queryParser?: (data: unknown) => unknown[];
@@ -34,11 +34,11 @@ type Props = {
 };
 
 export const HomeSection = ({
-  categoryButton,
-  categoryTitle,
-  categoryTitleDetail,
+  buttonTitle,
+  title,
+  titleDetail,
   fetchPolicy,
-  navigateToCategory,
+  navigate,
   navigation,
   query,
   queryParser,
@@ -63,17 +63,15 @@ export const HomeSection = ({
   }
 
   const items =
-    queryParser?.(data) ?? parseListItemsFromQuery(query, data, true, categoryTitleDetail ?? '');
+    queryParser?.(data) ?? parseListItemsFromQuery(query, data, true, titleDetail ?? '');
 
   if (!items || !items.length) return null;
 
   return (
     <>
       <TitleContainer>
-        <Touchable onPress={navigateToCategory}>
-          <Title accessibilityLabel={`${categoryTitle} (Überschrift) (Taste)`}>
-            {categoryTitle}
-          </Title>
+        <Touchable onPress={navigate}>
+          <Title accessibilityLabel={`${title} (Überschrift) (Taste)`}>{title}</Title>
         </Touchable>
       </TitleContainer>
       {device.platform === 'ios' && <TitleShadow />}
@@ -87,7 +85,7 @@ export const HomeSection = ({
         />
 
         <Wrapper>
-          <Button title={categoryButton} onPress={navigateToCategory} />
+          <Button title={buttonTitle} onPress={navigate} />
         </Wrapper>
       </View>
     </>

--- a/src/components/HomeSection.tsx
+++ b/src/components/HomeSection.tsx
@@ -5,6 +5,7 @@ import { NavigationScreenProp } from 'react-navigation';
 
 import { colors, consts, device } from '../config';
 import { parseListItemsFromQuery } from '../helpers';
+import { useHomeRefresh } from '../hooks/HomeRefresh';
 import { getQuery } from '../queries';
 import { SettingsContext } from '../SettingsProvider';
 import { Button } from './Button';
@@ -46,7 +47,12 @@ export const HomeSection = ({
   const { listTypesSettings } = useContext(SettingsContext);
   const listType = listTypesSettings[query];
 
-  const { data, loading } = useQuery(getQuery(query), { variables: queryVariables, fetchPolicy });
+  const { data, loading, refetch } = useQuery(getQuery(query), {
+    variables: queryVariables,
+    fetchPolicy
+  });
+
+  useHomeRefresh(refetch);
 
   if (loading) {
     return (

--- a/src/components/HomeSection.tsx
+++ b/src/components/HomeSection.tsx
@@ -1,0 +1,89 @@
+import React, { useContext } from 'react';
+import { QueryHookOptions, useQuery } from 'react-apollo';
+import { ActivityIndicator, View } from 'react-native';
+import { NavigationScreenProp } from 'react-navigation';
+
+import { colors, consts, device } from '../config';
+import { parseListItemsFromQuery } from '../helpers';
+import { getQuery } from '../queries';
+import { SettingsContext } from '../SettingsProvider';
+import { Button } from './Button';
+import { ListComponent } from './ListComponent';
+import { LoadingContainer } from './LoadingContainer';
+import { Title, TitleContainer, TitleShadow } from './Title';
+import { Touchable } from './Touchable';
+import { Wrapper } from './Wrapper';
+
+type Props = {
+  categoryTitle: string;
+  categoryTitleDetail?: string;
+  categoryButton: string;
+  fetchPolicy:
+    | 'cache-first'
+    | 'network-only'
+    | 'cache-only'
+    | 'no-cache'
+    | 'standby'
+    | 'cache-and-network';
+  navigateToCategory: () => void;
+  navigation: NavigationScreenProp<never>;
+  query: string;
+  queryParser?: (data: unknown) => unknown[];
+  queryVariables: QueryHookOptions;
+};
+
+export const HomeSection = ({
+  categoryButton,
+  categoryTitle,
+  categoryTitleDetail,
+  fetchPolicy,
+  navigateToCategory,
+  navigation,
+  query,
+  queryParser,
+  queryVariables
+}: Props) => {
+  const { listTypesSettings } = useContext(SettingsContext);
+  const listType = listTypesSettings[query];
+
+  const { data, loading } = useQuery(getQuery(query), { variables: queryVariables, fetchPolicy });
+
+  if (loading) {
+    return (
+      <LoadingContainer>
+        <ActivityIndicator color={colors.accent} />
+      </LoadingContainer>
+    );
+  }
+
+  const items =
+    queryParser?.(data) ?? parseListItemsFromQuery(query, data, true, categoryTitleDetail ?? '');
+
+  if (!items || !items.length) return null;
+
+  return (
+    <>
+      <TitleContainer>
+        <Touchable onPress={navigateToCategory}>
+          <Title accessibilityLabel={`${categoryTitle} (Überschrift) (Taste)`}>
+            {categoryTitle}
+          </Title>
+        </Touchable>
+      </TitleContainer>
+      {device.platform === 'ios' && <TitleShadow />}
+
+      <View>
+        <ListComponent
+          navigation={navigation}
+          data={items}
+          query={query}
+          horizontal={listType === consts.LIST_TYPES.CARD_LIST}
+        />
+
+        <Wrapper>
+          <Button title={categoryButton} onPress={navigateToCategory} />
+        </Wrapper>
+      </View>
+    </>
+  );
+};

--- a/src/components/ListComponent.js
+++ b/src/components/ListComponent.js
@@ -28,6 +28,9 @@ const getComponent = (query, listTypesSettings) =>
     [QUERY_TYPES.TOURS]: getListComponent(
       listTypesSettings[QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS]
     ),
+    [QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS]: getListComponent(
+      listTypesSettings[QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS]
+    ),
     [QUERY_TYPES.CATEGORIES]: CategoryList
   }[query]);
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -13,6 +13,7 @@ export * from './CategoryListItem';
 export * from './DiagonalGradient';
 export * from './DropdownHeader';
 export * from './DropdownSelect';
+export * from './HomeSection';
 export * from './HtmlView';
 export * from './Icon';
 export * from './Image';

--- a/src/components/widgets/ConstructionSiteWidget.tsx
+++ b/src/components/widgets/ConstructionSiteWidget.tsx
@@ -6,6 +6,7 @@ import { NavigationScreenProp } from 'react-navigation';
 import { colors, normalize, texts } from '../../config';
 import { ConstructionSiteContext } from '../../ConstructionSiteProvider';
 import { graphqlFetchPolicy } from '../../helpers';
+import { useHomeRefresh } from '../../hooks/HomeRefresh';
 import { constructionSite } from '../../icons';
 import { filterForValidConstructionSites } from '../../jsonValidation';
 import { NetworkContext } from '../../NetworkProvider';
@@ -25,7 +26,7 @@ export const ConstructionSiteWidget = ({ navigation }: Props) => {
 
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
 
-  const { data } = useQuery(getQuery(QUERY_TYPES.PUBLIC_JSON_FILE), {
+  const { data, refetch } = useQuery(getQuery(QUERY_TYPES.PUBLIC_JSON_FILE), {
     variables: { name: 'constructionSites' },
     fetchPolicy
   });
@@ -33,6 +34,8 @@ export const ConstructionSiteWidget = ({ navigation }: Props) => {
   const onPress = useCallback(() => {
     navigation.navigate('ConstructionSiteOverview');
   }, [constructionSites, navigation]);
+
+  useHomeRefresh(refetch);
 
   useEffect(() => {
     if (data) {

--- a/src/components/widgets/EventWidget.tsx
+++ b/src/components/widgets/EventWidget.tsx
@@ -7,6 +7,7 @@ import { NavigationScreenProp } from 'react-navigation';
 import { colors, consts, normalize, texts } from '../../config';
 import { graphqlFetchPolicy } from '../../helpers';
 import { useRefreshTime } from '../../hooks';
+import { useHomeRefresh } from '../../hooks/HomeRefresh';
 import { calendar } from '../../icons';
 import { NetworkContext } from '../../NetworkProvider';
 import { getQuery, QUERY_TYPES } from '../../queries';
@@ -30,7 +31,7 @@ export const EventWidget = ({ navigation }: Props) => {
     dateRange: [currentDate, currentDate]
   };
 
-  const { data, loading } = useQuery(getQuery(QUERY_TYPES.EVENT_RECORDS), {
+  const { data, loading, refetch } = useQuery(getQuery(QUERY_TYPES.EVENT_RECORDS), {
     fetchPolicy,
     variables: queryVariables
   });
@@ -43,6 +44,8 @@ export const EventWidget = ({ navigation }: Props) => {
       rootRouteName: 'EventRecords'
     });
   }, [navigation]);
+
+  useHomeRefresh(refetch);
 
   const eventCount = data?.eventRecords?.length;
 

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -5,6 +5,7 @@ import { NavigationScreenProp } from 'react-navigation';
 
 import { consts, normalize } from '../../config';
 import { graphqlFetchPolicy } from '../../helpers';
+import { useHomeRefresh } from '../../hooks/HomeRefresh';
 import { NetworkContext } from '../../NetworkProvider';
 import { getQuery, QUERY_TYPES } from '../../queries';
 import { Image } from '../Image';
@@ -21,10 +22,12 @@ export const WeatherWidget = ({ navigation }: { navigation: NavigationScreenProp
     fetchPolicy === 'network-only'
       ? { fetchPolicy, pollInterval: POLL_INTERVALS.WEATHER }
       : { fetchPolicy };
-  const { data } = useQuery(getQuery(QUERY_TYPES.WEATHER_MAP_CURRENT), queryVariables);
+  const { data, refetch } = useQuery(getQuery(QUERY_TYPES.WEATHER_MAP_CURRENT), queryVariables);
 
   const icon = data?.weatherMap?.current?.weather?.[0]?.icon ?? '02d';
   const temperature = data?.weatherMap?.current?.temp;
+
+  useHomeRefresh(refetch);
 
   return (
     <Touchable

--- a/src/helpers/queryDataParser.js
+++ b/src/helpers/queryDataParser.js
@@ -1,4 +1,5 @@
 import _filter from 'lodash/filter';
+import _shuffle from 'lodash/shuffle';
 
 import { consts, texts } from '../config';
 import { QUERY_TYPES } from '../queries';
@@ -151,4 +152,12 @@ export const parseListItemsFromQuery = (query, data, skipLastDivider, titleDetai
     case QUERY_TYPES.CATEGORIES:
       return parseCategories(data[query], skipLastDivider);
   }
+};
+
+export const parsePointsOfInterestAndTours = (data) => {
+  const pointsOfInterest = parsePointOfInterest(data?.[QUERY_TYPES.POINTS_OF_INTEREST]);
+
+  const tours = parseTours(data?.[QUERY_TYPES.TOURS]);
+
+  return _shuffle([...(pointsOfInterest || []), ...(tours || [])]);
 };

--- a/src/hooks/HomeRefresh.ts
+++ b/src/hooks/HomeRefresh.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { DeviceEventEmitter } from 'react-native';
+
+export const HOME_REFRESH_EVENT = 'SVA_HOME_REFRESH';
+
+export const useHomeRefresh = (onRefresh?: () => void) => {
+  useEffect(() => {
+    if (!onRefresh) return;
+
+    const subscription = DeviceEventEmitter.addListener(HOME_REFRESH_EVENT, () => onRefresh());
+
+    return () => subscription.remove();
+  }, [onRefresh]);
+};

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -150,12 +150,12 @@ export const HomeScreen = ({ navigation }) => {
             ({ categoryButton, categoryId, categoryTitle, categoryTitleDetail }, index) => (
               <HomeSection
                 key={index}
-                categoryButton={categoryButton}
+                buttonTitle={categoryButton}
                 categoryId={categoryId}
-                categoryTitle={categoryTitle}
-                categoryTitleDetail={categoryTitleDetail}
+                title={categoryTitle}
+                titleDetail={categoryTitleDetail}
                 fetchPolicy={fetchPolicy}
-                navigateToCategory={() =>
+                navigate={() =>
                   navigation.navigate(
                     NAVIGATION.NEWS_ITEMS_INDEX({ categoryId, categoryTitle, categoryTitleDetail })
                   )
@@ -169,10 +169,10 @@ export const HomeScreen = ({ navigation }) => {
 
         {showPointsOfInterestAndTours && (
           <HomeSection
-            categoryButton={buttonPointsOfInterestAndTours}
-            categoryTitle={headlinePointsOfInterestAndTours}
+            buttonTitle={buttonPointsOfInterestAndTours}
+            title={headlinePointsOfInterestAndTours}
             fetchPolicy={fetchPolicy}
-            navigateToCategory={() => navigation.navigate(NAVIGATION.CATEGORIES_INDEX)}
+            navigate={() => navigation.navigate(NAVIGATION.CATEGORIES_INDEX)}
             navigation={navigation}
             query={QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS}
             queryParser={parsePointsOfInterestAndTours}
@@ -182,9 +182,9 @@ export const HomeScreen = ({ navigation }) => {
 
         {showEvents && (
           <HomeSection
-            categoryButton={buttonEvents}
-            categoryTitle={headlineEvents}
-            navigateToCategory={() => navigation.navigate(NAVIGATION.EVENT_RECORDS_INDEX)}
+            buttonTitle={buttonEvents}
+            title={headlineEvents}
+            navigate={() => navigation.navigate(NAVIGATION.EVENT_RECORDS_INDEX)}
             navigation={navigation}
             query={QUERY_TYPES.EVENT_RECORDS}
             queryVariables={{ limit: 3, order: 'listDate_ASC' }}

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,6 +1,12 @@
 import PropTypes from 'prop-types';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
-import { RefreshControl, ScrollView, StyleSheet, TouchableOpacity } from 'react-native';
+import {
+  DeviceEventEmitter,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity
+} from 'react-native';
 
 import { auth } from '../auth';
 import {
@@ -17,6 +23,7 @@ import {
 import { colors, consts, normalize, texts } from '../config';
 import { graphqlFetchPolicy, parsePointsOfInterestAndTours, rootRouteName } from '../helpers';
 import { useMatomoAlertOnStartUp, useMatomoTrackScreenView, usePushNotifications } from '../hooks';
+import { HOME_REFRESH_EVENT } from '../hooks/HomeRefresh';
 import { favSettings } from '../icons';
 import { NetworkContext } from '../NetworkProvider';
 import { getQueryType, QUERY_TYPES } from '../queries';
@@ -80,9 +87,11 @@ export const HomeScreen = ({ navigation }) => {
 
   const refresh = () => {
     setRefreshing(true);
-    // for refetching data on the home screen we need to re-render the whole screen,
-    // in order to re-run every existing query.
-    // there is no solution to call the Apollo `refetch` for every `Query` component.
+
+    // this will trigger the onRefresh functions provided to the useHomeRefresh hook in other
+    // components.
+    DeviceEventEmitter.emit(HOME_REFRESH_EVENT);
+
     // we simulate state change of `refreshing` with setting it to `true` first and after
     // a timeout to `false` again, which will result in a re-rendering of the screen.
     setTimeout(() => {
@@ -133,7 +142,7 @@ export const HomeScreen = ({ navigation }) => {
           />
         }
       >
-        <HomeCarousel navigation={navigation} refreshing={refreshing} />
+        <HomeCarousel navigation={navigation} />
         <Widgets navigation={navigation} widgets={widgets} />
 
         {showNews &&


### PR DESCRIPTION
## Changes proposed in this PR:

- Refactored the homescreen to reduce code redundancy.
- Added useHomeRefresh hook to add to components that have internal functions that need to be called when the pull-to-refresh is triggered.
  - in our case those are all refetches of apollo queries for now
- added useHomeRefresh hook to widgets and new HomeSection component that was the result of the refactoring.

## Known "issue"

There are still remaining components that still use the "old" refreshing method with the "refreshing" prop.
These can be refactored at a later point.

SVA-172
