### PR TITLE
fix(drawer content): undefined key values for list

### DIFF
--- a/src/navigation/DrawerNavigatorItems.js
+++ b/src/navigation/DrawerNavigatorItems.js
@@ -48,7 +48,7 @@ const DrawerNavigatorItems = ({ drawerRoutes, navigation, state }) => {
         const accessibilityLabel = itemInfo.params.title;
 
         return (
-          <View key={route.key}>
+          <View key={itemInfo.params.title}>
             <Touchable
               accessible
               accessibilityLabel={accessibilityLabel}


### PR DESCRIPTION
## Changes proposed in this PR:

the values used as keys for the drawer content items were all undefined.

i replaced them by the titles now, as they should be unique at all times.
