### PR TITLE
feat(encounter): display supportid instead of userid

### DIFF
--- a/src/encounterApi/index.ts
+++ b/src/encounterApi/index.ts
@@ -1,3 +1,4 @@
 export * from './encounter';
 export * from './qr';
+export * from './support';
 export * from './user';

--- a/src/encounterApi/support.ts
+++ b/src/encounterApi/support.ts
@@ -1,0 +1,27 @@
+import { encounterApi } from '../config';
+import { getEncounterUserId } from '../helpers';
+
+const url = encounterApi.serverUrl + encounterApi.version + encounterApi.support.create;
+
+export const createSupportIdAsync = async (): Promise<string | undefined> => {
+  const userId = await getEncounterUserId();
+
+  if (!userId) {
+    return;
+  }
+
+  const response = await fetch(`${url}?user_id=${userId}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+
+  const json = await response.json();
+  const status = response.status;
+  const ok = response.ok;
+
+  if (ok && status === 200 && typeof json?.support_id === 'string') {
+    return json.support_id;
+  }
+};

--- a/src/hooks/encounter/index.ts
+++ b/src/hooks/encounter/index.ts
@@ -1,3 +1,4 @@
 export * from './encounter';
 export * from './qr';
+export * from './support';
 export * from './user';

--- a/src/hooks/encounter/support.ts
+++ b/src/hooks/encounter/support.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { createSupportIdAsync } from '../../encounterApi';
+
+export const useEncounterSupportId = (): {
+  error: boolean;
+  loading: boolean;
+  supportId?: string;
+  refresh: () => Promise<void>;
+  refreshing: boolean;
+} => {
+  const [supportId, setSupportId] = useState<string>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const getSupportId = useCallback(async () => {
+    setError(false);
+    setRefreshing(true);
+
+    const res = await createSupportIdAsync();
+
+    res?.length ? setSupportId(res) : setError(true);
+    setLoading(false);
+    setRefreshing(false);
+  }, []);
+
+  useEffect(() => {
+    getSupportId();
+  }, [getSupportId]);
+
+  return { loading, supportId, error, refresh: getSupportId, refreshing };
+};

--- a/src/screens/EncounterDataScreen.tsx
+++ b/src/screens/EncounterDataScreen.tsx
@@ -31,7 +31,7 @@ import {
 import { colors, consts, Icon, texts } from '../config';
 import { updateUserAsync } from '../encounterApi';
 import { momentFormat } from '../helpers';
-import { useEncounterUser, useSelectImage } from '../hooks';
+import { useEncounterUser, useSelectImage, useEncounterSupportId } from '../hooks';
 import { QUERY_TYPES } from '../queries';
 import { ScreenName } from '../types';
 
@@ -58,11 +58,35 @@ export const EncounterDataScreen = ({ navigation }: StackScreenProps<any>) => {
   const [lastName, setLastName] = useState<string>();
   const [birthDate, setBirthDate] = useState<Date>();
   const [phone, setPhone] = useState<string>();
-  const [userIdDisplayValue, setUserIdDisplayValue] = useState<string>();
+  const [supportIdDisplayValue, setSupportIdDisplayValue] = useState<string>();
 
   const { imageUri, selectImage } = useSelectImage();
 
-  const { error, loading, refresh, refreshing, user, userId } = useEncounterUser();
+  const {
+    error: errorSupportId,
+    loading: loadingSupportId,
+    refresh: refreshSupportId,
+    refreshing: refreshingSupportId,
+    supportId
+  } = useEncounterSupportId();
+
+  const {
+    error: errorUser,
+    loading: loadingUser,
+    refresh: refreshUser,
+    refreshing: refreshingUser,
+    user,
+    userId
+  } = useEncounterUser();
+
+  const refreshing = refreshingSupportId || refreshingUser;
+  const loading = loadingSupportId || loadingUser;
+  const error = errorSupportId || errorUser;
+
+  const refresh = useCallback(() => {
+    refreshSupportId();
+    refreshUser();
+  }, [refreshSupportId, refreshUser]);
 
   const onPressInfoVerification = useCallback(() => {
     navigation.navigate(ScreenName.Html, {
@@ -124,8 +148,11 @@ export const EncounterDataScreen = ({ navigation }: StackScreenProps<any>) => {
     setFirstName(user.firstName);
     setLastName(user.lastName);
     setPhone(user.phone);
-    setUserIdDisplayValue(userId);
   }, [user]);
+
+  useEffect(() => {
+    setSupportIdDisplayValue(supportId);
+  }, [supportId]);
 
   if (loading) {
     return <LoadingSpinner loading />;
@@ -256,14 +283,14 @@ export const EncounterDataScreen = ({ navigation }: StackScreenProps<any>) => {
                 </Touchable>
               </WrapperRow>
               <TextInput
-                accessibilityLabel={`${a11yLabels.encounterId} (${userIdDisplayValue})`}
-                onChangeText={setUserIdDisplayValue}
-                onBlur={() => setUserIdDisplayValue(userId)}
+                accessibilityLabel={`${a11yLabels.encounterId} (${supportIdDisplayValue})`}
+                onChangeText={setSupportIdDisplayValue}
+                onBlur={() => setSupportIdDisplayValue(supportId)}
                 onTouchStart={() => userIdInputRef.current?.focus()}
                 ref={userIdInputRef}
                 selectTextOnFocus={true}
                 style={[styles.inputField, styles.displayField]}
-                value={userIdDisplayValue}
+                value={supportIdDisplayValue}
               />
             </Wrapper>
             <Wrapper>


### PR DESCRIPTION
## Changes proposed in this PR:

- added api call and hook for fetching support ids
- replaced display of user id by support id

## Additional Information

⚠️ new secrets are required for the new api endpoint

---

SVA-287