### PR TITLE
fix: add order to event widget query

### DIFF
--- a/src/components/widgets/EventWidget.tsx
+++ b/src/components/widgets/EventWidget.tsx
@@ -22,7 +22,8 @@ export const EventWidget = ({ text }: WidgetProps) => {
 
   const currentDate = moment().format('YYYY-MM-DD');
   const queryVariables = {
-    dateRange: [currentDate, currentDate]
+    dateRange: [currentDate, currentDate],
+    order: 'listDate_ASC'
   };
 
   const { data, refetch } = useQuery(getQuery(QUERY_TYPES.EVENT_RECORDS), {


### PR DESCRIPTION
the order was missing in the query to be the same as in the events index screen