### PR TITLE
fix(image): message outside of image

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -76,11 +76,12 @@ export const Image = ({
         accessibilityLabel={source?.captionText}
         resizeMode={resizeMode}
         borderRadius={borderRadius}
-      />
-      {!!message && <ImageMessage message={message} />}
-      {!!globalSettings?.showImageRights && !!source?.copyright && (
-        <ImageRights imageRights={source.copyright} />
-      )}
+      >
+        {!!message && <ImageMessage message={message} />}
+        {!!globalSettings?.showImageRights && !!source?.copyright && (
+          <ImageRights imageRights={source.copyright} />
+        )}
+      </RNEImage>
     </View>
   );
 };


### PR DESCRIPTION
## Changes proposed in this PR:

- nested message and imagerights to be inside of the image
  - this way the absolute positioning is with respect to the image itself
  - previously it was with respect to the container (which was wider in landscape)
 
Before:

![Screenshot 2021-03-11 at 16 42 56](https://user-images.githubusercontent.com/59824597/110813574-e8ede500-8288-11eb-8409-d5d47f7cbac5.png)

After: 

![Screenshot 2021-03-11 at 16 42 46](https://user-images.githubusercontent.com/59824597/110813587-eb503f00-8288-11eb-81a5-8c6e945455e1.png)
