### PR TITLE
fix(oparl android): crash on overview screen

### DIFF
--- a/src/components/oParl/Meeting.tsx
+++ b/src/components/oParl/Meeting.tsx
@@ -69,7 +69,11 @@ export const Meeting = ({ data, navigation }: Props) => {
         left={meetingTexts.location}
         right={formattedLocation}
         onPress={() => {
-          navigation.push('OParlDetail', { type: location?.type, id: location?.id });
+          navigation.push('OParlDetail', {
+            type: location?.type,
+            id: location?.id,
+            title: texts.oparl.location.location
+          });
         }}
       />
       <Row left={meetingTexts.meetingState} right={meetingState} />

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -229,7 +229,7 @@ export const texts = {
       cancelled: 'Dieser Termin wurde abgesagt.',
       invitation: 'Einladung',
       license: 'Lizenz',
-      location: 'Sitzungsort',
+      location: 'Sitzungsort:',
       meeting: 'Sitzung',
       meetings: 'Sitzungen',
       meetingState: 'Status',

--- a/src/screens/OParl/OParlDetailScreen.tsx
+++ b/src/screens/OParl/OParlDetailScreen.tsx
@@ -23,8 +23,6 @@ export const OParlDetailScreen = ({ navigation }: Props) => {
   const oParlType = navigation.getParam('type');
   const id = navigation.getParam('id');
 
-  console.log(id);
-
   const [query, queryName] = getOParlQuery(oParlType);
 
   const { data: queryData, loading, error } = useOParlQuery(query, {

--- a/src/screens/OParl/OParlOverviewScreen.tsx
+++ b/src/screens/OParl/OParlOverviewScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView, StyleSheet } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { NavigationScreenProp } from 'react-navigation';
 
 import {
@@ -28,9 +28,11 @@ type TileProps = {
 const overviewTexts = texts.oparl.overview;
 
 const Tile = ({ icon, onPress, title }: TileProps) => (
-  <Touchable style={styles.background} disabled={!onPress} onPress={onPress}>
-    <Wrapper>{icon}</Wrapper>
-    <BoldText primary>{title}</BoldText>
+  <Touchable disabled={!onPress} onPress={onPress}>
+    <View style={styles.background}>
+      <Wrapper>{icon}</Wrapper>
+      <BoldText primary>{title}</BoldText>
+    </View>
   </Touchable>
 );
 
@@ -74,6 +76,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     margin: 12,
     marginBottom: 0,
+    minHeight: 140,
     padding: 12,
     justifyContent: 'center',
     alignItems: 'center'


### PR DESCRIPTION
- with the removal of the diagonal gradient the touchable had more than one child
  - the `TouchableNativeFeedback` requires exactly one child
- reintroduced a height for the wrapping views because the screen seemed very empty with only 3 entries being cramped at the top

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode
