### PR TITLE
fix(oparl): missing id in meeting query

### DIFF
--- a/src/queries/OParl/meeting.ts
+++ b/src/queries/OParl/meeting.ts
@@ -57,6 +57,7 @@ export const meetingQuery = [
             deleted
 
             organization {
+              id: externalId
               name
               shortName
             }


### PR DESCRIPTION
## Changes proposed in this PR:

The missing id for the organizations was causing the cache to malfunction.
