### PR TITLE
chore(location service): rename sortPOIs to locationService

### DIFF
--- a/src/hooks/locationHooks.ts
+++ b/src/hooks/locationHooks.ts
@@ -12,7 +12,9 @@ const requestAndFetchPosition = async (
 ) => {
   const { status } = await Location.requestForegroundPermissionsAsync();
 
-  await setAndSyncLocationSettings({ sortPOIs: status === Location.PermissionStatus.GRANTED });
+  await setAndSyncLocationSettings({
+    locationService: status === Location.PermissionStatus.GRANTED
+  });
 
   if (status === Location.PermissionStatus.GRANTED) {
     let location: Location.LocationObject | undefined;
@@ -59,7 +61,7 @@ export const usePosition = (skip?: boolean) => {
   const [position, setPosition] = useState<Location.LocationObject>();
   const [loading, setLoading] = useState(false);
 
-  const shouldGetPosition = !skip && locationSettings.sortPOIs;
+  const shouldGetPosition = !skip && locationSettings.locationService;
 
   useEffect(() => {
     let mounted = true;

--- a/src/index.js
+++ b/src/index.js
@@ -176,8 +176,8 @@ const MainAppWithApolloProvider = () => {
 
     // if there are no locationSettings yet, set the defaults as fallback
     const locationSettings = globalSettings.settings.locationService
-      ? (await storageHelper.locationSettings()) || { sortPOIs: true }
-      : { sortPOIs: false };
+      ? (await storageHelper.locationSettings()) || { locationService: true }
+      : { locationService: false };
 
     setInitialGlobalSettings(globalSettings);
     setInitialListTypesSettings(listTypesSettings);

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -157,7 +157,7 @@ export const SettingsScreen = () => {
       if (settings.locationService) {
         const systemPermission = await Location.getForegroundPermissionsAsync();
 
-        const { sortPOIs = systemPermission.status !== Location.PermissionStatus.DENIED } =
+        const { locationService = systemPermission.status !== Location.PermissionStatus.DENIED } =
           locationSettings || {};
 
         additionalSectionedData.push({
@@ -166,12 +166,12 @@ export const SettingsScreen = () => {
               title: texts.settingsTitles.locationService,
               topDivider: true,
               type: 'toggle',
-              value: sortPOIs,
+              value: locationService,
               onActivate: (revert) => {
                 Location.getForegroundPermissionsAsync().then((response) => {
                   // if the system permission is granted, we can simply enable the sorting
                   if (response.status === Location.PermissionStatus.GRANTED) {
-                    const newSettings = { sortPOIs: true };
+                    const newSettings = { locationService: true };
                     setAndSyncLocationSettings(newSettings);
                     return;
                   }
@@ -186,7 +186,7 @@ export const SettingsScreen = () => {
                         if (response.status !== Location.PermissionStatus.GRANTED) {
                           revert();
                         } else {
-                          const newSettings = { sortPOIs: true };
+                          const newSettings = { locationService: true };
                           setAndSyncLocationSettings(newSettings);
                           return;
                         }
@@ -203,7 +203,7 @@ export const SettingsScreen = () => {
                   );
                 });
               },
-              onDeactivate: () => setAndSyncLocationSettings({ sortPOIs: false })
+              onDeactivate: () => setAndSyncLocationSettings({ locationService: false })
             }
           ]
         });

--- a/src/types/LocationSettings.ts
+++ b/src/types/LocationSettings.ts
@@ -1,3 +1,3 @@
 export type LocationSettings = Partial<{
-  sortPOIs: boolean;
+  locationService: boolean;
 }>;


### PR DESCRIPTION
renamed `sortPOIs` because the name was no longer appropriate.

if tested on a device which had location services already enabled, the stored settings need to be overwritten by toggling it off and on again in the settings.