### PR TITLE
fix(image copyrights): crashing on empty string

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -57,7 +57,7 @@ export const Image = ({
         borderRadius={borderRadius}
       />
       {!!message && <ImageMessage message={message} />}
-      {globalSettings?.showImageRights && source?.copyright && (
+      {!!globalSettings?.showImageRights && !!source?.copyright && (
         <ImageRights imageRights={source.copyright} />
       )}
     </View>


### PR DESCRIPTION
- the empty string is evaluated to false
  - this caused it to be tried to to be rendered (outside of text component)
