### PR TITLE
Feature/sva 298 sort pois by distance

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "expo-linear-gradient": "~9.2.0",
     "expo-linking": "~2.3.1",
     "expo-localization": "^10.2.0",
+    "expo-location": "~12.1.2",
     "expo-notifications": "~0.12.3",
     "expo-permissions": "~12.1.1",
     "expo-screen-orientation": "~3.2.1",

--- a/src/SettingsProvider.js
+++ b/src/SettingsProvider.js
@@ -8,9 +8,15 @@ export const SettingsContext = createContext({
   }
 });
 
-export const SettingsProvider = ({ initialGlobalSettings, initialListTypesSettings, children }) => {
+export const SettingsProvider = ({
+  initialGlobalSettings,
+  initialListTypesSettings,
+  initialLocationSettings,
+  children
+}) => {
   const [globalSettings, setGlobalSettings] = useState(initialGlobalSettings);
   const [listTypesSettings, setListTypesSettings] = useState(initialListTypesSettings);
+  const [locationSettings, setLocationSettings] = useState(initialLocationSettings);
 
   return (
     <SettingsContext.Provider
@@ -18,7 +24,9 @@ export const SettingsProvider = ({ initialGlobalSettings, initialListTypesSettin
         globalSettings,
         setGlobalSettings,
         listTypesSettings,
-        setListTypesSettings
+        setListTypesSettings,
+        locationSettings,
+        setLocationSettings
       }}
     >
       {children}
@@ -29,5 +37,6 @@ export const SettingsProvider = ({ initialGlobalSettings, initialListTypesSettin
 SettingsProvider.propTypes = {
   initialGlobalSettings: PropTypes.object.isRequired,
   initialListTypesSettings: PropTypes.object.isRequired,
+  initialLocationSettings: PropTypes.object.isRequired,
   children: PropTypes.array.isRequired
 };

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -385,6 +385,10 @@ export const texts = {
       onDeactivate:
         'Soll Matomo Analytics deaktiviert werden? Die Deaktivierung von Matomo Analytics wird mit dem nächsten Neustart der App wirksam.',
       yes: 'Ja'
+    },
+    locationService: {
+      onSystemPermissionMissing:
+        'Um diese Einstellung zu aktivieren, muss zunächst die Berechtigung die Ortungsdienste ihres Gerätes zu verwenden in den Systemeinstellungen erteilt werden.'
     }
   },
   settingsScreen: {
@@ -401,6 +405,7 @@ export const texts = {
       sectionTitle: 'Listen-Layouts',
       textList: 'Textliste'
     },
+    locationService: 'Ortungsdienste',
     pushNotifications: 'Push-Benachrichtigungen'
   },
   survey: {

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -14,6 +14,7 @@ export * from './mapHelper';
 export * from './matomoHelper';
 export * from './momentHelper';
 export * from './personNameHelper';
+export * from './positionHelper';
 export * from './priceHelper';
 export * from './queryHelper';
 export * from './refreshIntervalHelper';

--- a/src/helpers/positionHelper.ts
+++ b/src/helpers/positionHelper.ts
@@ -1,0 +1,55 @@
+type LatLon = {
+  latitude: number;
+  longitude: number;
+};
+
+const calculateDistance = (a: LatLon, b: LatLon) =>
+  Math.sqrt(Math.pow(a.latitude - b.latitude, 2) + Math.pow(a.longitude - b.longitude, 2));
+
+const sortByDistancesFromPoint = <T>(
+  inputArray: T[],
+  getLatLon: (value: T) => LatLon | undefined,
+  position: LatLon
+): T[] => {
+  const sortingArray = inputArray.map((value, index) => {
+    const latLon = getLatLon(value);
+
+    return {
+      distance: latLon && calculateDistance(latLon, position),
+      index
+    };
+  });
+
+  sortingArray.sort((a, b) => {
+    if (a.distance !== undefined && b.distance !== undefined) {
+      // if both are defined, compare the distances
+      return a.distance - b.distance;
+    } else if (a.distance !== undefined) {
+      // if only the first one is defined treat it as being closer
+      return -1;
+    } else if (b.distance !== undefined) {
+      // if only the second one is defined treat it as being closer
+      return 1;
+    } else {
+      // if both are undefined, treat them as equal
+      return 0;
+    }
+  });
+
+  return sortingArray.map((value) => inputArray[value.index]);
+};
+
+// this gets the position out of the item parsed for displaying in the index screen
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getLatLonForPOI = (item: any): LatLon | undefined => {
+  const latitude = item?.params?.details?.addresses?.[0]?.geoLocation?.latitude;
+  const longitude = item?.params?.details?.addresses?.[0]?.geoLocation?.longitude;
+
+  if (latitude && longitude) {
+    return { latitude, longitude };
+  }
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const sortPOIsByDistanceFromPosition = (pointsOfInterest: any[], position: LatLon) =>
+  sortByDistancesFromPoint(pointsOfInterest, getLatLonForPOI, position);

--- a/src/helpers/storageHelper.js
+++ b/src/helpers/storageHelper.js
@@ -9,6 +9,8 @@ export const resetStore = async () => await AsyncStorage.clear();
 export const storageHelper = {
   globalSettings: () => readFromStore('globalSettings'),
   setGlobalSettings: (globalSettings) => addToStore('globalSettings', globalSettings),
+  locationSettings: () => readFromStore('locationSettings'),
+  setLocationSettings: (settings) => addToStore('locationSettings', settings),
   matomoSettings: () => readFromStore('matomoSettings'),
   setMatomoSettings: (matomoSettings) => addToStore('matomoSettings', matomoSettings),
   listTypesSettings: () => readFromStore('listTypesSettings'),

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,6 +1,7 @@
 export * from './apollo';
 export * from './Bookmarks';
 export * from './constructionSites';
+export * from './locationHooks';
 export * from './matomoHooks';
 export * from './NewsCategories';
 export * from './openWebScreen';

--- a/src/hooks/locationHooks.ts
+++ b/src/hooks/locationHooks.ts
@@ -1,23 +1,49 @@
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import * as Location from 'expo-location';
 
-const requestAndFetchPosition = async () => {
+import { SettingsContext } from '../SettingsProvider';
+import { storageHelper } from '../helpers';
+import { LocationSettings } from '../types';
+
+const requestAndFetchPosition = async (
+  setAndSyncLocationSettings: (arg: LocationSettings) => Promise<void>
+) => {
   const { status } = await Location.requestForegroundPermissionsAsync();
+
+  await setAndSyncLocationSettings({ sortPOIs: status === Location.PermissionStatus.GRANTED });
 
   if (status === Location.PermissionStatus.GRANTED) {
     return await Location.getCurrentPositionAsync({});
   }
 };
 
-export const usePosition = (enabled: boolean) => {
+export const useLocationSettings = () => {
+  // @ts-expect-error settings are not properly typed
+  const { locationSettings, setLocationSettings } = useContext(SettingsContext);
+
+  const setAndSyncLocationSettings = async (newSettings: LocationSettings) => {
+    setLocationSettings(newSettings);
+    await storageHelper.setLocationSettings(newSettings);
+  };
+
+  return {
+    locationSettings: locationSettings as LocationSettings,
+    setAndSyncLocationSettings
+  };
+};
+
+export const usePosition = (skip?: boolean) => {
+  const { locationSettings, setAndSyncLocationSettings } = useLocationSettings();
   const [position, setPosition] = useState<Location.LocationObject>();
   const [loading, setLoading] = useState(false);
 
+  const shouldGetPosition = !skip && locationSettings.sortPOIs;
+
   useEffect(() => {
     let mounted = true;
-    if (enabled) {
+    if (shouldGetPosition) {
       setLoading(true);
-      requestAndFetchPosition()
+      requestAndFetchPosition(setAndSyncLocationSettings)
         .then((result) => {
           if (mounted && result) {
             setPosition(result);
@@ -28,7 +54,8 @@ export const usePosition = (enabled: boolean) => {
     return () => {
       mounted = false;
     };
-  }, [enabled]);
+  }, [shouldGetPosition]);
 
-  return { loading, position: enabled ? position : undefined };
+  // actively return undefined as the position, to avoid using the position from when the in app setting was true
+  return { loading, position: shouldGetPosition ? position : undefined };
 };

--- a/src/hooks/locationHooks.ts
+++ b/src/hooks/locationHooks.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import * as Location from 'expo-location';
+
+const requestAndFetchPosition = async () => {
+  const { status } = await Location.requestForegroundPermissionsAsync();
+
+  if (status === Location.PermissionStatus.GRANTED) {
+    return await Location.getCurrentPositionAsync({});
+  }
+};
+
+export const usePosition = (enabled: boolean) => {
+  const [position, setPosition] = useState<Location.LocationObject>();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    if (enabled) {
+      setLoading(true);
+      requestAndFetchPosition()
+        .then((result) => {
+          if (mounted && result) {
+            setPosition(result);
+          }
+        })
+        .finally(() => setLoading(false));
+    }
+    return () => {
+      mounted = false;
+    };
+  }, [enabled]);
+
+  return { loading, position: enabled ? position : undefined };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,8 @@ const MainAppWithApolloProvider = () => {
   const [client, setClient] = useState();
   const [initialGlobalSettings, setInitialGlobalSettings] = useState({});
   const [initialListTypesSettings, setInitialListTypesSettings] = useState({});
+  const [initialLocationSettings, setInitialLocationSettings] = useState({});
+
   const [authRetried, setAuthRetried] = useState(false);
   const [netInfo, setNetInfo] = useState({
     isConnected: null,
@@ -172,8 +174,14 @@ const MainAppWithApolloProvider = () => {
       storageHelper.setGlobalSettings(globalSettings);
     }
 
+    // if there are no locationSettings yet, set the defaults as fallback
+    const locationSettings = globalSettings.settings.locationService
+      ? (await storageHelper.locationSettings()) || { sortPOIs: true }
+      : { sortPOIs: false };
+
     setInitialGlobalSettings(globalSettings);
     setInitialListTypesSettings(listTypesSettings);
+    setInitialLocationSettings(locationSettings);
   };
 
   // setup global settings if apollo client setup finished
@@ -209,7 +217,9 @@ const MainAppWithApolloProvider = () => {
 
   return (
     <ApolloProvider client={client}>
-      <SettingsProvider {...{ initialGlobalSettings, initialListTypesSettings }}>
+      <SettingsProvider
+        {...{ initialGlobalSettings, initialListTypesSettings, initialLocationSettings }}
+      >
         <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
         <Navigator />
       </SettingsProvider>

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -16,11 +16,19 @@ import {
   SafeAreaViewFlex
 } from '../components';
 import { getQuery, getFetchMoreQuery, QUERY_TYPES } from '../queries';
-import { graphqlFetchPolicy, matomoTrackingString, parseListItemsFromQuery } from '../helpers';
-import { useTrackScreenViewAsync } from '../hooks';
+import {
+  graphqlFetchPolicy,
+  matomoTrackingString,
+  parseListItemsFromQuery,
+  sortPOIsByDistanceFromPosition
+} from '../helpers';
+import { usePosition, useTrackScreenViewAsync } from '../hooks';
 
 const { MATOMO_TRACKING } = consts;
 
+// TODO: make a list component for POIs that already includes the mapswitchheader?
+// TODO: make a list component that already includes the news/events filter?
+// eslint-disable-next-line complexity
 export const IndexScreen = ({ navigation, route }) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const { globalSettings } = useContext(SettingsContext);
@@ -32,6 +40,12 @@ export const IndexScreen = ({ navigation, route }) => {
   const trackScreenViewAsync = useTrackScreenViewAsync();
 
   const query = route.params?.query ?? '';
+
+  // TODO: implement and use settings
+  const sortByDistance = query === QUERY_TYPES.POINTS_OF_INTEREST;
+
+  const { loading: loadingPosition, position } = usePosition(sortByDistance);
+
   const title = route.params?.title ?? '';
   const titleDetail = route.params?.titleDetail ?? '';
   const bookmarkable = route.params?.bookmarkable;
@@ -74,6 +88,14 @@ export const IndexScreen = ({ navigation, route }) => {
     },
     [setQueryVariables, queryVariables]
   );
+
+  // if we show the map or want to sort by distance, we need to fetch all the entries at once
+  // this is not a big issue if we want to sort by distance, because getting the location usually takes longer than fetching all entries
+  if (showMap || sortByDistance) {
+    delete queryVariables.limit;
+  } else {
+    queryVariables.limit = route.params?.queryVariables?.limit ?? 15;
+  }
 
   useEffect(() => {
     isConnected && auth();
@@ -145,7 +167,7 @@ export const IndexScreen = ({ navigation, route }) => {
           fetchPolicy={fetchPolicy}
         >
           {({ data, loading, fetchMore, refetch }) => {
-            if (loading) {
+            if (loading || loadingPosition) {
               return (
                 <LoadingContainer>
                   <ActivityIndicator color={colors.accent} />
@@ -153,15 +175,13 @@ export const IndexScreen = ({ navigation, route }) => {
               );
             }
 
-            const listItems = parseListItemsFromQuery(
-              query,
-              data,
-              false,
-              titleDetail,
-              bookmarkable
-            );
+            let listItems = parseListItemsFromQuery(query, data, false, titleDetail, bookmarkable);
 
             if (!listItems) return null;
+
+            if (sortByDistance && position) {
+              listItems = sortPOIsByDistanceFromPosition(listItems, position.coords);
+            }
 
             const fetchMoreData = () =>
               fetchMore({

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -41,10 +41,10 @@ export const IndexScreen = ({ navigation, route }) => {
 
   const query = route.params?.query ?? '';
 
-  // TODO: implement and use settings
+  // we currently only require the position for POIs
   const sortByDistance = query === QUERY_TYPES.POINTS_OF_INTEREST;
 
-  const { loading: loadingPosition, position } = usePosition(sortByDistance);
+  const { loading: loadingPosition, position } = usePosition(!sortByDistance);
 
   const title = route.params?.title ?? '';
   const titleDetail = route.params?.titleDetail ?? '';

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
 import { ActivityIndicator, Alert, SectionList, View } from 'react-native';
+import * as Location from 'expo-location';
 
 import { OrientationContext } from '../OrientationProvider';
 import { SettingsContext } from '../SettingsProvider';
@@ -19,7 +20,7 @@ import {
 import { PushNotificationStorageKeys, setInAppPermission } from '../pushNotifications';
 import { QUERY_TYPES } from '../queries';
 import { createMatomoUserId, readFromStore, removeMatomoUserId, storageHelper } from '../helpers';
-import { useMatomoTrackScreenView } from '../hooks';
+import { useLocationSettings, useMatomoTrackScreenView } from '../hooks';
 
 const { MATOMO_TRACKING } = consts;
 
@@ -61,6 +62,7 @@ const onDeactivatePushNotifications = (revert) => {
 export const SettingsScreen = () => {
   const { orientation, dimensions } = useContext(OrientationContext);
   const { globalSettings, listTypesSettings, setListTypesSettings } = useContext(SettingsContext);
+  const { locationSettings, setAndSyncLocationSettings } = useLocationSettings();
   const [sectionedData, setSectionedData] = useState([]);
 
   useMatomoTrackScreenView(MATOMO_TRACKING.SCREEN_VIEW.SETTINGS);
@@ -100,6 +102,7 @@ export const SettingsScreen = () => {
           ]
         });
       }
+
       // settings should sometimes contain matomo analytics next, depending on server settings
       if (settings.matomo) {
         const { consent: matomoValue = false } = await storageHelper.matomoSettings();
@@ -145,6 +148,62 @@ export const SettingsScreen = () => {
                   ],
                   { cancelable: false }
                 )
+            }
+          ]
+        });
+      }
+
+      // settings should sometimes contain location settings next, depending on server settings
+      if (settings.locationService) {
+        const systemPermission = await Location.getForegroundPermissionsAsync();
+
+        const { sortPOIs = systemPermission.status !== Location.PermissionStatus.DENIED } =
+          locationSettings || {};
+
+        additionalSectionedData.push({
+          data: [
+            {
+              title: texts.settingsTitles.locationService,
+              topDivider: true,
+              type: 'toggle',
+              value: sortPOIs,
+              onActivate: (revert) => {
+                Location.getForegroundPermissionsAsync().then((response) => {
+                  // if the system permission is granted, we can simply enable the sorting
+                  if (response.status === Location.PermissionStatus.GRANTED) {
+                    const newSettings = { sortPOIs: true };
+                    setAndSyncLocationSettings(newSettings);
+                    return;
+                  }
+
+                  // if we can ask for the system permission, do so and update the settings or revert depending on the outcome
+                  if (
+                    response.status === Location.PermissionStatus.UNDETERMINED ||
+                    response.canAskAgain
+                  ) {
+                    Location.requestForegroundPermissionsAsync()
+                      .then((response) => {
+                        if (response.status !== Location.PermissionStatus.GRANTED) {
+                          revert();
+                        } else {
+                          const newSettings = { sortPOIs: true };
+                          setAndSyncLocationSettings(newSettings);
+                          return;
+                        }
+                      })
+                      .catch(() => revert());
+                    return;
+                  }
+
+                  // if we neither have the permission, nor can we ask for it, then show an alert that the permission is missing
+                  revert();
+                  Alert.alert(
+                    texts.settingsTitles.locationService,
+                    texts.settingsContents.locationService.onSystemPermissionMissing
+                  );
+                });
+              },
+              onDeactivate: () => setAndSyncLocationSettings({ sortPOIs: false })
             }
           ]
         });

--- a/src/types/LocationSettings.ts
+++ b/src/types/LocationSettings.ts
@@ -1,0 +1,3 @@
+export type LocationSettings = Partial<{
+  sortPOIs: boolean;
+}>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@ export * from './ConstructionSite';
 export * from './Contact';
 export * from './GenericItem';
 export * from './GenericType';
+export * from './LocationSettings';
 export * from './Navigation';
 export * from './OParlObjectTypes';
 export * from './Survey';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6449,6 +6449,14 @@ expo-localization@^10.2.0:
   dependencies:
     rtl-detect "^1.0.2"
 
+expo-location@~12.1.2:
+  version "12.1.2"
+  resolved "https://registry.yarnpkg.com/expo-location/-/expo-location-12.1.2.tgz#66641a087f1aa4231c9e49ea9d520438d3e35f33"
+  integrity sha512-6P/JR8xkw7UjifiDhyvgYtGZ1iKSLjmAcb0Ksirh3jA3Sao7dbz5ykPu44+UnUZ/SLVqaScJoyMkGclFrtzu8Q==
+  dependencies:
+    "@expo/config-plugins" "^3.0.0"
+    expo-modules-core "~0.2.0"
+
 expo-modules-autolinking@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/expo-modules-autolinking/-/expo-modules-autolinking-0.0.2.tgz#6015c4e0ba995144145ad29fb2a4b34deba73955"


### PR DESCRIPTION
## Changes proposed in this PR:

- the app will now react to a new server provided setting for location services
  - the server setting has to be located besides the settings for matomo etc. in global settings -> settings
  - the key for the new setting is globalSettings -> settings -> locationService
  - if enabled the app will sort the POIs of a selected category by proximity to the users current location
  - locationService can be disabled in app by a new setting on the settings screen, if it is enabled by the server sided config
 
---

SVA-298