### PR TITLE
BBNavi: text adjustments

### DIFF
--- a/src/components/infoCard/AddressSection.tsx
+++ b/src/components/infoCard/AddressSection.tsx
@@ -20,7 +20,7 @@ import { InfoBox } from '../Wrapper';
 type Props = {
   address?: Address;
   addresses?: Address[];
-  openWebScreen: (link: string) => void;
+  openWebScreen: (link: string, specificTitle?: string) => void;
 };
 
 const addressOnPress = (
@@ -111,7 +111,8 @@ export const AddressSection = ({ address, addresses, openWebScreen }: Props) => 
                   <TouchableOpacity
                     onPress={() =>
                       openWebScreen(
-                        getBBNaviUrl(bbNaviBaseUrl, item, position ?? lastKnownPosition)
+                        getBBNaviUrl(bbNaviBaseUrl, item, position ?? lastKnownPosition),
+                        texts.screenTitles.routePlanner
                       )
                     }
                   >

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -351,7 +351,7 @@ export const texts = {
     openingTime: 'Öffnungszeiten',
     operatingCompany: 'Anbieter',
     prices: 'Preise',
-    routePlanner: 'Zum Stadtnavi',
+    routePlanner: 'Zum Routenplaner bbnavi',
     showLunches: 'Zum aktuellen Gastro-Angebot',
     yourPosition: 'Ihre Position'
   },
@@ -373,6 +373,7 @@ export const texts = {
     company: appJson.expo.name,
     about: appJson.expo.name,
     constructionSite: 'Baustelle',
+    routePlanner: 'Routenplaner bbnavi',
     settings: 'Einstellungen',
     survey: 'Umfrage',
     surveys: 'Umfragen',

--- a/src/hooks/openWebScreen.ts
+++ b/src/hooks/openWebScreen.ts
@@ -11,11 +11,11 @@ export const useOpenWebScreen = (
   const navigation = useNavigation();
 
   const openWebScreen = useCallback(
-    (webUrl) =>
+    (webUrl: string, specificTitle?: string) =>
       navigation.navigate({
         name: 'Web',
         params: {
-          title: title,
+          title: specificTitle ?? title,
           webUrl: !!webUrl && typeof webUrl === 'string' ? webUrl : link,
           rootRouteName,
           shareContent


### PR DESCRIPTION
- added option to pass in a specific title for navigation to openWebScreen
- adjusted link text and navigation title for bbnavi

---

SVA-352

## Screenshots:

![Simulator Screen Shot - iPhone 12 Pro - 2021-11-11 at 15 07 14](https://user-images.githubusercontent.com/59824597/141311967-d9a5d4e0-06de-4929-9475-05dae2f454d4.png)
![Simulator Screen Shot - iPhone 12 Pro - 2021-11-11 at 15 07 31](https://user-images.githubusercontent.com/59824597/141311973-39585fe2-5ed8-4866-8458-a8db90b9ac4a.png)

