### PR TITLE
fix(index screen): not updating on query variable change

### DIFF
--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -84,7 +84,7 @@ export const IndexScreen = ({ navigation, route }) => {
     // have query variables from the previous screen, that does not work. this can result in an
     // empty screen because the query is not retuning anything.
     setQueryVariables(route.params?.queryVariables ?? {});
-  }, [query]);
+  }, [query, route.params?.queryVariables]);
 
   useEffect(() => {
     if (query) {


### PR DESCRIPTION
previously the index screen did not update, when changing query variables in the navigation params, as long as the query stayed the same.

the screen will now update properly when the query variables inside of the params change, even if the query remains the same.

SVA-260
