### PR TITLE
Refactor/sva 246 centralize font config

### DIFF
--- a/App.js
+++ b/App.js
@@ -15,12 +15,12 @@ const AppWithFonts = () => {
     trackAppStart();
 
     Font.loadAsync({
-      'titillium-web-bold': require('./assets/fonts/TitilliumWeb-Bold.ttf'),
-      'titillium-web-bold-italic': require('./assets/fonts/TitilliumWeb-BoldItalic.ttf'),
-      'titillium-web-regular': require('./assets/fonts/TitilliumWeb-Regular.ttf'),
-      'titillium-web-italic': require('./assets/fonts/TitilliumWeb-Italic.ttf'),
-      'titillium-web-light': require('./assets/fonts/TitilliumWeb-Light.ttf'),
-      'titillium-web-light-italic': require('./assets/fonts/TitilliumWeb-LightItalic.ttf')
+      bold: require('./assets/fonts/TitilliumWeb-Bold.ttf'),
+      'bold-italic': require('./assets/fonts/TitilliumWeb-BoldItalic.ttf'),
+      regular: require('./assets/fonts/TitilliumWeb-Regular.ttf'),
+      italic: require('./assets/fonts/TitilliumWeb-Italic.ttf'),
+      light: require('./assets/fonts/TitilliumWeb-Light.ttf'),
+      'light-italic': require('./assets/fonts/TitilliumWeb-LightItalic.ttf')
     })
       .catch((error) => console.warn('An error occurred with loading the fonts', error))
       .finally(() => setFontLoaded(true));

--- a/App.js
+++ b/App.js
@@ -4,7 +4,7 @@ import * as Font from 'expo-font';
 import MatomoTracker, { MatomoProvider, useMatomo } from 'matomo-tracker-react-native';
 
 import { MainApp } from './src';
-import { namespace, secrets } from './src/config';
+import { fontConfig, namespace, secrets } from './src/config';
 import { matomoSettings } from './src/helpers';
 
 const AppWithFonts = () => {
@@ -14,14 +14,7 @@ const AppWithFonts = () => {
   useEffect(() => {
     trackAppStart();
 
-    Font.loadAsync({
-      bold: require('./assets/fonts/TitilliumWeb-Bold.ttf'),
-      'bold-italic': require('./assets/fonts/TitilliumWeb-BoldItalic.ttf'),
-      regular: require('./assets/fonts/TitilliumWeb-Regular.ttf'),
-      italic: require('./assets/fonts/TitilliumWeb-Italic.ttf'),
-      light: require('./assets/fonts/TitilliumWeb-Light.ttf'),
-      'light-italic': require('./assets/fonts/TitilliumWeb-LightItalic.ttf')
-    })
+    Font.loadAsync(fontConfig)
       .catch((error) => console.warn('An error occurred with loading the fonts', error))
       .finally(() => setFontLoaded(true));
   }, []);

--- a/__tests__/components/__snapshots__/Button.test.js.snap
+++ b/__tests__/components/__snapshots__/Button.test.js.snap
@@ -47,7 +47,7 @@ exports[`Button renders a button with Outline style 1`] = `
         style={
           Object {
             "color": "rgb(16, 120, 33)",
-            "fontFamily": "titillium-web-bold",
+            "fontFamily": "bold",
             "fontSize": 18,
             "paddingBottom": 1,
             "paddingHorizontal": 15.680000000000001,
@@ -126,7 +126,7 @@ exports[`Button renders a default button 1`] = `
         style={
           Object {
             "color": "#FFFFFF",
-            "fontFamily": "titillium-web-bold",
+            "fontFamily": "bold",
             "fontSize": 18,
             "paddingBottom": 1,
             "paddingHorizontal": 15.680000000000001,

--- a/__tests__/components/__snapshots__/Link.test.js.snap
+++ b/__tests__/components/__snapshots__/Link.test.js.snap
@@ -133,7 +133,7 @@ exports[`Link renders a Link that opens a WebScreen 1`] = `
         Array [
           Object {
             "color": "rgb(16, 120, 33)",
-            "fontFamily": "titillium-web-regular",
+            "fontFamily": "regular",
             "fontSize": 17.92,
             "lineHeight": 24.64,
           },
@@ -279,7 +279,7 @@ exports[`Link renders a default Link 1`] = `
         Array [
           Object {
             "color": "rgb(16, 120, 33)",
-            "fontFamily": "titillium-web-regular",
+            "fontFamily": "regular",
             "fontSize": 17.92,
             "lineHeight": 24.64,
           },

--- a/src/components/BB-BUS/IndexFilter.js
+++ b/src/components/BB-BUS/IndexFilter.js
@@ -215,7 +215,7 @@ const styles = StyleSheet.create({
     borderWidth: 0,
     borderBottomWidth: StyleSheet.hairlineWidth,
     color: colors.darkText,
-    fontFamily: 'titillium-web-regular',
+    fontFamily: 'regular',
     fontSize: normalize(16),
     justifyContent: 'space-between',
     lineHeight: normalize(22),

--- a/src/components/BB-BUS/TextSearch.js
+++ b/src/components/BB-BUS/TextSearch.js
@@ -46,7 +46,7 @@ const styles = StyleSheet.create({
   inputStyle: {
     backgroundColor: colors.transparent,
     color: colors.darkText,
-    fontFamily: 'titillium-web-regular',
+    fontFamily: 'regular',
     fontSize: normalize(16)
   },
   marginLeft: {

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -50,7 +50,7 @@ export const Button = ({ title, onPress, invert }) => {
 const styles = StyleSheet.create({
   titleStyle: {
     color: colors.lightestText,
-    fontFamily: 'titillium-web-bold'
+    fontFamily: 'bold'
   },
   titleStyleLandscape: {
     paddingHorizontal: normalize(14)

--- a/src/components/HtmlView.js
+++ b/src/components/HtmlView.js
@@ -19,7 +19,7 @@ const tableCssRules =
     linkColor: colors.primary,
     // TODO: font family was not working at the moment with following implementation
     //       https://github.com/jsamr/react-native-render-html-table-bridge/blob/master/readme.md#how-to-load-custom-fonts
-    // fontFamily: 'titillium-web-regular',
+    // fontFamily: 'regular',
     thColor: colors.lightestText,
     trOddBackground: colors.lightestText,
     trOddColor: colors.darkText,

--- a/src/components/Label.js
+++ b/src/components/Label.js
@@ -6,7 +6,7 @@ import { Text } from './Text';
 
 export const Label = styled(Text)`
   color: ${colors.darkText};
-  font-family: titillium-web-regular;
+  font-family: regular;
   font-size: ${normalize(14)};
   line-height: ${normalize(28)};
 `;

--- a/src/components/StorySection.js
+++ b/src/components/StorySection.js
@@ -32,7 +32,7 @@ export const StorySection = ({ contentBlock, index, openWebScreen, settings }) =
                   : `<p>${contentBlock.intro}</p>`
               }</div>`
             )}
-            tagsStyles={{ div: { fontFamily: 'titillium-web-bold' } }}
+            tagsStyles={{ div: { fontFamily: 'bold' } }}
             openWebScreen={openWebScreen}
           />
         </WrapperHorizontal>

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -26,7 +26,7 @@ export const Text = ({ children, ...props }) => {
 
 export const RegularText = styled(Text)`
   color: ${colors.darkText};
-  font-family: titillium-web-regular;
+  font-family: regular;
   font-size: ${normalize(16)};
   line-height: ${normalize(22)};
 
@@ -94,7 +94,7 @@ export const RegularText = styled(Text)`
 `;
 
 export const BoldText = styled(RegularText)`
-  font-family: titillium-web-bold;
+  font-family: bold;
 `;
 
 Text.propTypes = {

--- a/src/components/Title.js
+++ b/src/components/Title.js
@@ -6,7 +6,7 @@ import { Text } from './Text';
 
 export const Title = styled(Text)`
   color: ${colors.primary};
-  font-family: titillium-web-bold;
+  font-family: bold;
   font-size: ${normalize(20)};
   line-height: ${normalize(26)};
   text-transform: uppercase;

--- a/src/config/fonts.ts
+++ b/src/config/fonts.ts
@@ -1,0 +1,8 @@
+export const fontConfig = {
+  bold: require('../../assets/fonts/TitilliumWeb-Bold.ttf'),
+  'bold-italic': require('../../assets/fonts/TitilliumWeb-BoldItalic.ttf'),
+  regular: require('../../assets/fonts/TitilliumWeb-Regular.ttf'),
+  italic: require('../../assets/fonts/TitilliumWeb-Italic.ttf'),
+  light: require('../../assets/fonts/TitilliumWeb-Light.ttf'),
+  'light-italic': require('../../assets/fonts/TitilliumWeb-LightItalic.ttf')
+};

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,6 +1,7 @@
 export * from './colors';
 export * from './consts';
 export * from './device';
+export * from './fonts';
 export * from './namespace';
 export * from './normalize';
 export * from './secrets';

--- a/src/config/styles/baseFontStyle.js
+++ b/src/config/styles/baseFontStyle.js
@@ -3,7 +3,7 @@ import { normalize } from '../normalize';
 
 export const baseFontStyle = {
   color: colors.darkText,
-  fontFamily: 'titillium-web-regular',
+  fontFamily: 'regular',
   fontSize: normalize(16),
   lineHeight: normalize(22)
 };

--- a/src/config/styles/html.js
+++ b/src/config/styles/html.js
@@ -11,19 +11,19 @@ export const html = {
   },
   a: {
     color: colors.primary,
-    fontFamily: 'titillium-web-bold',
+    fontFamily: 'bold',
     textDecorationLine: 'none'
   },
   h1: {
     color: colors.darkText,
-    fontFamily: 'titillium-web-bold',
+    fontFamily: 'bold',
     fontSize: normalize(24),
     lineHeight: normalize(30),
     marginBottom: normalize(24)
   },
   h2: {
     color: colors.darkText,
-    fontFamily: 'titillium-web-regular',
+    fontFamily: 'regular',
     fontSize: normalize(20),
     fontWeight: '400',
     lineHeight: normalize(26),
@@ -31,34 +31,34 @@ export const html = {
   },
   h3: {
     color: colors.darkText,
-    fontFamily: 'titillium-web-bold',
+    fontFamily: 'bold',
     fontSize: normalize(18),
     lineHeight: normalize(24)
   },
   h4: {
     color: colors.darkText,
-    fontFamily: 'titillium-web-regular',
+    fontFamily: 'regular',
     fontSize: normalize(18),
     fontWeight: '400',
     lineHeight: normalize(24)
   },
   h5: {
     color: colors.darkText,
-    fontFamily: 'titillium-web-regular',
+    fontFamily: 'regular',
     fontSize: normalize(16),
     fontWeight: '400'
   },
   h6: {
     color: colors.darkText,
-    fontFamily: 'titillium-web-regular',
+    fontFamily: 'regular',
     fontSize: normalize(14),
     fontWeight: '400'
   },
   b: {
-    fontFamily: 'titillium-web-bold'
+    fontFamily: 'bold'
   },
   strong: {
-    fontFamily: 'titillium-web-bold'
+    fontFamily: 'bold'
   },
   ul: {
     marginBottom: 0
@@ -74,6 +74,6 @@ export const html = {
     height: imageHeight(Dimensions.get('window').width)
   },
   em: {
-    fontFamily: 'titillium-web-italic'
+    fontFamily: 'italic'
   }
 };

--- a/src/navigation/DrawerNavigatorItems.js
+++ b/src/navigation/DrawerNavigatorItems.js
@@ -44,7 +44,7 @@ const DrawerNavigatorItems = ({ drawerRoutes, navigation, state }) => {
         const itemInfo = drawerRoutes[route];
         const focused =
           (activeRoute?.params?.rootRouteName ?? 'AppStack') === itemInfo.params.rootRouteName;
-        const fontFamily = focused ? 'titillium-web-bold' : 'titillium-web-regular';
+        const fontFamily = focused ? 'bold' : 'regular';
         const accessibilityLabel = itemInfo.params.title;
 
         return (
@@ -70,7 +70,7 @@ const DrawerNavigatorItems = ({ drawerRoutes, navigation, state }) => {
 
 const styles = StyleSheet.create({
   label: {
-    fontFamily: 'titillium-web-regular',
+    fontFamily: 'regular',
     fontSize: normalize(16),
     lineHeight: normalize(22),
     paddingHorizontal: normalize(15),

--- a/src/navigation/screenOptions.tsx
+++ b/src/navigation/screenOptions.tsx
@@ -47,7 +47,7 @@ export const defaultStackNavigatorScreenOptions = (
   headerBackground: () => <DiagonalGradient />,
   headerTitleStyle: {
     color: colors.lightestText,
-    fontFamily: device.platform === 'ios' ? 'titillium-web-bold' : 'titillium-web-regular',
+    fontFamily: device.platform === 'ios' ? 'bold' : 'regular',
     fontSize: normalize(20),
     fontWeight: '400',
     lineHeight: normalize(29)

--- a/src/screens/OParl/OParlPersonsScreen.tsx
+++ b/src/screens/OParl/OParlPersonsScreen.tsx
@@ -191,7 +191,7 @@ const styles = StyleSheet.create({
     borderWidth: 0,
     borderBottomWidth: StyleSheet.hairlineWidth,
     color: colors.darkText,
-    fontFamily: 'titillium-web-regular',
+    fontFamily: 'regular',
     fontSize: normalize(16),
     justifyContent: 'space-between',
     lineHeight: normalize(22),

--- a/src/screens/OParl/OParlSearchScreen.tsx
+++ b/src/screens/OParl/OParlSearchScreen.tsx
@@ -133,7 +133,7 @@ const styles = StyleSheet.create({
     borderWidth: 0,
     borderBottomWidth: StyleSheet.hairlineWidth,
     color: colors.darkText,
-    fontFamily: 'titillium-web-regular',
+    fontFamily: 'regular',
     fontSize: normalize(16),
     justifyContent: 'space-between',
     lineHeight: normalize(22),

--- a/src/screens/WasteCollectionScreen.js
+++ b/src/screens/WasteCollectionScreen.js
@@ -309,7 +309,7 @@ const styles = StyleSheet.create({
       : {},
   autoCompleteInput: {
     color: colors.darkText,
-    fontFamily: 'titillium-web-regular',
+    fontFamily: 'regular',
     fontSize: normalize(16),
     padding: normalize(8)
   },


### PR DESCRIPTION
## Changes proposed in this PR:

- centralized font configuration to config file
- components now only use a generic name for the type of font (e.g. `bold` or `italic` instead of the whole name of the font)
  - this makes almost components consistent between release branches, when it comes to font usage

SVA-246