### PR TITLE
Feature/sva 197 calendar export

### DIFF
--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -422,6 +422,7 @@ export const texts = {
     configureReminder: 'Erinnerungen einstellen',
     errorOnUpdateBody: 'Beim Aktualisieren Ihrer Einstellungen ist ein Fehler aufgetreten.',
     errorOnUpdateTitle: 'Fehler',
+    exportCalendar: 'Kalender exportieren',
     hint: 'Bitte geben Sie Ihre Straße an.',
     onDayBeforeCollection: 'Am Vortag',
     onDayOfCollection: 'Am Tag der Abholung',

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -422,6 +422,11 @@ export const texts = {
     configureReminder: 'Erinnerungen einstellen',
     errorOnUpdateBody: 'Beim Aktualisieren Ihrer Einstellungen ist ein Fehler aufgetreten.',
     errorOnUpdateTitle: 'Fehler',
+    exportAlertBody:
+      'Ein Download wurde gestartet.\nNachdem der Download abgeschlossen ist, können Sie die Termine durch öffnen der Datei in Ihren Kalender importieren.',
+    exportAlertMissingConnection:
+      'Es konnte keine Verbindung hergestellt werden. Bitte versuchen Sie es später erneut.',
+    exportAlertTitle: 'Abfallkalender',
     exportCalendar: 'Kalender exportieren',
     hint: 'Bitte geben Sie Ihre Straße an.',
     onDayBeforeCollection: 'Am Vortag',

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -423,9 +423,7 @@ export const texts = {
     errorOnUpdateBody: 'Beim Aktualisieren Ihrer Einstellungen ist ein Fehler aufgetreten.',
     errorOnUpdateTitle: 'Fehler',
     exportAlertBody:
-      'Ein Download wurde gestartet.\nNachdem der Download abgeschlossen ist, können Sie die Termine durch öffnen der Datei in Ihren Kalender importieren.',
-    exportAlertMissingConnection:
-      'Es konnte keine Verbindung hergestellt werden. Bitte versuchen Sie es später erneut.',
+      'Ein Download wird in einem externen Browser gestartet.\nNachdem der Download abgeschlossen ist, können Sie die Termine durch Öffnen der Datei in Ihren Kalender importieren.',
     exportAlertTitle: 'Abfallkalender',
     exportCalendar: 'Kalender exportieren',
     hint: 'Bitte geben Sie Ihre Straße an.',

--- a/src/screens/WasteCollectionScreen.js
+++ b/src/screens/WasteCollectionScreen.js
@@ -174,6 +174,24 @@ export const WasteCollectionScreen = ({ navigation }) => {
   );
 
   const triggerExport = useCallback(() => {
+    if (!isMainserverUp) {
+      return Alert.alert(
+        texts.wasteCalendar.exportAlertTitle,
+        texts.wasteCalendar.exportAlertMissingConnection,
+        [
+          {
+            onPress: () => {
+              setDownloadUrl('');
+            }
+          }
+        ],
+        {
+          onDismiss: () => {
+            setDownloadUrl('');
+          }
+        }
+      );
+    }
     const { street, zip, city } = getLocationData(streetData);
 
     const baseUrl = secrets[namespace].serverUrl + staticRestSuffix.wasteCalendarExport;
@@ -188,9 +206,7 @@ export const WasteCollectionScreen = ({ navigation }) => {
       isMainserverUp && setDownloadUrl(combinedUrl);
       Alert.alert(
         texts.wasteCalendar.exportAlertTitle,
-        isMainserverUp
-          ? texts.wasteCalendar.exportAlertBody
-          : texts.wasteCalendar.exportAlertMissingConnection,
+        texts.wasteCalendar.exportAlertBody,
         [
           {
             onPress: () => {


### PR DESCRIPTION
## Changes proposed in this PR:

- added export functionality for calendar
  - after selecting a street you can export the calendar by pressing the button at the bottom of the screen

![Screenshot 2021-05-26 at 13 04 54](https://user-images.githubusercontent.com/59824597/119649818-62768780-be23-11eb-9e73-50ea8df7668c.png)

- in the case of `!isMainserverUp` the user gets an alert that no connection could be established
  - this should only occur if the user previously cached the street information while having a connection and pressing the button afterwards without having a connection. 
![Screenshot 2021-05-26 at 13 19 22](https://user-images.githubusercontent.com/59824597/119651460-555a9800-be25-11eb-8d45-d534b8ebfc40.png)


### iOS
- when pressing the button a system dialog for subscribing the calendar pops up
![Screenshot 2021-05-26 at 13 05 44](https://user-images.githubusercontent.com/59824597/119649847-6a362c00-be23-11eb-9130-188dd8919d9a.png)
- after subscribing a new system dialog pops up
![Screenshot 2021-05-26 at 13 06 04](https://user-images.githubusercontent.com/59824597/119649969-90f46280-be23-11eb-952e-34ec657db56d.png)


### Android
- when pressing the button an alert pops up notifying the user about the download and to open the file to import into a calendar app
![Screenshot_20210526-131123](https://user-images.githubusercontent.com/59824597/119650845-93a38780-be24-11eb-8fee-94fd8acb8da6.png)


---

SVA-197

---

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode


