### PR TITLE
fix: add missing attributes to query

### DIFF
--- a/src/queries/eventRecords.js
+++ b/src/queries/eventRecords.js
@@ -48,6 +48,22 @@ export const GET_EVENT_RECORDS = gql`
         kind
         addition
       }
+      contacts {
+        id
+        firstName
+        lastName
+        phone
+        email
+        fax
+        webUrls {
+          url
+          description
+        }
+      }
+      webUrls: urls {
+        url
+        description
+      }
       priceInformations {
         name
         amount


### PR DESCRIPTION
- when fetching more events in list, the GET_EVENT_RECORDS query is fired
  - that query needs to have the same attributes requested, otherwise the data sets cannot match and an error occurs