### PR TITLE
feat(image): set original source on cache fail

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -72,13 +72,14 @@ export const Image = ({
             .then((path) => {
               mounted && setSource({ uri: path });
             })
-            .catch((err) =>
+            .catch((err) => {
               console.warn(
                 'An error occurred with cache management for an image',
                 props.source.uri,
                 err
-              )
-            )
+              );
+              mounted && setSource(props.source);
+            })
         : mounted && setSource(props.source);
     }
 


### PR DESCRIPTION
- previously the image would never load, when the caching failed
  - now it tries to fetch the remote directly

---

closes #361