### PR TITLE
Fix: wrong root route for categories of news

### DIFF
--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -62,13 +62,13 @@ const useRootRouteByCategory = (details, navigation) => {
     }
 
     // the types (may) differ, so == is required over ===
-    const newRootRouteName = categoriesNews.find((category) => category.categoryId == id)
+    const rootRouteNameByCategory = categoriesNews.find((category) => category.categoryId == id)
       ?.rootRouteName;
 
-    if (newRootRouteName?.length) {
-      navigation.setParams({ rootRouteName: newRootRouteName });
+    if (rootRouteNameByCategory?.length) {
+      navigation.setParams({ rootRouteName: rootRouteNameByCategory });
     }
-  }, [details.categories?.[0]?.id, categoriesNews]);
+  }, [id, categoriesNews]);
 };
 
 export const DetailScreen = ({ navigation, route }) => {

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -121,7 +121,7 @@ export const HomeScreen = ({ navigation, route }) => {
         titleDetail: categoryTitleDetail,
         query: QUERY_TYPES.NEWS_ITEMS,
         queryVariables: { limit: 15, ...{ categoryId } },
-        rootRouteName: rootRouteName?.length ? rootRouteName : ROOT_ROUTE_NAMES.NEWS_ITEMS
+        rootRouteName: rootRouteName || ROOT_ROUTE_NAMES.NEWS_ITEMS
       }
     })
   };


### PR DESCRIPTION
Fixed drawer root route highlighting not respecty categorized news.

- There is now the possibility to add a `rootRouteName` to the `categoriesNews` key of the global settings.
  - if that key is not present, the app will still fall back to `NewsItems`

---

SVA-262