### PR TITLE
chore(html table): exchange dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@apollo/react-hooks": "~3.1.5",
+    "@native-html/table-plugin": "2.1.5",
     "@react-native-async-storage/async-storage": "~1.15.0",
     "@react-native-community/datetimepicker": "3.5.2",
     "@react-native-community/masked-view": "0.1.10",
@@ -73,7 +74,6 @@
     "react-native-modal-dropdown": "https://github.com/donni106/react-native-modal-dropdown#feature/search-options",
     "react-native-reanimated": "~2.2.0",
     "react-native-render-html": "4.2.5",
-    "react-native-render-html-table-bridge": "~0.3.1",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.4.0",
     "react-native-snap-carousel": "~3.9.0",

--- a/src/components/HtmlView.js
+++ b/src/components/HtmlView.js
@@ -24,14 +24,30 @@ const cssRules =
     trOddBackground: colors.lightestText,
     trOddColor: colors.darkText,
     trEvenBackground: colors.lightestText,
-    trEvenColor: colors.darkText,
-    outerBorderWidthPx: 1,
-    outerBorderColor: '#b5b5b5',
-    columnsBorderWidthPx: 1
+    trEvenColor: colors.darkText
   }) +
   `
 :root {
   font-size: ${normalize(13)}px;
+}
+th {
+  border-bottom: 0.25px solid ${'#3f5c7a'};
+  border-left: 0.25px solid ${'#3f5c7a'};
+  border-top: 0.25px solid ${'#3f5c7a'};
+}
+th:last-child {
+  border-right: 0.25px solid ${'#3f5c7a'};
+}
+td {
+  border-bottom: 0.25px solid ${'#b5b5b5'};
+  border-left: 0.25px solid ${'#b5b5b5'};
+  border-top: 0;
+}
+td:last-child {
+  border-right: 0.25px solid ${'#b5b5b5'};
+}
+table {
+  border-bottom: 0.25px solid ${'#b5b5b5'};
 }
 `;
 

--- a/src/components/HtmlView.js
+++ b/src/components/HtmlView.js
@@ -2,49 +2,41 @@ import PropTypes from 'prop-types';
 import React, { memo } from 'react';
 import HTML from 'react-native-render-html';
 import {
-  IGNORED_TAGS,
   alterNode,
-  makeTableRenderer,
+  cssRulesFromSpecs,
   defaultTableStylesSpecs,
-  cssRulesFromSpecs
-} from 'react-native-render-html-table-bridge';
+  IGNORED_TAGS,
+  makeTableRenderer
+} from '@native-html/table-plugin';
 import { WebView } from 'react-native-webview';
 
 import { colors, consts, normalize, styles } from '../config';
 import { imageWidth, openLink } from '../helpers';
 
-const tableCssRules =
+const cssRules =
   cssRulesFromSpecs({
     ...defaultTableStylesSpecs,
     linkColor: colors.primary,
-    // TODO: font family was not working at the moment with following implementation
-    //       https://github.com/jsamr/react-native-render-html-table-bridge/blob/master/readme.md#how-to-load-custom-fonts
+    // TODO: font family documentation
+    //      https://github.com/native-html/plugins/tree/rnrh/4.x#how-to-load-custom-fonts
     // fontFamily: 'regular',
     thColor: colors.lightestText,
     trOddBackground: colors.lightestText,
     trOddColor: colors.darkText,
     trEvenBackground: colors.lightestText,
-    trEvenColor: colors.darkText
+    trEvenColor: colors.darkText,
+    outerBorderWidthPx: 1,
+    outerBorderColor: '#b5b5b5',
+    columnsBorderWidthPx: 1
   }) +
   `
 :root {
   font-size: ${normalize(13)}px;
 }
-th {
-  border-left: 0.25px solid ${'#3f5c7a'};
-  border-top: 0.25px solid ${'#3f5c7a'};
-}
-td {
-  border-left: 0.25px solid ${'#b5b5b5'};
-  border-top: 0.25px solid ${'#b5b5b5'};
-}
 `;
 
 const renderers = {
-  table: makeTableRenderer({
-    WebViewComponent: WebView,
-    cssRules: tableCssRules
-  })
+  table: makeTableRenderer({ WebView, cssRules })
 };
 
 const htmlConfig = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2946,6 +2946,11 @@
     lodash.pick "^4.4.0"
     lodash.template "^4.5.0"
 
+"@formidable-webview/webshell@^2.2.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@formidable-webview/webshell/-/webshell-2.5.0.tgz#a4aac1ceb8d89a111c63aa14a53804c95ad6dfa0"
+  integrity sha512-Ylyjbkdg1j7s2IXrHe40Xfu9l7LXC7JFiigWMdIeUomqhdjcVRE8kCdQI7WnUy5VgLIos2l0Nu9p6Os78CJK5w==
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -3512,6 +3517,16 @@
     "@babel/runtime" "^7.7.2"
     regenerator-runtime "^0.13.3"
 
+"@native-html/table-plugin@2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@native-html/table-plugin/-/table-plugin-2.1.5.tgz#27651d93b5f2430fbfbf459be215e8e513b77bfc"
+  integrity sha512-IoJTdYJl0Z1Zbh4cGj9P1w42u+pIYbCU4BXZNL6R6JeT3cBWrn6SXtuehmrRD049raFXtCO1YZvyJjNEu/muiA==
+  dependencies:
+    "@formidable-webview/webshell" "^2.2.0"
+    "@types/prop-types" "^15.7.3"
+    prop-types "^15.7.2"
+    stringify-entities "^3.0.1"
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
@@ -3852,10 +3867,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/prop-types@^15.7.1":
-  version "15.7.1"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
-  integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
+"@types/prop-types@^15.7.3":
+  version "15.7.4"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
+  integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
 "@types/react-dom@~16.9.8":
   version "16.9.10"
@@ -5119,14 +5134,14 @@ chalk@^4.1.0:
     supports-color "^7.1.0"
 
 character-entities-html4@^1.0.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.3.tgz#5ce6e01618e47048ac22f34f7f39db5c6fd679ef"
-  integrity sha512-SwnyZ7jQBCRHELk9zf2CN5AnGEc2nA+uKMZLHvcqhpPprjkYhiLn0DywMHgN5ttFZuITMATbh68M6VIVKwJbcg==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.4.tgz#0e64b0a3753ddbf1fdc044c5fd01d0199a02e125"
+  integrity sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==
 
 character-entities-legacy@^1.0.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz#3c729991d9293da0ede6dddcaf1f2ce1009ee8b4"
-  integrity sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"
+  integrity sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==
 
 chardet@^0.4.0:
   version "0.4.2"
@@ -7482,19 +7497,6 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
-is-alphabetical@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.3.tgz#eb04cc47219a8895d8450ace4715abff2258a1f8"
-  integrity sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==
-
-is-alphanumerical@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz#57ae21c374277b3defe0274c640a5704b8f6657c"
-  integrity sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==
-  dependencies:
-    is-alphabetical "^1.0.0"
-    is-decimal "^1.0.0"
-
 is-arguments@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3"
@@ -7580,11 +7582,6 @@ is-date-object@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
   integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
 
-is-decimal@^1.0.0, is-decimal@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.3.tgz#381068759b9dc807d8c0dc0bfbae2b68e1da48b7"
-  integrity sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==
-
 is-descriptor@^0.1.0:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
@@ -7668,11 +7665,6 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
-
-is-hexadecimal@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz#e8a426a69b6d31470d3a33a47bb825cda02506ee"
-  integrity sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==
 
 is-nan@^1.2.1:
   version "1.3.0"
@@ -10247,11 +10239,6 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
   integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
-ramda@^0.26.1:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
-  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
-
 range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
@@ -10424,16 +10411,6 @@ react-native-reanimated@~2.2.0:
     fbjs "^3.0.0"
     mockdate "^3.0.2"
     string-hash-64 "^1.0.3"
-
-react-native-render-html-table-bridge@~0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/react-native-render-html-table-bridge/-/react-native-render-html-table-bridge-0.3.1.tgz#253bf29f7d9ea252d9a69a1f2e95318c77901dec"
-  integrity sha512-adKzoWiUF77GaFuUNGp5ZN6Vk96ZV6CzvTXEjS1SIJQPS9lDRs3H/Ph+30GBVF9sMYGRAN2OiiUcnOLeWAl/lQ==
-  dependencies:
-    "@types/prop-types" "^15.7.1"
-    prop-types "^15.7.2"
-    ramda "^0.26.1"
-    stringify-entities "^2.0.0"
 
 react-native-render-html@4.2.5:
   version "4.2.5"
@@ -11588,16 +11565,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-stringify-entities@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-2.0.0.tgz#fa7ca6614b355fb6c28448140a20c4ede7462827"
-  integrity sha512-fqqhZzXyAM6pGD9lky/GOPq6V4X0SeTAFBl0iXb/BzOegl40gpf/bV3QQP7zULNYvjr6+Dx8SCaDULjVoOru0A==
+stringify-entities@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-3.1.0.tgz#b8d3feac256d9ffcc9fa1fefdcf3ca70576ee903"
+  integrity sha512-3FP+jGMmMV/ffZs86MoghGqAoqXAdxLrJP4GUdrDN1aIScYih5tuIO3eF4To5AJZ79KDZ8Fpdy7QJnK8SsL1Vg==
   dependencies:
     character-entities-html4 "^1.0.0"
     character-entities-legacy "^1.0.0"
-    is-alphanumerical "^1.0.0"
-    is-decimal "^1.0.2"
-    is-hexadecimal "^1.0.0"
+    xtend "^4.0.0"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
## Changes proposed in this PR:

- the react-native-render-html-table-bridge is outdated and deprecated
  - instead added a version of @native-html/table-plugin that is compatible with our version of react-native-render-html
- adjusted some stylings to make it close to how it was before

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode
