### PR TITLE
Survey: display results

### DIFF
--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -32,7 +32,7 @@ const SingleResult = ({ option, selected, totalCount }: SingleProps) => {
   const width = percentString === '0%' ? barBorderRadius * 2 : percentString;
   return (
     <WrapperRow spaceBetween style={styles.container}>
-      <View>
+      <View style={styles.labelContainer}>
         <BoldText small>{getAnswerLabel('de', option.index)}</BoldText>
         <BoldText small>{getAnswerLabel('pl', option.index)}</BoldText>
       </View>
@@ -97,5 +97,12 @@ const styles = StyleSheet.create({
   container: {
     marginBottom: normalize(12)
   },
-  countContainer: { justifyContent: 'center' }
+  countContainer: {
+    position: 'absolute',
+    right: 0,
+    top: normalize(7)
+  },
+  labelContainer: {
+    width: 100
+  }
 });

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -59,6 +59,7 @@ export const Results = ({ responseOptions, selectedOption }: Props) => {
   const languages = useSurveyLanguages();
   const sortedOptions = responseOptions
     .map((option, index) => ({ ...option, index }))
+    // deepcode ignore NoZeroReturnedInSort: The callback provided to sort does return 0 implicitly if the compared values are equal.
     .sort((a, b) => -a.votesCount + b.votesCount);
 
   const totalCount = responseOptions.reduce(
@@ -88,7 +89,10 @@ export const Results = ({ responseOptions, selectedOption }: Props) => {
 const barBorderRadius = 4;
 
 const styles = StyleSheet.create({
-  barContainer: { flex: 1, justifyContent: 'center' },
+  barContainer: {
+    flex: 1,
+    justifyContent: 'center'
+  },
   baseBarStyle: {
     backgroundColor: colors.primary,
     borderRadius: 4,
@@ -103,6 +107,6 @@ const styles = StyleSheet.create({
     top: normalize(7)
   },
   labelContainer: {
-    width: 100
+    width: 100 // this fixes the width of the left labels, so that all bars start at a common line
   }
 });

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { colors, normalize, texts } from '../config';
+import { combineLanguages, getAnswerLabel } from '../helpers';
+import { useSurveyLanguages } from '../hooks';
+import { SectionHeader } from './SectionHeader';
+import { ResponseOption } from '../types';
+import { BoldText } from './Text';
+import { Wrapper, WrapperHorizontal, WrapperRow } from './Wrapper';
+
+type Props = { responseOptions: ResponseOption[]; selectedOption: string };
+type SingleProps = {
+  option: ResponseOption & { index: number };
+  selected: boolean;
+  totalCount: number;
+};
+
+const getPercent = (partial: number, total: number) => {
+  if (!total) {
+    return '0%';
+  }
+  return `${((100 * partial) / total).toFixed(0)}%`;
+};
+
+const getCountLabel = (partial: number, total: number) => {
+  return `${partial} / ${getPercent(partial, total)}`;
+};
+
+const SingleResult = ({ option, selected, totalCount }: SingleProps) => {
+  const percentString = getPercent(option.votesCount, totalCount);
+  const width = percentString === '0%' ? barBorderRadius * 2 : percentString;
+  return (
+    <WrapperRow spaceBetween style={styles.container}>
+      <View>
+        <BoldText small>{getAnswerLabel('de', option.index)}</BoldText>
+        <BoldText small>{getAnswerLabel('pl', option.index)}</BoldText>
+      </View>
+      <WrapperHorizontal style={styles.barContainer}>
+        <View
+          style={[
+            styles.baseBarStyle,
+            // eslint-disable-next-line react-native/no-inline-styles
+            {
+              opacity: selected ? 1 : 0.5,
+              width
+            }
+          ]}
+        />
+      </WrapperHorizontal>
+      <View style={styles.countContainer}>
+        <BoldText>{getCountLabel(option.votesCount, totalCount)}</BoldText>
+      </View>
+    </WrapperRow>
+  );
+};
+
+export const Results = ({ responseOptions, selectedOption }: Props) => {
+  const languages = useSurveyLanguages();
+  const sortedOptions = responseOptions
+    .map((option, index) => ({ ...option, index }))
+    .sort((a, b) => -a.votesCount + b.votesCount);
+
+  const totalCount = responseOptions.reduce(
+    (prev, currentOption) => prev + currentOption.votesCount,
+    0
+  );
+
+  const title = combineLanguages(languages, texts.survey.result);
+
+  return (
+    <>
+      {!!title && <SectionHeader title={title} />}
+      <Wrapper>
+        {sortedOptions.map((option) => (
+          <SingleResult
+            key={option.id}
+            option={option}
+            selected={selectedOption === option.id}
+            totalCount={totalCount}
+          />
+        ))}
+      </Wrapper>
+    </>
+  );
+};
+
+const barBorderRadius = 4;
+
+const styles = StyleSheet.create({
+  barContainer: { flex: 1, justifyContent: 'center' },
+  baseBarStyle: {
+    backgroundColor: colors.primary,
+    borderRadius: 4,
+    height: normalize(26)
+  },
+  container: {
+    marginBottom: normalize(12)
+  },
+  countContainer: { justifyContent: 'center' }
+});

--- a/src/components/SurveyAnswer.tsx
+++ b/src/components/SurveyAnswer.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { colors, texts } from '../config';
+import { colors } from '../config';
+import { getAnswerLabel } from '../helpers';
 import { useSurveyLanguages } from '../hooks';
 import { ResponseOption } from '../types';
 import { Radiobutton } from './Radiobutton';
@@ -14,10 +15,6 @@ type Props = {
   responseOption: ResponseOption;
   selected: boolean;
   setSelection: (id: string) => void;
-};
-
-const getAnswerLabel = (lang: 'de' | 'pl', index: number) => {
-  return `${texts.survey.answerLabelPrefix[lang]} ${String.fromCharCode(65 + index)}:`;
 };
 
 export const SurveyAnswer = ({ faded, index, responseOption, selected, setSelection }: Props) => {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -40,6 +40,7 @@ export * from './MediaSection';
 export * from './Offer';
 export * from './PreviewSection';
 export * from './Radiobutton';
+export * from './Results';
 export * from './SafeAreaViewFlex';
 export * from './SectionHeader';
 export * from './ServiceBox';

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -432,6 +432,10 @@ export const texts = {
       pl:
         'Wyniki ankiety nie będą wyświetlane, dopóki nie oddasz głosu lub ankieta nie zostanie zakończona.'
     },
+    result: {
+      de: 'Ergebnis',
+      pl: 'Wynik'
+    },
     submitAnswer: {
       de: 'Antwort senden',
       pl: 'wyślij odpowiedź'

--- a/src/helpers/surveyHelper.tsx
+++ b/src/helpers/surveyHelper.tsx
@@ -1,3 +1,5 @@
+import { texts } from '../config';
+
 export const combineLanguages = (
   languages: string[],
   localeObj?: Record<string, string | undefined>
@@ -10,4 +12,8 @@ export const combineLanguages = (
     .map((language) => localeObj?.[language])
     .filter((langTitle) => langTitle?.length)
     .join(' / ');
+};
+
+export const getAnswerLabel = (lang: 'de' | 'pl', index: number) => {
+  return `${texts.survey.answerLabelPrefix[lang]} ${String.fromCharCode(65 + index)}:`;
 };

--- a/src/screens/SurveyDetailScreen.tsx
+++ b/src/screens/SurveyDetailScreen.tsx
@@ -7,6 +7,7 @@ import {
   BoldText,
   Button,
   RegularText,
+  Results,
   SafeAreaViewFlex,
   SectionHeader,
   SurveyAnswer,
@@ -107,14 +108,6 @@ export const SurveyDetailScreen = ({ route }: Props) => {
               key={responseOption.id}
             />
           ))}
-          <Wrapper style={styles.noPaddingBottom}>
-            <RegularText error small>
-              {texts.survey.hint.de}
-            </RegularText>
-            <RegularText error italic small>
-              {texts.survey.hint.pl}
-            </RegularText>
-          </Wrapper>
           <Wrapper>
             <Button
               disabled={!selection || (!!previousSubmission && selection === previousSubmission)}
@@ -122,6 +115,18 @@ export const SurveyDetailScreen = ({ route }: Props) => {
               onPress={submitSelection}
             />
           </Wrapper>
+          {!previousSubmission ? (
+            <Wrapper style={styles.noPaddingBottom}>
+              <RegularText error small>
+                {texts.survey.hint.de}
+              </RegularText>
+              <RegularText error italic small>
+                {texts.survey.hint.pl}
+              </RegularText>
+            </Wrapper>
+          ) : (
+            <Results responseOptions={survey.responseOptions} selectedOption={previousSubmission} />
+          )}
         </WrapperWithOrientation>
       </ScrollView>
     </SafeAreaViewFlex>


### PR DESCRIPTION
## Changes proposed in this PR:

- added results visualization to details
- added logic to either show the hint or show the results

- [x] retarget to epic once #239  is merged

---

SVA2-20

---

## How to test:
* [ ] Android portrait mode
* [ ] iOS portrait mode
* [ ] Android landscape mode
* [ ] iOS landscape mode

**Add additional information for testing, if required**

## Screenshots:
![Simulator Screen Shot - iPhone 12 Pro - 2021-06-18 at 15 43 12](https://user-images.githubusercontent.com/59824597/122571467-0d5a1a00-d04d-11eb-8852-b157538ff8a2.png)
![Simulator Screen Shot - iPhone 12 Pro - 2021-06-18 at 15 51 55](https://user-images.githubusercontent.com/59824597/122571581-29f65200-d04d-11eb-8ecd-f01b09419f26.png)

