### PR TITLE
 share logic in webScreen

### DIFF
--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -36,9 +36,10 @@ export const NewsItem = ({ data, route }) => {
   const title = mainTitle || (!!contentBlocks && !!contentBlocks.length && contentBlocks[0].title);
   const rootRouteName = route.params?.rootRouteName ?? '';
   const headerTitle = route.params?.title ?? '';
+  const shareContent = route.params?.shareContent;
 
   // action to open source urls
-  const openWebScreen = useOpenWebScreen(headerTitle, link, rootRouteName);
+  const openWebScreen = useOpenWebScreen(headerTitle, link, rootRouteName, shareContent);
 
   // the categories of a news item can be nested and we need the map of all names of all categories
   const categoryNames = categories && categories.map((category) => category.name).join(' / ');

--- a/src/config/navigation/defaultStackConfig.tsx
+++ b/src/config/navigation/defaultStackConfig.tsx
@@ -197,7 +197,8 @@ export const defaultStackConfig = ({
     },
     {
       routeName: ScreenName.Web,
-      screenComponent: WebScreen
+      screenComponent: WebScreen,
+      screenOptions: screenOptionsWithShare(isDrawer)
     }
   ]
 });

--- a/src/hooks/openWebScreen.ts
+++ b/src/hooks/openWebScreen.ts
@@ -1,7 +1,16 @@
 import { useNavigation } from '@react-navigation/core';
 import { useCallback } from 'react';
 
-export const useOpenWebScreen = (title: string, link?: string, rootRouteName?: string) => {
+export const useOpenWebScreen = (
+  title: string,
+  link?: string,
+  rootRouteName?: string,
+  shareContent?: {
+    message: string;
+    title: string;
+    url: string;
+  }
+) => {
   const navigation = useNavigation();
 
   const openWebScreen = useCallback(
@@ -11,7 +20,8 @@ export const useOpenWebScreen = (title: string, link?: string, rootRouteName?: s
         params: {
           title: title,
           webUrl: !!webUrl && typeof webUrl === 'string' ? webUrl : link,
-          rootRouteName
+          rootRouteName,
+          shareContent
         }
       }),
     [title, link, navigation, rootRouteName]


### PR DESCRIPTION
feat: passing shareContent as a param 

- in openWebScreen type of shareContent is defined and passed it to params
- in newsItem is defined and passed to openWebScreen
- screenOptionsWithShare containing the share logic, must be the screen option of WebScreen

Share logic is now working just fine in WebScreen newItwms 
![IMG_1525](https://user-images.githubusercontent.com/43641321/127362970-a7952e88-0df7-46be-aa3c-32e0f4609d78.PNG) ![IMG_1526](https://user-images.githubusercontent.com/43641321/127362981-7864351d-42af-4afd-817b-3220528da834.PNG)

https://github.com/ikuseiGmbH/smart-village-app-app/issues/81