### PR TITLE
fix: adjust paddings for list items with switches

### DIFF
--- a/src/components/ToggleListItem.js
+++ b/src/components/ToggleListItem.js
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { ActivityIndicator, StyleSheet } from 'react-native';
 import { ListItem } from 'react-native-elements';
 
-import { colors, consts, normalize } from '../config';
+import { colors, consts, device, normalize } from '../config';
 
 import { Switch } from './Switch';
 import { BoldText } from './Text';
@@ -44,10 +44,7 @@ export const ToggleListItem = ({ item, index, section }) => {
         bottomDivider !== undefined || index < section.data.length - 1
       }
       topDivider={topDivider ?? false}
-      containerStyle={{
-        backgroundColor: colors.transparent,
-        paddingVertical: normalize(12)
-      }}
+      containerStyle={styles.container}
       rightIcon={
         <WrapperRow>
           {loading && <ActivityIndicator color={colors.accent} style={styles.marginRight} />}
@@ -63,6 +60,10 @@ export const ToggleListItem = ({ item, index, section }) => {
 };
 
 const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.transparent,
+    paddingVertical: device.platform === 'ios' ? normalize(12) : normalize(3.85)
+  },
   marginRight: {
     marginRight: normalize(7)
   }

--- a/src/components/wasteCalendar/WasteReminderSettings.tsx
+++ b/src/components/wasteCalendar/WasteReminderSettings.tsx
@@ -69,12 +69,14 @@ const CategoryEntry = ({
   active,
   categoryKey,
   categoryName,
-  dispatch
+  dispatch,
+  bottomDivider
 }: {
   categoryKey: string;
   categoryName: string;
   active: boolean;
   dispatch: React.Dispatch<ReminderSettingsAction>;
+  bottomDivider: boolean;
 }) => {
   const [switchValue, setSwitchValue] = useState(active);
 
@@ -100,7 +102,8 @@ const CategoryEntry = ({
   return (
     <ListItem
       title={<RegularText>{categoryName}</RegularText>}
-      bottomDivider
+      bottomDivider={bottomDivider}
+      containerStyle={styles.switchContainer}
       rightIcon={<Switch switchValue={switchValue ?? false} toggleSwitch={toggleSwitch} />}
       onPress={onPress}
       delayPressIn={0}
@@ -261,12 +264,13 @@ export const WasteReminderSettings = ({
             <BoldText>{texts.wasteCalendar.whichType}</BoldText>
             <FlatList
               data={Object.keys(types)}
-              renderItem={({ item }) => (
+              renderItem={({ item, index }) => (
                 <CategoryEntry
                   active={state.activeTypes[item]?.active}
                   categoryKey={item}
                   categoryName={types[item].label}
                   dispatch={dispatch}
+                  bottomDivider={index < Object.keys(types).length - 1}
                 />
               )}
               keyExtractor={keyExtractor}
@@ -297,7 +301,6 @@ export const WasteReminderSettings = ({
                   {texts.wasteCalendar.onDayOfCollection}
                 </RegularText>
               }
-              bottomDivider
               rightIcon={
                 <Radiobutton
                   onPress={onPressDayOfCollection}
@@ -367,6 +370,10 @@ export const WasteReminderSettings = ({
 };
 
 const styles = StyleSheet.create({
+  switchContainer: {
+    backgroundColor: colors.transparent,
+    paddingVertical: device.platform === 'ios' ? normalize(12) : normalize(3.85)
+  },
   dateTimePickerContainerIOS: {
     backgroundColor: colors.surface
   },
@@ -379,6 +386,7 @@ const styles = StyleSheet.create({
     paddingTop: normalize(14)
   },
   radioContainer: {
-    backgroundColor: colors.transparent
+    backgroundColor: colors.transparent,
+    paddingVertical: device.platform === 'ios' ? normalize(3.125) : normalize(0)
   }
 });


### PR DESCRIPTION
- on android the switch is bigger than visually rendered, there is space integrated so we need to reduce the list item padding to adjust according our overall list items
- values like 3.85 and 3.125 are used to result in paddings that makes the list item heights fit in size
- removed bottom dividers where not necessary, for last items in lists

**waste:**
|ios before|ios after|
|---|---|
|![IMG_0007](https://user-images.githubusercontent.com/1942953/140933785-4f9271fe-b805-420b-a849-f42bbe05e6ba.PNG)|![IMG_0008](https://user-images.githubusercontent.com/1942953/140933827-2dd22312-3de0-4de1-b25b-9f61d01d0ddd.PNG)|

|android before|android after|
|---|---|
|![Screenshot_20211109-141250](https://user-images.githubusercontent.com/1942953/140934089-19974c62-2449-4c15-80f2-b77184254c3e.png)|![Screenshot_20211109-141552](https://user-images.githubusercontent.com/1942953/140934122-eee9cab2-b805-4de3-895c-b5a732c14c88.png)|

**settings:**
|android before|android after|
|---|---|
|![Screenshot_20211109-141709](https://user-images.githubusercontent.com/1942953/140934208-ef594b02-4e76-4f61-b1d6-ab0a8568b768.png)|![Screenshot_20211109-141718](https://user-images.githubusercontent.com/1942953/140934232-6fde2642-5fa5-47d5-8200-3e9a25d10dcb.png)|