### PR TITLE
feat(matomo): add more device infos to tracking

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Font from 'expo-font';
 import MatomoTracker, { MatomoProvider, useMatomo } from 'matomo-tracker-react-native';
@@ -6,13 +6,21 @@ import MatomoTracker, { MatomoProvider, useMatomo } from 'matomo-tracker-react-n
 import { MainApp } from './src';
 import { fontConfig, namespace, secrets } from './src/config';
 import { matomoSettings } from './src/helpers';
+import { useUserInfoAsync } from './src/hooks';
 
 const AppWithFonts = () => {
   const [fontLoaded, setFontLoaded] = useState(false);
   const { trackAppStart } = useMatomo();
+  const userInfoAsync = useUserInfoAsync();
+
+  const trackAppStartAsync = useCallback(async () => {
+    const userInfo = await userInfoAsync();
+
+    trackAppStart({ userInfo });
+  }, [userInfoAsync]);
 
   useEffect(() => {
-    trackAppStart();
+    trackAppStartAsync();
 
     Font.loadAsync(fontConfig)
       .catch((error) => console.warn('An error occurred with loading the fonts', error))

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "graphql-anywhere": "~4.2.4",
     "graphql-tag": "^2.12.5",
     "lodash": "~4.17.21",
-    "matomo-tracker-react-native": "^0.2.2",
+    "matomo-tracker-react-native": "^0.3.0",
     "moment": "~2.29.1",
     "qs": "^6.10.1",
     "react": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "expo-font": "~9.2.1",
     "expo-linear-gradient": "~9.2.0",
     "expo-linking": "~2.3.1",
+    "expo-localization": "^10.2.0",
     "expo-notifications": "~0.12.3",
     "expo-permissions": "~12.1.1",
     "expo-screen-orientation": "~3.2.1",

--- a/src/screens/HtmlScreen.js
+++ b/src/screens/HtmlScreen.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
 import { RefreshControl, ScrollView } from 'react-native';
 import { Query } from 'react-apollo';
-import { useMatomo } from 'matomo-tracker-react-native';
 
 import { NetworkContext } from '../NetworkProvider';
 import { auth } from '../auth';
@@ -10,7 +9,7 @@ import { colors, consts } from '../config';
 import { Button, HtmlView, SafeAreaViewFlex, Wrapper, WrapperWithOrientation } from '../components';
 import { graphqlFetchPolicy, trimNewLines } from '../helpers';
 import { getQuery } from '../queries';
-import { useRefreshTime } from '../hooks';
+import { useRefreshTime, useTrackScreenViewAsync } from '../hooks';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 
 const { MATOMO_TRACKING } = consts;
@@ -21,7 +20,7 @@ export const HtmlScreen = ({ navigation, route }) => {
   const queryVariables = route.params?.queryVariables ?? {};
   const title = route.params?.title ?? '';
   const [refreshing, setRefreshing] = useState(false);
-  const { trackScreenView } = useMatomo();
+  const trackScreenViewAsync = useTrackScreenViewAsync();
 
   if (!query || !queryVariables?.name) return null;
 
@@ -33,7 +32,7 @@ export const HtmlScreen = ({ navigation, route }) => {
 
   // NOTE: we cannot use the `useMatomoTrackScreenView` hook here, as we need the `title` dependency
   useEffect(() => {
-    isConnected && title && trackScreenView(`${MATOMO_TRACKING.SCREEN_VIEW.HTML} / ${title}`);
+    isConnected && title && trackScreenViewAsync(`${MATOMO_TRACKING.SCREEN_VIEW.HTML} / ${title}`);
   }, [title]);
 
   if (!refreshTime) {

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { ActivityIndicator, RefreshControl } from 'react-native';
 import { Query } from 'react-apollo';
-import { useMatomo } from 'matomo-tracker-react-native';
 
 import { NetworkContext } from '../NetworkProvider';
 import { SettingsContext } from '../SettingsProvider';
@@ -18,6 +17,7 @@ import {
 } from '../components';
 import { getQuery, getFetchMoreQuery, QUERY_TYPES } from '../queries';
 import { graphqlFetchPolicy, matomoTrackingString, parseListItemsFromQuery } from '../helpers';
+import { useTrackScreenViewAsync } from '../hooks';
 
 const { MATOMO_TRACKING } = consts;
 
@@ -29,7 +29,7 @@ export const IndexScreen = ({ navigation, route }) => {
   const [queryVariables, setQueryVariables] = useState(route.params?.queryVariables ?? {});
   const [refreshing, setRefreshing] = useState(false);
   const [showMap, setShowMap] = useState(false);
-  const { trackScreenView } = useMatomo();
+  const trackScreenViewAsync = useTrackScreenViewAsync();
 
   const query = route.params?.query ?? '';
   const title = route.params?.title ?? '';
@@ -111,7 +111,9 @@ export const IndexScreen = ({ navigation, route }) => {
       // NOTE: we cannot use the `useMatomoTrackScreenView` hook here, as we need the `query`
       //       dependency
       isConnected &&
-        trackScreenView(matomoTrackingString([MATOMO_TRACKING_SCREEN, MATOMO_TRACKING_CATEGORY]));
+        trackScreenViewAsync(
+          matomoTrackingString([MATOMO_TRACKING_SCREEN, MATOMO_TRACKING_CATEGORY])
+        );
     }
   }, [isConnected, query]);
 

--- a/src/screens/WebScreen.js
+++ b/src/screens/WebScreen.js
@@ -2,23 +2,23 @@ import PropTypes from 'prop-types';
 import React, { useContext, useEffect } from 'react';
 import { ActivityIndicator } from 'react-native';
 import { WebView } from 'react-native-webview';
-import { useMatomo } from 'matomo-tracker-react-native';
 
 import { colors, consts } from '../config';
 import { LoadingContainer, SafeAreaViewFlex, WrapperWithOrientation } from '../components';
 import { NetworkContext } from '../NetworkProvider';
+import { useTrackScreenViewAsync } from '../hooks';
 
 const { MATOMO_TRACKING } = consts;
 
 export const WebScreen = ({ route }) => {
   const { isConnected } = useContext(NetworkContext);
-  const { trackScreenView } = useMatomo();
+  const trackScreenViewAsync = useTrackScreenViewAsync();
   const webUrl = route.params?.webUrl ?? '';
 
   // NOTE: we cannot use the `useMatomoTrackScreenView` hook here, as we need the `webUrl`
   //       dependency
   useEffect(() => {
-    isConnected && webUrl && trackScreenView(`${MATOMO_TRACKING.SCREEN_VIEW.WEB} / ${webUrl}`);
+    isConnected && webUrl && trackScreenViewAsync(`${MATOMO_TRACKING.SCREEN_VIEW.WEB} / ${webUrl}`);
   }, [webUrl]);
 
   if (!webUrl) return null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6438,6 +6438,13 @@ expo-linking@~2.3.1:
     qs "^6.5.0"
     url-parse "^1.4.4"
 
+expo-localization@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/expo-localization/-/expo-localization-10.2.0.tgz#cf7e1eeea4593711e0be832888ae25a0cd89d341"
+  integrity sha512-fe72BnW3jGmgIqyfYoGAmG3o83+DJ6pQotsuIGzo+ZasqBw0ho6TPWRS64B0nt+8ZSLzJ9n1WxInH+Z8zYzb7w==
+  dependencies:
+    rtl-detect "^1.0.2"
+
 expo-modules-autolinking@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/expo-modules-autolinking/-/expo-modules-autolinking-0.0.2.tgz#6015c4e0ba995144145ad29fb2a4b34deba73955"
@@ -10923,6 +10930,11 @@ rsvp@^4.8.4:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.4.tgz#b50e6b34583f3dd89329a2f23a8a2be072845911"
   integrity sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==
+
+rtl-detect@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/rtl-detect/-/rtl-detect-1.0.4.tgz#40ae0ea7302a150b96bc75af7d749607392ecac6"
+  integrity sha512-EBR4I2VDSSYr7PkBmFy04uhycIpDKp+21p/jARYXlCSjQksTBQcJ0HFUPOO79EPPH5JS6VAhiIQbycf0O3JAxQ==
 
 run-async@^2.2.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8872,10 +8872,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-matomo-tracker-react-native@^0.2.2:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/matomo-tracker-react-native/-/matomo-tracker-react-native-0.2.3.tgz#ce800bf5e31fc1099460f5c212cc54fb192edc32"
-  integrity sha512-VV1izaajMDAiEGMVdmyjvr2anqB98FycZBKhWYRLLt4T8wxL+O+bbHweHPmC41Bma/u5bHzXJPe5MSve107UfA==
+matomo-tracker-react-native@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/matomo-tracker-react-native/-/matomo-tracker-react-native-0.3.0.tgz#423b69eff93885b127f34a96f7c5233de06e4014"
+  integrity sha512-aZsAlZ1QquxtLiu7eU27PY1Gxedde9DhCJJSbCAOugc0pwUhnH74dJtG4S29FUnRZgsquPIoK1K4Zx+QwdZJ7w==
 
 md5-file@^3.2.3:
   version "3.2.3"


### PR DESCRIPTION
- created `userInfo` object from different sources and pass it to matomo tracking
  - ⚠️  new matomo-tracker-react-native 0.3.0 is required for this to work!
    - PR: https://github.com/donni106/matomo-tracker-react-native/pull/6
  - `userInfo` contains app-version, language, screen resolution and an user agent to identify devices more detailed (still anonymously!)
  - added a new hook to build this object
- added new hook to async track screen view for a given `name` using the new user info hook

![Bildschirmfoto 2021-07-17 um 00 37 02](https://user-images.githubusercontent.com/1942953/126014826-e1c0f905-6687-4747-a60a-a9c76263f22a.png)

---

![Bildschirmfoto 2021-07-17 um 00 37 09](https://user-images.githubusercontent.com/1942953/126014827-705ef042-5a19-46e1-9351-9a8aadae755a.png) ![Bildschirmfoto 2021-07-17 um 00 37 14](https://user-images.githubusercontent.com/1942953/126014829-40034eed-9a08-46e5-b886-2c3f60d046bf.png) ![Bildschirmfoto 2021-07-17 um 00 37 18](https://user-images.githubusercontent.com/1942953/126014830-04dc4a2e-889c-4ccf-936e-7cb316d1d673.png) ![Bildschirmfoto 2021-07-17 um 00 37 22](https://user-images.githubusercontent.com/1942953/126014832-a7987c90-974b-4843-985a-105e4c679729.png) ![Bildschirmfoto 2021-07-17 um 00 37 26](https://user-images.githubusercontent.com/1942953/126014833-32910fbe-d5d2-4827-a4b1-43df2acf698a.png)
