### PR TITLE
chore(push notifications): enable disabling through server settings

### DIFF
--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -100,7 +100,7 @@ export const texts = {
     greetingBody:
       'Damit Sie wichtige Mitteilungen aus Ihrer Kommune erreichen, würden wir Ihnen gerne Benachrichtigungen schicken. Sie können diese Einstellung jederzeit in Ihrem persönlichen Bereich ändern.',
     greetingTitle: 'Willkommen',
-    permissionMissingBody: 'Bitte überprüfe deine Benachrichtigungseinstellungen im System.',
+    permissionMissingBody: 'Bitte überprüfen Sie Ihre Benachrichtigungseinstellungen im System.',
     permissionMissingTitle: 'Hinweis'
   },
   screenTitles: {

--- a/src/hooks/PushNotification.ts
+++ b/src/hooks/PushNotification.ts
@@ -16,8 +16,15 @@ type ResponseHandler = (arg: Notifications.NotificationResponse) => void;
 export const usePushNotifications = (
   notificationHandler?: NotificationHandler,
   interactionHandler?: ResponseHandler,
-  behavior?: Notifications.NotificationBehavior
+  behavior?: Notifications.NotificationBehavior,
+  active?: boolean
 ): void => {
+  // this causes the active state to never change between rerenders.
+  // like this enabling or disabling the pushNotifications requires an app restart.
+  const [isActive] = useState(active);
+
+  if (isActive === false) return;
+
   const notificationListener = useRef<Subscription>();
   const responseListener = useRef<Subscription>();
 

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -77,7 +77,12 @@ export const HomeScreen = ({ navigation }) => {
     [navigation]
   );
 
-  usePushNotifications(undefined, interactionHandler);
+  usePushNotifications(
+    undefined,
+    interactionHandler,
+    undefined,
+    globalSettings?.settings?.pushNotifications
+  );
   useMatomoAlertOnStartUp();
   useMatomoTrackScreenView(MATOMO_TRACKING.SCREEN_VIEW.HOME);
 

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -81,11 +81,14 @@ export const SettingsScreen = () => {
 
     const updateSectionedData = async () => {
       const { settings = { matomo: false } } = globalSettings;
-      const pushPermission = await readFromStore(PushNotificationStorageKeys.IN_APP_PERMISSION);
 
-      // settings should always contain push notifications
-      const additionalSectionedData = [
-        {
+      const additionalSectionedData = [];
+
+      // add push notification option if they are enabled
+      if (settings.pushNotifications !== false) {
+        const pushPermission = await readFromStore(PushNotificationStorageKeys.IN_APP_PERMISSION);
+
+        additionalSectionedData.push({
           data: [
             {
               title: texts.settingsTitles.pushNotifications,
@@ -96,9 +99,8 @@ export const SettingsScreen = () => {
               onDeactivate: onDeactivatePushNotifications
             }
           ]
-        }
-      ];
-
+        });
+      }
       // settings should sometimes contain matomo analytics next, depending on server settings
       if (settings.matomo) {
         const { consent: matomoValue = false } = await storageHelper.matomoSettings();


### PR DESCRIPTION
## Changes proposed in this PR:

Some communities do not immediately want to have push notifications enabled. so i added the option to disable it through server settings.
this way the permission popup and the settings should not show, when the server sided settings do explicitly set push notifications to a disabled state.

SVA-185