### PR TITLE
BB Bus: always use cache first

### DIFF
--- a/src/config/consts.js
+++ b/src/config/consts.js
@@ -1,5 +1,6 @@
 const ONCE_A_DAY = 'ONCE_A_DAY';
 const ONCE_PER_HOUR = 'ONCE_PER_HOUR';
+const NEVER = 'NEVER';
 
 export const consts = {
   a11yLabel: {
@@ -48,8 +49,9 @@ export const consts = {
     // refresh intervals per time:
     ONCE_A_DAY,
     ONCE_PER_HOUR,
+    NEVER,
     // refresh intervals per type:
-    BB_BUS: ONCE_A_DAY,
+    BB_BUS: NEVER,
     BOOKMARKS: ONCE_A_DAY,
     EVENTS: ONCE_A_DAY,
     NEWS: ONCE_A_DAY,

--- a/src/helpers/refreshIntervalHelper.js
+++ b/src/helpers/refreshIntervalHelper.js
@@ -52,6 +52,10 @@ export const refreshTimeFor = async (refreshTimeKey, refreshInterval) => {
 
       break;
     }
+    case consts.REFRESH_INTERVALS.NEVER: {
+      // always return tomorrow, so that we never refresh
+      return moment().add(1, 'days').unix();
+    }
     default:
       break;
   }

--- a/src/helpers/refreshIntervalHelper.js
+++ b/src/helpers/refreshIntervalHelper.js
@@ -18,6 +18,11 @@ import { addToStore, readFromStore } from './storageHelper';
  * @return {Promise<number>} refresh time in seconds from 01.01.1970 00:00:00 UTC
  */
 export const refreshTimeFor = async (refreshTimeKey, refreshInterval) => {
+  if (refreshInterval === consts.REFRESH_INTERVALS.NEVER) {
+    // always return tomorrow, so that we never refresh
+    return moment().add(1, 'days').unix();
+  }
+
   const refreshIntervals = await readFromStore('refresh-intervals');
   const now = moment().unix(); // now in seconds from 01.01.1970 00:00:00 UTC
   const refreshTime =
@@ -51,10 +56,6 @@ export const refreshTimeFor = async (refreshTimeKey, refreshInterval) => {
       }
 
       break;
-    }
-    case consts.REFRESH_INTERVALS.NEVER: {
-      // always return tomorrow, so that we never refresh
-      return moment().add(1, 'days').unix();
     }
     default:
       break;


### PR DESCRIPTION
- added new const for refresh intervals: NEVER
- if this is selected as the refresh interval the request will always be 'cache-first'

SVA-194