### PR TITLE
fix(text): removed required flag from prop

### DIFF
--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -92,5 +92,5 @@ export const BoldText = styled(RegularText)`
 `;
 
 Text.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node
 };


### PR DESCRIPTION
## Changes proposed in this PR:

The children prop may be undefined, so the `.isRequired` was unnecessary, while causing issues since we use `RegularText` for spacing in a couple of places.
