### PR TITLE
fix(location overview): category id not being used

### DIFF
--- a/src/components/map/LocationOverview.tsx
+++ b/src/components/map/LocationOverview.tsx
@@ -20,10 +20,13 @@ import { Wrapper, WrapperWithOrientation } from '../Wrapper';
 import { WebViewMap } from './WebViewMap';
 
 type Props = {
-  category: string;
-  dataProviderName?: string;
   position?: LocationObject;
   navigation: StackNavigationProp<never>;
+  queryVariables: {
+    category?: string;
+    categoryId?: string | number;
+    dataProvider?: string;
+  };
   route: RouteProp<any, never>;
 };
 
@@ -54,13 +57,7 @@ const mapToMapMarkers = (data: any): MapMarker[] | undefined => {
   );
 };
 
-export const LocationOverview = ({
-  navigation,
-  position,
-  route,
-  category,
-  dataProviderName
-}: Props) => {
+export const LocationOverview = ({ navigation, position, queryVariables, route }: Props) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const [selectedPointOfInterest, setSelectedPointOfInterest] = useState<string>();
 
@@ -69,7 +66,7 @@ export const LocationOverview = ({
   const overviewQuery = getQuery(QUERY_TYPES.POINTS_OF_INTEREST);
   const { data: overviewData, loading } = useQuery(overviewQuery, {
     fetchPolicy,
-    variables: { category, dataProvider: dataProviderName }
+    variables: queryVariables
   });
 
   const detailsQuery = getQuery(QUERY_TYPES.POINT_OF_INTEREST);

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -156,8 +156,11 @@ export const IndexScreen = ({ navigation, route }) => {
           navigation={navigation}
           route={route}
           position={position}
-          category={queryVariables.category}
-          dataProviderName={queryVariables.dataProvider}
+          queryVariables={{
+            category: queryVariables.category,
+            categoryId: queryVariables.categoryId,
+            dataProvider: queryVariables.dataProvider
+          }}
         />
       ) : (
         <Query


### PR DESCRIPTION
- previously we exclusively used the category string, now we also use the id

- we still use a specific selection of query variables to avoid interactions with pagination

SVA-352