### PR TITLE
Fix/android notification channel color

### DIFF
--- a/__tests__/components/__snapshots__/Icon.test.js.snap
+++ b/__tests__/components/__snapshots__/Icon.test.js.snap
@@ -4,8 +4,10 @@ exports[`Icon renders a default Icon 1`] = `
 <View
   hitSlop={
     Object {
-      "bottom": 12,
-      "top": 12,
+      "bottom": 7.439999999999998,
+      "left": 7.439999999999998,
+      "right": 7.439999999999998,
+      "top": 7.439999999999998,
     }
   }
 >
@@ -17,8 +19,10 @@ exports[`Icon renders a svg Icon 1`] = `
 <View
   hitSlop={
     Object {
-      "bottom": 12,
-      "top": 12,
+      "bottom": 8.559999999999999,
+      "left": 8.559999999999999,
+      "right": 8.559999999999999,
+      "top": 8.559999999999999,
     }
   }
 >
@@ -93,8 +97,10 @@ exports[`Icon renders an Icon with custom color 1`] = `
 <View
   hitSlop={
     Object {
-      "bottom": 12,
-      "top": 12,
+      "bottom": 7.439999999999998,
+      "left": 7.439999999999998,
+      "right": 7.439999999999998,
+      "top": 7.439999999999998,
     }
   }
 >
@@ -106,8 +112,10 @@ exports[`Icon renders an Icon with custom style 1`] = `
 <View
   hitSlop={
     Object {
-      "bottom": 12,
-      "top": 12,
+      "bottom": 7.439999999999998,
+      "left": 7.439999999999998,
+      "right": 7.439999999999998,
+      "top": 7.439999999999998,
     }
   }
   style={

--- a/__tests__/components/__snapshots__/Link.test.js.snap
+++ b/__tests__/components/__snapshots__/Link.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Link renders a Link that opens a WebScreen 1`] = `
 <View
-  accessibilityLabel="description (Taste)"
+  accessibilityLabel="(description) (Link)"
   accessible={true}
   focusable={true}
   onClick={[Function]}
@@ -30,8 +30,10 @@ exports[`Link renders a Link that opens a WebScreen 1`] = `
     <View
       hitSlop={
         Object {
-          "bottom": 12,
-          "top": 12,
+          "bottom": 8.559999999999999,
+          "left": 8.559999999999999,
+          "right": 8.559999999999999,
+          "top": 8.559999999999999,
         }
       }
       style={
@@ -148,7 +150,7 @@ exports[`Link renders a Link that opens a WebScreen 1`] = `
 
 exports[`Link renders a default Link 1`] = `
 <View
-  accessibilityLabel="description (Taste)"
+  accessibilityLabel="(description) (Link)"
   accessible={true}
   focusable={true}
   onClick={[Function]}
@@ -176,8 +178,10 @@ exports[`Link renders a default Link 1`] = `
     <View
       hitSlop={
         Object {
-          "bottom": 12,
-          "top": 12,
+          "bottom": 8.559999999999999,
+          "left": 8.559999999999999,
+          "right": 8.559999999999999,
+          "top": 8.559999999999999,
         }
       }
       style={

--- a/__tests__/helpers/colorHelper.test.js
+++ b/__tests__/helpers/colorHelper.test.js
@@ -1,0 +1,31 @@
+import { parseColorToHex } from '../../src/helpers';
+
+describe('parsing different color formats into 6 digit hex format', () => {
+  it('does not alter 6 digit hex format', () => {
+    const testValue = '#001f20';
+    const expectedValue = testValue;
+
+    expect(parseColorToHex(testValue)).toEqual(expectedValue);
+  });
+
+  it('does correctly transform 3 digit hex format into 6 digit hex format', () => {
+    const testValue = '#01f';
+    const expectedValue = '#0011ff';
+
+    expect(parseColorToHex(testValue)).toEqual(expectedValue);
+  });
+
+  it('does correctly transform rgb format into 6 digit hex format', () => {
+    const testValue = 'rgb(0,13,200)';
+    const expectedValue = '#000dc8';
+
+    expect(parseColorToHex(testValue)).toEqual(expectedValue);
+  });
+
+  it('does correctly transform rgb format with varying whitespace into 6 digit hex format', () => {
+    const testValue = 'rgb( 0 ,13  , 200 )';
+    const expectedValue = '#000dc8';
+
+    expect(parseColorToHex(testValue)).toEqual(expectedValue);
+  });
+});

--- a/src/helpers/colorHelper.ts
+++ b/src/helpers/colorHelper.ts
@@ -1,0 +1,29 @@
+export const parseColorToHex = (color: string) => {
+  // check if it is already the correct format
+  if (color.match(/^#[0-9a-fA-F]{6}$/)) {
+    return color;
+  }
+
+  // check for format #fff
+  const shortFormatMatches = /^#([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/.exec(color);
+  if (shortFormatMatches) {
+    shortFormatMatches.shift();
+    shortFormatMatches.forEach((value, index) => (shortFormatMatches[index] = value + value));
+    return `#${shortFormatMatches.join('')}`;
+  }
+
+  // check for format rgb(r,g,b)
+  const rgbFormatMatches = /^rgb\(\s*(?<red>\d+)\s*,\s*(?<green>\d+)\s*,\s*(?<blue>\d+)\s*\)$/.exec(
+    color
+  );
+  if (rgbFormatMatches) {
+    rgbFormatMatches.shift();
+    const hexValues = rgbFormatMatches.map((value) => {
+      const hexValue = Number.parseInt(value);
+      return hexValue < 16 ? `0${hexValue.toString(16)}` : hexValue.toString(16);
+    });
+    return `#${hexValues.join('')}`;
+  }
+
+  return undefined;
+};

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -3,6 +3,7 @@ export * from './parser';
 export * from './addressHelper';
 export * from './bookmarkHelper';
 export * from './calendarHelper';
+export * from './colorHelper';
 export * from './dateTimeHelper';
 export * from './fileSizeHelper';
 export * from './graphqlHelper';

--- a/src/pushNotifications/PermissionHandling.ts
+++ b/src/pushNotifications/PermissionHandling.ts
@@ -3,7 +3,7 @@ import { PermissionStatus } from 'expo-permissions';
 import * as Notifications from 'expo-notifications';
 import Constants from 'expo-constants';
 
-import { addToStore, readFromStore } from '../helpers';
+import { addToStore, parseColorToHex, readFromStore } from '../helpers';
 import { colors, device, texts } from '../config';
 
 import { handleIncomingToken, PushNotificationStorageKeys } from './TokenHandling';
@@ -53,7 +53,7 @@ const registerForPushNotificationsAsync = async () => {
       name: 'default',
       importance: Notifications.AndroidImportance.DEFAULT,
       vibrationPattern: [0, 250, 250, 250],
-      lightColor: colors.primary
+      lightColor: parseColorToHex(colors.primary) ?? '#ffffff' // fall back to white if we can't make sense of the color value
     });
   }
 


### PR DESCRIPTION
## Changes proposed in this PR:

- added color parsing for the android notification channel color
  - the color needs to be provided in a 6 digit hex format, e.g. `#1230f0`
  - we now have 3 supported color formats: `rgb(r,g,b)`, `#rgb` and `#rrggbb`

---

More info in this PR: https://github.com/ikuseiGmbH/smart-village-app-app/pull/352#issuecomment-934331027