### PR TITLE
fix(survey widget): icon being too big

### DIFF
--- a/src/components/widgets/SurveyWidget.tsx
+++ b/src/components/widgets/SurveyWidget.tsx
@@ -33,7 +33,7 @@ export const SurveyWidget = ({ text }: WidgetProps) => {
   return (
     <DefaultWidget
       count={surveys?.ongoing.length}
-      Icon={Icon.Surveys}
+      Icon={(props) => <Icon.Surveys {...props} size={26} />}
       onPress={onPress}
       text={text ?? texts.widgets.surveys}
     />


### PR DESCRIPTION
## Changes proposed in this PR:

- the icon was too big, which caused the text to be not in line with other widgets

---

SVA-256

## Screenshots:

| before | after |
|--|--|
|  ![Simulator Screen Shot - iPhone 12 Pro - 2021-08-25 at 14 18 36](https://user-images.githubusercontent.com/59824597/130789582-0e995362-d402-44f2-997a-a9650923dc59.png)| ![Simulator Screen Shot - iPhone 12 Pro - 2021-08-25 at 14 18 11](https://user-images.githubusercontent.com/59824597/130789590-066ec4ea-04f5-4ee0-880a-90960381095c.png)  |

