### PR TITLE
fix(detail screen): crash on push

### DIFF
--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -112,7 +112,7 @@ export const DetailScreen = ({ navigation }) => {
         // if there is no cached `data` or network fetched `data` we fallback to the `details`.
         if ((!data || !data[query]) && !details) return null;
 
-        const Component = getComponent(query, data?.[query]?.genericType ?? details.genericType);
+        const Component = getComponent(query, data?.[query]?.genericType ?? details?.genericType);
 
         if (!Component) return null;
 


### PR DESCRIPTION
## Changes proposed in this PR:

- added missing optional chaining for details on detail screen
  - this caused a crash with push notifications as details are null
