### PR TITLE
Survey: response options

### DIFF
--- a/src/components/SurveyAnswer.tsx
+++ b/src/components/SurveyAnswer.tsx
@@ -1,0 +1,59 @@
+import React, { useCallback } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { colors } from '../config';
+import { useSurveyLanguages } from '../hooks';
+import { ResponseOption } from '../types';
+import { Radiobutton } from './Radiobutton';
+import { BoldText, RegularText } from './Text';
+import { Touchable } from './Touchable';
+import { Wrapper, WrapperRow } from './Wrapper';
+
+type Props = {
+  faded: boolean;
+  index: number;
+  responseOption: ResponseOption;
+  selected: boolean;
+  setSelection: (id: string) => void;
+};
+
+export const SurveyAnswer = ({ faded, index, responseOption, selected, setSelection }: Props) => {
+  const languages = useSurveyLanguages();
+
+  const { id } = responseOption;
+  const onPress = useCallback(() => setSelection(id), [id, setSelection]);
+
+  const fadeStyle = { opacity: faded ? 0.5 : 1 };
+
+  return (
+    <Touchable onPress={onPress}>
+      <Wrapper style={[styles.noPaddingBottom, fadeStyle]}>
+        <View style={styles.border}>
+          <WrapperRow>
+            <Wrapper style={styles.radioButtonContainer}>
+              <Radiobutton selected={selected} />
+            </Wrapper>
+            <Wrapper>
+              <BoldText>Antwort {String.fromCharCode(65 + index)}:</BoldText>
+              <RegularText>{responseOption.title[languages[0]]}</RegularText>
+              <BoldText italic>Odpowiedź {String.fromCharCode(65 + index)}:</BoldText>
+              <RegularText italic>{responseOption.title[languages[0]]}</RegularText>
+            </Wrapper>
+          </WrapperRow>
+        </View>
+      </Wrapper>
+    </Touchable>
+  );
+};
+
+const styles = StyleSheet.create({
+  border: {
+    borderColor: colors.darkText,
+    borderWidth: 1
+  },
+  noPaddingBottom: {
+    paddingBottom: 0
+  },
+  radioButtonContainer: {
+    justifyContent: 'center'
+  }
+});

--- a/src/components/SurveyAnswer.tsx
+++ b/src/components/SurveyAnswer.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { colors } from '../config';
+import { colors, texts } from '../config';
 import { useSurveyLanguages } from '../hooks';
 import { ResponseOption } from '../types';
 import { Radiobutton } from './Radiobutton';
@@ -14,6 +14,10 @@ type Props = {
   responseOption: ResponseOption;
   selected: boolean;
   setSelection: (id: string) => void;
+};
+
+const getAnswerLabel = (lang: 'de' | 'pl', index: number) => {
+  return `${texts.survey.answerLabelPrefix[lang]} ${String.fromCharCode(65 + index)}:`;
 };
 
 export const SurveyAnswer = ({ faded, index, responseOption, selected, setSelection }: Props) => {
@@ -32,10 +36,10 @@ export const SurveyAnswer = ({ faded, index, responseOption, selected, setSelect
             <Wrapper style={styles.radioButtonContainer}>
               <Radiobutton selected={selected} />
             </Wrapper>
-            <Wrapper>
-              <BoldText>Antwort {String.fromCharCode(65 + index)}:</BoldText>
+            <Wrapper style={styles.answerContainer}>
+              <BoldText>{getAnswerLabel('de', index)}</BoldText>
               <RegularText>{responseOption.title[languages[0]]}</RegularText>
-              <BoldText italic>Odpowiedź {String.fromCharCode(65 + index)}:</BoldText>
+              <BoldText italic>{getAnswerLabel('pl', index)}</BoldText>
               <RegularText italic>{responseOption.title[languages[0]]}</RegularText>
             </Wrapper>
           </WrapperRow>
@@ -46,6 +50,9 @@ export const SurveyAnswer = ({ faded, index, responseOption, selected, setSelect
 };
 
 const styles = StyleSheet.create({
+  answerContainer: {
+    flex: 1
+  },
   border: {
     borderColor: colors.darkText,
     borderWidth: 1

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -31,6 +31,12 @@ export const RegularText = styled(Text)`
   line-height: ${normalize(22)};
 
   ${(props) =>
+    props.italic &&
+    css`
+      font-family: titillium-web-italic;
+    `};
+
+  ${(props) =>
     props.small &&
     css`
       font-size: ${normalize(14)};
@@ -81,6 +87,12 @@ export const RegularText = styled(Text)`
     `};
 
   ${(props) =>
+    props.error &&
+    css`
+      color: ${colors.error};
+    `};
+
+  ${(props) =>
     props.center &&
     css`
       text-align: center;
@@ -95,6 +107,11 @@ export const RegularText = styled(Text)`
 
 export const BoldText = styled(RegularText)`
   font-family: titillium-web-bold;
+  ${(props) =>
+    props.italic &&
+    css`
+      font-family: titillium-web-bold-italic;
+    `};
 `;
 
 Text.propTypes = {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -46,6 +46,7 @@ export * from './ServiceBox';
 export * from './SettingsListItem';
 export * from './ShareHeader';
 export * from './StorySection';
+export * from './SurveyAnswer';
 export * from './Switch';
 export * from './TabBarIcon';
 export * from './Text';

--- a/src/config/colors.js
+++ b/src/config/colors.js
@@ -6,6 +6,8 @@ export const colors = {
   secondary: 'rgb(9, 72, 60)',
   accent: 'rgb(15, 70, 24)',
 
+  error: 'rgb(174, 0, 29)',
+
   darkText: '#000000',
   lighterText: 'rgba(221, 242, 243, 0.6)',
   lightestText: '#FFFFFF',

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -405,6 +405,10 @@ export const texts = {
   },
   survey: {
     archive: 'Umfrage-Archiv',
+    answerLabelPrefix: {
+      de: 'Antwort',
+      pl: 'Odpowiedź'
+    },
     dateEnd: {
       de: 'Abschluss der Umfrage:',
       pl: 'Wypełnienie ankiety:'

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -404,7 +404,25 @@ export const texts = {
     pushNotifications: 'Push-Benachrichtigungen'
   },
   survey: {
-    archive: 'Umfrage-Archiv'
+    archive: 'Umfrage-Archiv',
+    dateEnd: {
+      de: 'Abschluss der Umfrage:',
+      pl: 'Wypełnienie ankiety:'
+    },
+    dateStart: {
+      de: 'Start der Umfrage:',
+      pl: 'Rozpocznij ankietę:'
+    },
+    hint: {
+      de:
+        'Die Umfrageergebnisse werden erst angezeigt, wenn Sie Ihre Stimme abgegeben haben oder die Umfrage beendet wurde.',
+      pl:
+        'Wyniki ankiety nie będą wyświetlane, dopóki nie oddasz głosu lub ankieta nie zostanie zakończona.'
+    },
+    submitAnswer: {
+      de: 'Antwort senden',
+      pl: 'wyślij odpowiedź'
+    }
   },
   tabBarLabel: {
     home: 'Übersicht',

--- a/src/hooks/surveyHooks.ts
+++ b/src/hooks/surveyHooks.ts
@@ -1,2 +1,33 @@
+import { useCallback, useEffect, useState } from 'react';
+import { readFromStore } from '../helpers';
+
 // TODO: implement properly
 export const useSurveyLanguages = () => ['de', 'pl'];
+
+const SURVEY_ANSWERS_STORAGE_PREFIX = 'SVA_SURVEY_ANSWERS_';
+export const useAnswerSelection = (id?: string) => {
+  const [selection, setSelection] = useState<string | undefined>();
+
+  const readPreviousAnswer = useCallback(async (id?: string) => {
+    if (!id) return;
+
+    const previousAnswer = await readFromStore(SURVEY_ANSWERS_STORAGE_PREFIX + id);
+
+    if (previousAnswer) {
+      setSelection(previousAnswer);
+    }
+  }, []);
+
+  // const submitSelection = useCallback(async () => {
+  //   if (selection) {
+  //     // TODO: add mutation here
+  //     await addToStore(SURVEY_ANSWERS_STORAGE_PREFIX + id, selection);
+  //   }
+  // }, [id, selection]);
+
+  useEffect(() => {
+    readPreviousAnswer(id);
+  }, [id]);
+
+  return { selection, setSelection };
+};

--- a/src/queries/survey.js
+++ b/src/queries/survey.js
@@ -12,6 +12,11 @@ export const DETAILED_SURVEY = gql`
     title
     questionTitle
     description
+    date {
+      id
+      dateEnd
+      dateStart
+    }
     responseOptions {
       id
       title

--- a/src/screens/SurveyDetailScreen.tsx
+++ b/src/screens/SurveyDetailScreen.tsx
@@ -1,23 +1,46 @@
 import { RouteProp } from '@react-navigation/core';
+import { noop } from 'lodash';
 import React from 'react';
 import { useQuery } from 'react-apollo';
-import { ScrollView, StyleSheet } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 
 import {
   BoldText,
+  Button,
   RegularText,
   SafeAreaViewFlex,
   SectionHeader,
+  SurveyAnswer,
   Wrapper,
+  WrapperRow,
   WrapperWithOrientation
 } from '../components';
-import { combineLanguages } from '../helpers';
-import { usePullToRefetch, useSurveyLanguages } from '../hooks';
+import { texts } from '../config';
+import { combineLanguages, momentFormat } from '../helpers';
+import { useAnswerSelection, usePullToRefetch, useSurveyLanguages } from '../hooks';
 import { DETAILED_SURVEY } from '../queries/survey';
 import { Survey } from '../types';
 
 type Props = {
   route: RouteProp<any, any>;
+};
+
+const DateComponent = ({ start, date }: { start?: boolean; date: string }) => {
+  return (
+    <Wrapper style={styles.noPaddingBottom}>
+      <WrapperRow center spaceBetween>
+        <View>
+          <RegularText small>
+            {start ? texts.survey.dateStart.de : texts.survey.dateEnd.de}
+          </RegularText>
+          <RegularText italic small>
+            {start ? texts.survey.dateStart.pl : texts.survey.dateEnd.pl}
+          </RegularText>
+        </View>
+        <RegularText>{momentFormat(date)}</RegularText>
+      </WrapperRow>
+    </Wrapper>
+  );
 };
 
 const useSurvey = (id?: string) => {
@@ -33,6 +56,7 @@ const useSurvey = (id?: string) => {
 export const SurveyDetailScreen = ({ route }: Props) => {
   const { loading, refetch, survey } = useSurvey(route.params?.id);
   const languages = useSurveyLanguages();
+  const { selection, setSelection } = useAnswerSelection(route.params?.id);
 
   const RefreshControl = usePullToRefetch(loading, refetch);
 
@@ -41,33 +65,55 @@ export const SurveyDetailScreen = ({ route }: Props) => {
   }
 
   const title = combineLanguages(languages, survey.title);
-  const description = combineLanguages(languages, survey.description);
   const questionTitle = combineLanguages(languages, survey.questionTitle);
-  const responseOptions = survey.responseOptions.map((responseOption) => ({
-    title: combineLanguages(languages, responseOption.title),
-    id: responseOption.id
-  }));
+
+  const shownTitle = title?.length ? title : questionTitle;
 
   return (
     <SafeAreaViewFlex>
       <ScrollView refreshControl={RefreshControl}>
         <WrapperWithOrientation>
-          {!!title?.length && <SectionHeader title={title} />}
-          {!!description?.length && (
-            <Wrapper>
-              <RegularText>{description}</RegularText>
+          {!!shownTitle?.length && <SectionHeader title={shownTitle} />}
+          <DateComponent start date={survey.dates.dateStart} />
+          <DateComponent date={survey.dates.dateEnd} />
+          {!!survey.description?.[languages[0]]?.length && (
+            <Wrapper style={styles.noPaddingBottom}>
+              <RegularText>{survey.description[languages[0]]}</RegularText>
+              {!!survey.description?.[languages[1]]?.length && (
+                <RegularText italic>{survey.description[languages[1]]}</RegularText>
+              )}
             </Wrapper>
           )}
-          {!!questionTitle?.length && (
-            <Wrapper>
-              <BoldText>{questionTitle}</BoldText>
+          {!!survey.questionTitle?.[languages[0]]?.length && !!title?.length && (
+            <Wrapper style={styles.noPaddingBottom}>
+              <BoldText>{survey.questionTitle?.[languages[0]]}</BoldText>
+              <BoldText italic>{survey.questionTitle?.[languages[1]]}</BoldText>
             </Wrapper>
           )}
-          {responseOptions.map((responseOption) => (
-            <Wrapper key={responseOption.id} style={styles.noPaddingBottom}>
-              <RegularText>{responseOption.title}</RegularText>
-            </Wrapper>
+          {survey.responseOptions.map((responseOption, index) => (
+            <SurveyAnswer
+              faded={!!selection && selection !== responseOption.id}
+              index={index}
+              responseOption={responseOption}
+              selected={selection === responseOption.id}
+              setSelection={setSelection}
+              key={responseOption.id}
+            />
           ))}
+          <Wrapper style={styles.noPaddingBottom}>
+            <RegularText error small>
+              {texts.survey.hint.de}
+            </RegularText>
+            <RegularText error italic small>
+              {texts.survey.hint.pl}
+            </RegularText>
+          </Wrapper>
+          <Wrapper>
+            <Button
+              title={texts.survey.submitAnswer.de + '\n' + texts.survey.submitAnswer.pl}
+              onPress={noop}
+            />
+          </Wrapper>
         </WrapperWithOrientation>
       </ScrollView>
     </SafeAreaViewFlex>

--- a/src/screens/SurveyDetailScreen.tsx
+++ b/src/screens/SurveyDetailScreen.tsx
@@ -74,8 +74,8 @@ export const SurveyDetailScreen = ({ route }: Props) => {
       <ScrollView refreshControl={RefreshControl}>
         <WrapperWithOrientation>
           {!!shownTitle?.length && <SectionHeader title={shownTitle} />}
-          <DateComponent start date={survey.dates.dateStart} />
-          <DateComponent date={survey.dates.dateEnd} />
+          <DateComponent start date={survey.date.dateStart} />
+          <DateComponent date={survey.date.dateEnd} />
           {!!survey.description?.[languages[0]]?.length && (
             <Wrapper style={styles.noPaddingBottom}>
               <RegularText>{survey.description[languages[0]]}</RegularText>

--- a/src/types/Survey.ts
+++ b/src/types/Survey.ts
@@ -1,3 +1,9 @@
+export type ResponseOption = {
+  id: string;
+  title: Record<string, string | undefined>;
+  votesCount: number;
+};
+
 export type Survey = {
   id: string;
   title?: Record<string, string | undefined>;
@@ -7,9 +13,5 @@ export type Survey = {
     dateStart: string;
     dateEnd: string;
   };
-  responseOptions: Array<{
-    id: string;
-    title: Record<string, string | undefined>;
-    votesCount: number;
-  }>;
+  responseOptions: ResponseOption[];
 };

--- a/src/types/Survey.ts
+++ b/src/types/Survey.ts
@@ -9,7 +9,7 @@ export type Survey = {
   title?: Record<string, string | undefined>;
   questionTitle: Record<string, string | undefined>;
   description?: Record<string, string | undefined>;
-  dates: {
+  date: {
     dateStart: string;
     dateEnd: string;
   };


### PR DESCRIPTION
## Changes proposed in this PR:

- Overhauled the detail screen
  - added unique selection logic to response options 

- [x] retarget to epic once #236 is merged

---

SVA2-11

![Screenshot 2021-06-18 at 12 17 21](https://user-images.githubusercontent.com/59824597/122546404-310e6780-d02f-11eb-834c-7f3beef64624.png)


---

## How to test:
* [ ] Android portrait mode
* [ ] iOS portrait mode
* [ ] Android landscape mode
* [ ] iOS landscape mode

**Add additional information for testing, if required**

## Screenshots:

![Screenshot 2021-06-18 at 11 56 10](https://user-images.githubusercontent.com/59824597/122546116-eb519f00-d02e-11eb-8bb7-15f31b269771.png)
![Screenshot 2021-06-18 at 11 58 39](https://user-images.githubusercontent.com/59824597/122546124-ed1b6280-d02e-11eb-8471-09da2c702ac5.png)
![Screenshot 2021-06-18 at 11 56 24](https://user-images.githubusercontent.com/59824597/122546130-edb3f900-d02e-11eb-9f03-ab9a849fd4a5.png)
![Screenshot 2021-06-18 at 11 56 19](https://user-images.githubusercontent.com/59824597/122546132-ee4c8f80-d02e-11eb-8404-9a7080783fd1.png)

