### PR TITLE
fix(require cycle): navigation config

### DIFF
--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -14,7 +14,7 @@ import {
   Tour
 } from '../components';
 import { colors, consts } from '../config';
-import { navigatorConfig } from '../config/navigation';
+import { navigatorConfig } from '../config/navigation/config';
 import { graphqlFetchPolicy } from '../helpers';
 import { useRefreshTime } from '../hooks';
 import { screenOptionsWithShare } from '../navigation/screenOptions';


### PR DESCRIPTION
There was a require cycle caused by the import of the navigation config in the detail screen through the index file. this resolves the cycle.

@SoleCincis this is an example of the possible cycle creation using index files, that we talked about.