### PR TITLE
fix: pass query limit to data list section props

### DIFF
--- a/src/components/HomeSection.tsx
+++ b/src/components/HomeSection.tsx
@@ -1,6 +1,6 @@
 import { StackNavigationProp } from '@react-navigation/stack';
 import React from 'react';
-import { QueryHookOptions, useQuery } from 'react-apollo';
+import { useQuery } from 'react-apollo';
 
 import { useHomeRefresh } from '../hooks/HomeRefresh';
 import { getQuery } from '../queries';
@@ -21,7 +21,7 @@ type Props = {
   navigate: () => void;
   navigation: StackNavigationProp<any>;
   query: string;
-  queryVariables: QueryHookOptions;
+  queryVariables: { limit?: number };
 };
 
 export const HomeSection = ({
@@ -44,6 +44,7 @@ export const HomeSection = ({
   return (
     <DataListSection
       buttonTitle={buttonTitle}
+      limit={queryVariables?.limit}
       loading={loading}
       navigate={navigate}
       navigation={navigation}

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -19,6 +19,7 @@ import { HOME_REFRESH_EVENT } from '../hooks/HomeRefresh';
 import { NetworkContext } from '../NetworkProvider';
 import { getQueryType, QUERY_TYPES } from '../queries';
 import { SettingsContext } from '../SettingsProvider';
+import { ScreenName } from '../types';
 
 const { MATOMO_TRACKING, ROOT_ROUTE_NAMES } = consts;
 
@@ -156,11 +157,7 @@ export const HomeScreen = ({ navigation, route }) => {
                 title={categoryTitle}
                 titleDetail={categoryTitleDetail}
                 fetchPolicy={fetchPolicy}
-                navigate={() =>
-                  navigation.navigate(
-                    NAVIGATION.NEWS_ITEMS_INDEX({ categoryId, categoryTitle, categoryTitleDetail })
-                  )
-                }
+                navigate={() => navigation.navigate(ScreenName.EncounterRegistration)}
                 navigation={navigation}
                 query={QUERY_TYPES.NEWS_ITEMS}
                 queryVariables={{ limit: 3, ...{ categoryId } }}


### PR DESCRIPTION
if we change the limit per query variables this was not passed down to the render element, so it always rendered 3, instead of more if requested.