### PR TITLE
Feature: app intro

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,16 +1,15 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import * as SplashScreen from 'expo-splash-screen';
 import * as Font from 'expo-font';
-import MatomoTracker, { MatomoProvider, useMatomo } from 'matomo-tracker-react-native';
+import * as SplashScreen from 'expo-splash-screen';
+import { useMatomo } from 'matomo-tracker-react-native';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { MainApp } from './src';
-import { fontConfig, namespace, secrets } from './src/config';
-import { matomoSettings } from './src/helpers';
+import { fontConfig } from './src/config';
 import { useUserInfoAsync } from './src/hooks';
 
-const AppWithFonts = () => {
+const App = () => {
   const [fontLoaded, setFontLoaded] = useState(false);
-  const { trackAppStart } = useMatomo();
+  const { trackAppStart } = useMatomo(); // TODO: move app start track inside of matomo provider again
   const userInfoAsync = useUserInfoAsync();
 
   const trackAppStartAsync = useCallback(async () => {
@@ -20,6 +19,7 @@ const AppWithFonts = () => {
   }, [userInfoAsync]);
 
   useEffect(() => {
+    SplashScreen.preventAutoHideAsync();
     trackAppStartAsync();
 
     Font.loadAsync(fontConfig)
@@ -28,40 +28,6 @@ const AppWithFonts = () => {
   }, []);
 
   return fontLoaded ? <MainApp /> : null;
-};
-
-const App = () => {
-  const [matomoInstance, setMatomoInstance] = useState();
-
-  useEffect(() => {
-    SplashScreen.preventAutoHideAsync();
-
-    matomoSettings()
-      .then((settings) =>
-        setMatomoInstance(
-          new MatomoTracker({
-            urlBase: secrets[namespace]?.matomoUrl,
-            siteId: secrets[namespace]?.matomoSiteId,
-            userId: settings?.userId,
-            disabled: !settings?.consent || __DEV__,
-            log: __DEV__
-          })
-        )
-      )
-      .catch((error) => {
-        console.warn('An error occurred with setup Matomo tracking', error);
-        setMatomoInstance({ error: true });
-      });
-  }, []);
-
-  if (!matomoInstance) return null;
-  if (matomoInstance && matomoInstance.error) return <AppWithFonts />;
-
-  return (
-    <MatomoProvider instance={matomoInstance}>
-      <AppWithFonts />
-    </MatomoProvider>
-  );
 };
 
 export default App;

--- a/App.js
+++ b/App.js
@@ -1,26 +1,15 @@
 import * as Font from 'expo-font';
 import * as SplashScreen from 'expo-splash-screen';
-import { useMatomo } from 'matomo-tracker-react-native';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { MainApp } from './src';
 import { fontConfig } from './src/config';
-import { useUserInfoAsync } from './src/hooks';
 
 const App = () => {
   const [fontLoaded, setFontLoaded] = useState(false);
-  const { trackAppStart } = useMatomo(); // TODO: move app start track inside of matomo provider again
-  const userInfoAsync = useUserInfoAsync();
-
-  const trackAppStartAsync = useCallback(async () => {
-    const userInfo = await userInfoAsync();
-
-    trackAppStart({ userInfo });
-  }, [userInfoAsync]);
 
   useEffect(() => {
     SplashScreen.preventAutoHideAsync();
-    trackAppStartAsync();
 
     Font.loadAsync(fontConfig)
       .catch((error) => console.warn('An error occurred with loading the fonts', error))

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "react": "17.0.1",
     "react-apollo": "~3.1.5",
     "react-native": "^0.64.3",
+    "react-native-app-intro-slider": "^4.0.4",
     "react-native-autocomplete-input": "^4.2.0",
     "react-native-calendars": "^1.1266.0",
     "react-native-collapsible": "^1.6.0",

--- a/src/CustomMatomoProvider.js
+++ b/src/CustomMatomoProvider.js
@@ -4,23 +4,26 @@ import React, { useEffect, useState } from 'react';
 
 import { namespace, secrets } from './config';
 import { matomoSettings } from './helpers';
+import { useUserInfoAsync } from './hooks';
 
 export const CustomMatomoProvider = ({ children }) => {
   const [matomoInstance, setMatomoInstance] = useState();
+  const getUserInfo = useUserInfoAsync();
 
   useEffect(() => {
     matomoSettings()
-      .then((settings) =>
-        setMatomoInstance(
-          new MatomoTracker({
-            urlBase: secrets[namespace]?.matomoUrl,
-            siteId: secrets[namespace]?.matomoSiteId,
-            userId: settings?.userId,
-            disabled: !settings?.consent || __DEV__,
-            log: __DEV__
-          })
-        )
-      )
+      .then((settings) => {
+        const instance = new MatomoTracker({
+          urlBase: secrets[namespace]?.matomoUrl,
+          siteId: secrets[namespace]?.matomoSiteId,
+          userId: settings?.userId,
+          disabled: !settings?.consent || __DEV__,
+          log: __DEV__
+        });
+
+        getUserInfo().then((userInfo) => instance.trackAppStart(userInfo));
+        setMatomoInstance(instance);
+      })
       .catch((error) => {
         console.warn('An error occurred with setup Matomo tracking', error);
         setMatomoInstance({});

--- a/src/CustomMatomoProvider.js
+++ b/src/CustomMatomoProvider.js
@@ -1,0 +1,37 @@
+import MatomoTracker, { MatomoProvider } from 'matomo-tracker-react-native';
+import PropTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
+
+import { namespace, secrets } from './config';
+import { matomoSettings } from './helpers';
+
+export const CustomMatomoProvider = ({ children }) => {
+  const [matomoInstance, setMatomoInstance] = useState();
+
+  useEffect(() => {
+    matomoSettings()
+      .then((settings) =>
+        setMatomoInstance(
+          new MatomoTracker({
+            urlBase: secrets[namespace]?.matomoUrl,
+            siteId: secrets[namespace]?.matomoSiteId,
+            userId: settings?.userId,
+            disabled: !settings?.consent || __DEV__,
+            log: __DEV__
+          })
+        )
+      )
+      .catch((error) => {
+        console.warn('An error occurred with setup Matomo tracking', error);
+        setMatomoInstance({});
+      });
+  }, []);
+
+  if (!matomoInstance) return null;
+
+  return <MatomoProvider instance={matomoInstance}>{children}</MatomoProvider>;
+};
+
+CustomMatomoProvider.propTypes = {
+  children: PropTypes.node
+};

--- a/src/OnboardingManager.tsx
+++ b/src/OnboardingManager.tsx
@@ -36,6 +36,7 @@ const useInitializeAfterOnboarding = (onboardingComplete: boolean) => {
         Initializers[Initializer.PushNotifications]();
       }
 
+      // set orientation to "default", to allow both portrait and landscape
       ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.DEFAULT);
     }
   }, [onboardingComplete]);

--- a/src/OnboardingManager.tsx
+++ b/src/OnboardingManager.tsx
@@ -2,7 +2,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import React, { useContext, useEffect, useState } from 'react';
 
 import { addToStore, readFromStore } from './helpers';
-import { Initializers } from './helpers/initializationHelper';
+import { Initializer, Initializers } from './helpers/initializationHelper';
 import { AppIntroScreen } from './screens';
 import { SettingsContext } from './SettingsProvider';
 
@@ -15,7 +15,11 @@ export const OnboardingManager = ({ children }: { children: React.ReactNode }) =
   const {
     globalSettings: {
       // @ts-expect-error settings context is not properly typed
-      settings: { onboarding: onboardingActive }
+      settings: {
+        locationService: locationServiceActive,
+        onboarding: onboardingActive,
+        pushNotifications: pushNotificationsActive
+      }
     }
   } = useContext(SettingsContext);
 
@@ -55,8 +59,13 @@ export const OnboardingManager = ({ children }: { children: React.ReactNode }) =
   // this effect ensures that all settings will be properly initialized, even when onboarding was completed before the settings where available, or an error occured
   useEffect(() => {
     if (onboardingStatus === 'complete') {
-      // TODO: filter out settings disabled by globalsettings
-      Initializers.forEach((init) => init());
+      // TODO: add matomo
+      if (locationServiceActive) {
+        Initializers[Initializer.LocationService]();
+      }
+      if (pushNotificationsActive) {
+        Initializers[Initializer.PushNotifications]();
+      }
     }
   }, [onboardingStatus]);
 

--- a/src/OnboardingManager.tsx
+++ b/src/OnboardingManager.tsx
@@ -1,3 +1,4 @@
+import * as ScreenOrientation from 'expo-screen-orientation';
 import * as SplashScreen from 'expo-splash-screen';
 import React, { useContext, useEffect, useState } from 'react';
 
@@ -34,6 +35,8 @@ const useInitializeAfterOnboarding = (onboardingComplete: boolean) => {
       if (pushNotificationsActive) {
         Initializers[Initializer.PushNotifications]();
       }
+
+      ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.DEFAULT);
     }
   }, [onboardingComplete]);
 };

--- a/src/OnboardingManager.tsx
+++ b/src/OnboardingManager.tsx
@@ -1,0 +1,74 @@
+import * as SplashScreen from 'expo-splash-screen';
+import React, { useContext, useEffect, useState } from 'react';
+
+import { addToStore, readFromStore } from './helpers';
+import { Initializers } from './helpers/initializationHelper';
+import { AppIntroScreen } from './screens';
+import { SettingsContext } from './SettingsProvider';
+
+const ONBOARDING_STORE_KEY = 'ONBOARDING_STORE_KEY';
+
+export const OnboardingManager = ({ children }: { children: React.ReactNode }) => {
+  const [onboardingStatus, setOnboardingStatus] = useState<'loading' | 'complete' | 'incomplete'>(
+    'loading'
+  );
+  const {
+    globalSettings: {
+      // @ts-expect-error settings context is not properly typed
+      settings: { onboarding: onboardingActive }
+    }
+  } = useContext(SettingsContext);
+
+  const setOnboardingComplete = () => {
+    setOnboardingStatus('complete');
+
+    addToStore(ONBOARDING_STORE_KEY, 'complete');
+  };
+
+  useEffect(() => {
+    const loadAndSetOnboardingStatus = async () => {
+      try {
+        const onboardingComplete = await readFromStore(ONBOARDING_STORE_KEY);
+
+        if (onboardingComplete === 'complete') {
+          setOnboardingStatus('complete');
+        } else {
+          setOnboardingStatus('incomplete');
+        }
+      } catch (e) {
+        setOnboardingStatus('complete');
+
+        console.error(e);
+      } finally {
+        await SplashScreen.hideAsync();
+      }
+    };
+
+    if (onboardingActive) {
+      loadAndSetOnboardingStatus();
+    } else {
+      setOnboardingStatus('complete');
+      SplashScreen.hideAsync();
+    }
+  }, []);
+
+  // this effect ensures that all settings will be properly initialized, even when onboarding was completed before the settings where available, or an error occured
+  useEffect(() => {
+    if (onboardingStatus === 'complete') {
+      // TODO: filter out settings disabled by globalsettings
+      Initializers.forEach((init) => init());
+    }
+  }, [onboardingStatus]);
+
+  // render null while onboarding status is loading from AsyncStorage
+  if (onboardingStatus === 'loading') {
+    return null;
+  }
+
+  if (onboardingStatus === 'incomplete') {
+    return <AppIntroScreen setOnboardingComplete={setOnboardingComplete} />;
+  }
+
+  // TODO: move matomo provider  here
+  return <>{children}</>;
+};

--- a/src/SettingsProvider.js
+++ b/src/SettingsProvider.js
@@ -5,6 +5,9 @@ export const SettingsContext = createContext({
   globalSettings: {
     filter: {},
     sections: {}
+  },
+  onboardingSettings: {
+    onboardingComplete: true
   }
 });
 
@@ -12,11 +15,13 @@ export const SettingsProvider = ({
   initialGlobalSettings,
   initialListTypesSettings,
   initialLocationSettings,
+  initialOnboardingSettings,
   children
 }) => {
   const [globalSettings, setGlobalSettings] = useState(initialGlobalSettings);
   const [listTypesSettings, setListTypesSettings] = useState(initialListTypesSettings);
   const [locationSettings, setLocationSettings] = useState(initialLocationSettings);
+  const [onboardingSettings, setOnboardingSettings] = useState(initialOnboardingSettings);
 
   return (
     <SettingsContext.Provider
@@ -26,7 +31,9 @@ export const SettingsProvider = ({
         listTypesSettings,
         setListTypesSettings,
         locationSettings,
-        setLocationSettings
+        setLocationSettings,
+        onboardingSettings,
+        setOnboardingSettings
       }}
     >
       {children}
@@ -38,5 +45,6 @@ SettingsProvider.propTypes = {
   initialGlobalSettings: PropTypes.object.isRequired,
   initialListTypesSettings: PropTypes.object.isRequired,
   initialLocationSettings: PropTypes.object.isRequired,
-  children: PropTypes.array.isRequired
+  initialOnboardingSettings: PropTypes.object.isRequired,
+  children: PropTypes.object.isRequired
 };

--- a/src/SettingsProvider.js
+++ b/src/SettingsProvider.js
@@ -5,9 +5,6 @@ export const SettingsContext = createContext({
   globalSettings: {
     filter: {},
     sections: {}
-  },
-  onboardingSettings: {
-    onboardingComplete: true
   }
 });
 
@@ -15,13 +12,11 @@ export const SettingsProvider = ({
   initialGlobalSettings,
   initialListTypesSettings,
   initialLocationSettings,
-  initialOnboardingSettings,
   children
 }) => {
   const [globalSettings, setGlobalSettings] = useState(initialGlobalSettings);
   const [listTypesSettings, setListTypesSettings] = useState(initialListTypesSettings);
   const [locationSettings, setLocationSettings] = useState(initialLocationSettings);
-  const [onboardingSettings, setOnboardingSettings] = useState(initialOnboardingSettings);
 
   return (
     <SettingsContext.Provider
@@ -31,9 +26,7 @@ export const SettingsProvider = ({
         listTypesSettings,
         setListTypesSettings,
         locationSettings,
-        setLocationSettings,
-        onboardingSettings,
-        setOnboardingSettings
+        setLocationSettings
       }}
     >
       {children}
@@ -45,6 +38,5 @@ SettingsProvider.propTypes = {
   initialGlobalSettings: PropTypes.object.isRequired,
   initialListTypesSettings: PropTypes.object.isRequired,
   initialLocationSettings: PropTypes.object.isRequired,
-  initialOnboardingSettings: PropTypes.object.isRequired,
   children: PropTypes.object.isRequired
 };

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -113,6 +113,14 @@ export const RegularText = styled(Text)`
 
 export const BoldText = styled(RegularText)`
   font-family: bold;
+
+  ${(props) =>
+    props.big &&
+    css`
+      font-size: ${normalize(20)};
+      line-height: ${normalize(26)};
+    `};
+
   ${(props) =>
     props.italic &&
     css`

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -412,10 +412,6 @@ export const texts = {
   pushNotifications: {
     abort: 'Abbrechen',
     approve: 'Jetzt einschalten',
-    decline: 'Vielleicht später',
-    greetingBody:
-      'Damit Sie wichtige Mitteilungen aus Ihrer Kommune erreichen, würden wir Ihnen gerne Benachrichtigungen schicken. Sie können diese Einstellung jederzeit in Ihrem persönlichen Bereich ändern.',
-    greetingTitle: 'Willkommen',
     permissionMissingBody: 'Bitte überprüfen Sie Ihre Benachrichtigungseinstellungen im System.',
     permissionMissingTitle: 'Hinweis',
     permissionRequiredBody:

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -437,6 +437,8 @@ export const texts = {
       no: 'Nein',
       onActivate:
         'Soll Matomo Analytics aktiviert werden? Dies trägt zur Verbesserung der App bei. Matomo Analytics wird nach der Aktivierung mit dem nächsten Neustart der App wirksam.',
+      onActivateWithoutRestart:
+        'Soll Matomo Analytics aktiviert werden? Dies trägt zur Verbesserung der App bei.',
       onDeactivate:
         'Soll Matomo Analytics deaktiviert werden? Die Deaktivierung von Matomo Analytics wird mit dem nächsten Neustart der App wirksam.',
       yes: 'Ja'

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -1,6 +1,9 @@
 import appJson from '../../app.json';
 
 export const texts = {
+  appIntro: {
+    continue: 'Weiter'
+  },
   backToTop: 'zurück nach oben',
   bbBus: {
     authority: {

--- a/src/helpers/initializationHelper.ts
+++ b/src/helpers/initializationHelper.ts
@@ -18,8 +18,6 @@ const initializeLocationServices = async () => {
   }
 };
 
-// TODO: check how to do it with matomo and initialization differences (pre/post rendering the provider)
-// -> change type from `() => void` to `(onboarding?: boolean) => void` ?
 export const Initializers = {
   [Initializer.LocationService]: initializeLocationServices,
   [Initializer.MatomoTracking]: showMatomoAlert,

--- a/src/helpers/initializationHelper.ts
+++ b/src/helpers/initializationHelper.ts
@@ -18,8 +18,8 @@ const initializeLocationServices = async () => {
 
 // TODO: check how to do it with matomo and initialization differences (pre/post rendering the provider)
 // -> change type from `() => void` to `(onboarding?: boolean) => void` ?
-export const Initializers = new Map<Initializer, () => void>([
-  [Initializer.LocationService, initializeLocationServices],
-  [Initializer.MatomoTracking, () => undefined], // TODO:  get permission -> request if not present
-  [Initializer.PushNotifications, handleSystemPermissions]
-]);
+export const Initializers = {
+  [Initializer.LocationService]: initializeLocationServices,
+  [Initializer.MatomoTracking]: () => undefined, // TODO:  get permission -> request if not present
+  [Initializer.PushNotifications]: handleSystemPermissions
+};

--- a/src/helpers/initializationHelper.ts
+++ b/src/helpers/initializationHelper.ts
@@ -2,6 +2,8 @@ import * as Location from 'expo-location';
 
 import { handleSystemPermissions } from '../pushNotifications';
 
+import { showMatomoAlert } from './matomoHelper';
+
 export enum Initializer {
   LocationService = 'locationService',
   MatomoTracking = 'matomoTracking',
@@ -20,6 +22,6 @@ const initializeLocationServices = async () => {
 // -> change type from `() => void` to `(onboarding?: boolean) => void` ?
 export const Initializers = {
   [Initializer.LocationService]: initializeLocationServices,
-  [Initializer.MatomoTracking]: () => undefined, // TODO:  get permission -> request if not present
+  [Initializer.MatomoTracking]: showMatomoAlert,
   [Initializer.PushNotifications]: handleSystemPermissions
 };

--- a/src/helpers/initializationHelper.ts
+++ b/src/helpers/initializationHelper.ts
@@ -1,0 +1,25 @@
+import * as Location from 'expo-location';
+
+import { handleSystemPermissions } from '../pushNotifications';
+
+export enum Initializer {
+  LocationService = 'locationService',
+  MatomoTracking = 'matomoTracking',
+  PushNotifications = 'pushNotifications'
+}
+
+const initializeLocationServices = async () => {
+  const { canAskAgain, status } = await Location.getForegroundPermissionsAsync();
+
+  if (status !== Location.PermissionStatus.GRANTED && canAskAgain) {
+    await Location.requestForegroundPermissionsAsync();
+  }
+};
+
+// TODO: check how to do it with matomo and initialization differences (pre/post rendering the provider)
+// -> change type from `() => void` to `(onboarding?: boolean) => void` ?
+export const Initializers = new Map<Initializer, () => void>([
+  [Initializer.LocationService, initializeLocationServices],
+  [Initializer.MatomoTracking, () => undefined], // TODO:  get permission -> request if not present
+  [Initializer.PushNotifications, handleSystemPermissions]
+]);

--- a/src/helpers/matomoHelper.js
+++ b/src/helpers/matomoHelper.js
@@ -1,6 +1,33 @@
+import { Alert } from 'react-native';
 import { v4 as uuid } from 'uuid';
 
+import { texts } from '../config';
 import { storageHelper } from '../helpers/storageHelper';
+
+// TODO: use as initializer. add arg for changing text depending on place where it is used
+export const showMatomoAlert = async () => {
+  const settings = await matomoSettings();
+
+  if (!settings?.matomoHandledOnStartup) {
+    Alert.alert(
+      texts.settingsTitles.analytics,
+      texts.settingsContents.analytics.onActivate,
+      [
+        {
+          text: texts.settingsContents.analytics.no,
+          style: 'cancel'
+        },
+        {
+          text: texts.settingsContents.analytics.yes,
+          onPress: createMatomoUserId
+        }
+      ],
+      { cancelable: false }
+    );
+
+    setMatomoHandledOnStartup();
+  }
+};
 
 export const matomoSettings = async () => {
   let settings = await storageHelper.matomoSettings();
@@ -22,7 +49,7 @@ export const matomoSettings = async () => {
     delete settings.userId;
   }
 
-  storageHelper.setMatomoSettings(settings);
+  await storageHelper.setMatomoSettings(settings);
 
   return settings;
 };
@@ -33,7 +60,7 @@ export const matomoSettings = async () => {
  * the user already consented manually.
  */
 export const createMatomoUserId = async () => {
-  const settings = await storageHelper.matomoSettings();
+  const settings = await matomoSettings();
 
   if (settings) {
     settings.userId = uuid();
@@ -47,7 +74,7 @@ export const createMatomoUserId = async () => {
  * Remove a Matomo user id and the consent to be tracked.
  */
 export const removeMatomoUserId = async () => {
-  const settings = await storageHelper.matomoSettings();
+  const settings = await matomoSettings();
 
   if (settings?.userId) {
     delete settings.userId;
@@ -61,7 +88,7 @@ export const removeMatomoUserId = async () => {
  * be shown once.
  */
 export const setMatomoHandledOnStartup = async () => {
-  const settings = await storageHelper.matomoSettings();
+  const settings = await matomoSettings();
 
   if (settings) {
     settings.matomoHandledOnStartup = true;

--- a/src/helpers/matomoHelper.js
+++ b/src/helpers/matomoHelper.js
@@ -4,14 +4,15 @@ import { v4 as uuid } from 'uuid';
 import { texts } from '../config';
 import { storageHelper } from '../helpers/storageHelper';
 
-// TODO: use as initializer. add arg for changing text depending on place where it is used
-export const showMatomoAlert = async () => {
+export const showMatomoAlert = async (fromAppIntro) => {
   const settings = await matomoSettings();
 
   if (!settings?.matomoHandledOnStartup) {
     Alert.alert(
       texts.settingsTitles.analytics,
-      texts.settingsContents.analytics.onActivate,
+      fromAppIntro
+        ? texts.settingsContents.analytics.onActivateWithoutRestart
+        : texts.settingsContents.analytics.onActivate,
       [
         {
           text: texts.settingsContents.analytics.no,

--- a/src/helpers/storageHelper.js
+++ b/src/helpers/storageHelper.js
@@ -10,6 +10,7 @@ export const storageHelper = {
   globalSettings: () => readFromStore('globalSettings'),
   setGlobalSettings: (globalSettings) => addToStore('globalSettings', globalSettings),
   locationSettings: () => readFromStore('locationSettings'),
+  onboardingSettings: () => readFromStore('onboardingSettings'),
   setLocationSettings: (settings) => addToStore('locationSettings', settings),
   matomoSettings: () => readFromStore('matomoSettings'),
   setMatomoSettings: (matomoSettings) => addToStore('matomoSettings', matomoSettings),

--- a/src/helpers/storageHelper.js
+++ b/src/helpers/storageHelper.js
@@ -10,7 +10,6 @@ export const storageHelper = {
   globalSettings: () => readFromStore('globalSettings'),
   setGlobalSettings: (globalSettings) => addToStore('globalSettings', globalSettings),
   locationSettings: () => readFromStore('locationSettings'),
-  onboardingSettings: () => readFromStore('onboardingSettings'),
   setLocationSettings: (settings) => addToStore('locationSettings', settings),
   matomoSettings: () => readFromStore('matomoSettings'),
   setMatomoSettings: (matomoSettings) => addToStore('matomoSettings', matomoSettings),

--- a/src/hooks/locationHooks.ts
+++ b/src/hooks/locationHooks.ts
@@ -88,7 +88,7 @@ const usePos = (func: RequestPermissionAndFetchFunction, skip?: boolean) => {
   const [position, setPosition] = useState<Location.LocationObject>();
   const [loading, setLoading] = useState(false);
 
-  const shouldGetPosition = !skip && locationSettings.locationService;
+  const shouldGetPosition = !skip && locationSettings.locationService !== false;
 
   useEffect(() => {
     let mounted = true;

--- a/src/hooks/matomoHooks.js
+++ b/src/hooks/matomoHooks.js
@@ -2,13 +2,10 @@ import Constants from 'expo-constants';
 import * as Localization from 'expo-localization';
 import { useMatomo } from 'matomo-tracker-react-native';
 import { useCallback, useContext, useEffect } from 'react';
-import { Alert } from 'react-native';
 
 import appJson from '../../app.json';
-import { device, texts } from '../config';
-import { createMatomoUserId, setMatomoHandledOnStartup, storageHelper } from '../helpers';
+import { device } from '../config';
 import { NetworkContext } from '../NetworkProvider';
-import { SettingsContext } from '../SettingsProvider';
 
 export const useUserInfoAsync = () =>
   useCallback(async () => {
@@ -51,37 +48,5 @@ export const useMatomoTrackScreenView = (name) => {
 
   useEffect(() => {
     isConnected && trackScreenViewAsync(name);
-  }, []);
-};
-
-export const useMatomoAlertOnStartUp = () => {
-  const { globalSettings } = useContext(SettingsContext);
-
-  useEffect(() => {
-    const showMatomoAlert = async () => {
-      const settings = await storageHelper.matomoSettings();
-
-      if (!settings?.matomoHandledOnStartup) {
-        Alert.alert(
-          texts.settingsTitles.analytics,
-          texts.settingsContents.analytics.onActivate,
-          [
-            {
-              text: texts.settingsContents.analytics.no,
-              style: 'cancel'
-            },
-            {
-              text: texts.settingsContents.analytics.yes,
-              onPress: createMatomoUserId
-            }
-          ],
-          { cancelable: false }
-        );
-
-        setMatomoHandledOnStartup();
-      }
-    };
-
-    !!globalSettings?.settings?.matomo && showMatomoAlert();
   }, []);
 };

--- a/src/hooks/matomoHooks.js
+++ b/src/hooks/matomoHooks.js
@@ -50,18 +50,3 @@ export const useMatomoTrackScreenView = (name) => {
     isConnected && trackScreenViewAsync(name);
   }, []);
 };
-
-export const useTrackAppStart = () => {
-  const { trackAppStart } = useMatomo();
-  const userInfoAsync = useUserInfoAsync();
-
-  const trackAppStartAsync = useCallback(async () => {
-    const userInfo = await userInfoAsync();
-
-    trackAppStart({ userInfo });
-  }, [userInfoAsync]);
-
-  useEffect(() => {
-    trackAppStartAsync();
-  }, []);
-};

--- a/src/hooks/matomoHooks.js
+++ b/src/hooks/matomoHooks.js
@@ -50,3 +50,18 @@ export const useMatomoTrackScreenView = (name) => {
     isConnected && trackScreenViewAsync(name);
   }, []);
 };
+
+export const useTrackAppStart = () => {
+  const { trackAppStart } = useMatomo();
+  const userInfoAsync = useUserInfoAsync();
+
+  const trackAppStartAsync = useCallback(async () => {
+    const userInfo = await userInfoAsync();
+
+    trackAppStart({ userInfo });
+  }, [userInfoAsync]);
+
+  useEffect(() => {
+    trackAppStartAsync();
+  }, []);
+};

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,7 @@ import { ApolloClient } from 'apollo-client';
 import { ApolloLink } from 'apollo-link';
 import { setContext } from 'apollo-link-context';
 import { createHttpLink } from 'apollo-link-http';
-import * as ScreenOrientation from 'expo-screen-orientation';
 import * as SecureStore from 'expo-secure-store';
-import * as SplashScreen from 'expo-splash-screen';
 import _isEmpty from 'lodash/isEmpty';
 import React, { useEffect, useState } from 'react';
 import { ApolloProvider } from 'react-apollo';
@@ -36,7 +34,6 @@ const { LIST_TYPES } = consts;
 
 const MainAppWithApolloProvider = () => {
   const [loading, setLoading] = useState(true);
-  const [isSplashScreenVisible, setIsSplashScreenVisible] = useState(true);
   const [client, setClient] = useState();
   const [initialGlobalSettings, setInitialGlobalSettings] = useState({});
   const [initialListTypesSettings, setInitialListTypesSettings] = useState({});
@@ -207,16 +204,7 @@ const MainAppWithApolloProvider = () => {
     initialGlobalSettings && client && setLoading(false);
   }, [initialGlobalSettings]);
 
-  useEffect(() => {
-    !loading &&
-      SplashScreen.hideAsync().then(() => {
-        setIsSplashScreenVisible(false);
-        // set orientation to "default", to allow both portrait and landscape
-        ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.DEFAULT);
-      });
-  }, [loading]);
-
-  if (loading || isSplashScreenVisible) {
+  if (loading) {
     return (
       <LoadingContainer>
         <ActivityIndicator color={colors.accent} />

--- a/src/index.js
+++ b/src/index.js
@@ -178,7 +178,9 @@ const MainAppWithApolloProvider = () => {
     }
 
     // if there are no locationSettings yet, set the defaults as fallback
-    const locationSettings = (await storageHelper.locationSettings()) || {};
+    const locationSettings = !globalSettings.settings.locationService
+      ? { locationService: false }
+      : (await storageHelper.locationSettings()) || {};
 
     const defaultAlternativePosition =
       globalSettings.settings.locationService?.defaultAlternativePosition;
@@ -189,9 +191,9 @@ const MainAppWithApolloProvider = () => {
       );
     }
 
-    setInitialGlobalSettings(globalSettings);
-    setInitialListTypesSettings(listTypesSettings);
     setInitialLocationSettings(locationSettings);
+    setInitialListTypesSettings(listTypesSettings);
+    setInitialGlobalSettings(globalSettings);
   };
 
   // setup global settings if apollo client setup finished

--- a/src/index.js
+++ b/src/index.js
@@ -183,9 +183,7 @@ const MainAppWithApolloProvider = () => {
     }
 
     // if there are no locationSettings yet, set the defaults as fallback
-    const locationSettings = globalSettings.settings.locationService
-      ? (await storageHelper.locationSettings()) || { locationService: true }
-      : { locationService: false };
+    const locationSettings = (await storageHelper.locationSettings()) || {};
 
     const defaultAlternativePosition =
       globalSettings.settings.locationService?.defaultAlternativePosition;

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import _isEmpty from 'lodash/isEmpty';
 import React, { useEffect, useState } from 'react';
 import { ApolloProvider } from 'react-apollo';
-import { ActivityIndicator, StatusBar } from 'react-native';
+import { ActivityIndicator } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { auth } from './auth';
@@ -40,6 +40,9 @@ const MainAppWithApolloProvider = () => {
   const [initialGlobalSettings, setInitialGlobalSettings] = useState({});
   const [initialListTypesSettings, setInitialListTypesSettings] = useState({});
   const [initialLocationSettings, setInitialLocationSettings] = useState({});
+  const [initialOnboardingSettings, setInitialOnboardingSetting] = useState({
+    onboardingComplete: false
+  });
 
   const [authRetried, setAuthRetried] = useState(false);
   const [netInfo, setNetInfo] = useState({
@@ -192,10 +195,16 @@ const MainAppWithApolloProvider = () => {
         defaultAlternativePosition
       );
     }
+    // if there are no onboarding settings yet, set the defaults as fallback
+    // only use the onboarding if it was not already completed, but is enabled on the server
+    const onboardingSettings = (await storageHelper.onboardingSettings()) || {
+      onboardingComplete: false
+    };
 
     setInitialGlobalSettings(globalSettings);
     setInitialListTypesSettings(listTypesSettings);
     setInitialLocationSettings(locationSettings);
+    setInitialOnboardingSetting(onboardingSettings);
   };
 
   // setup global settings if apollo client setup finished
@@ -232,9 +241,13 @@ const MainAppWithApolloProvider = () => {
   return (
     <ApolloProvider client={client}>
       <SettingsProvider
-        {...{ initialGlobalSettings, initialListTypesSettings, initialLocationSettings }}
+        {...{
+          initialGlobalSettings,
+          initialListTypesSettings,
+          initialLocationSettings,
+          initialOnboardingSettings
+        }}
       >
-        <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
         <Navigator />
       </SettingsProvider>
     </ApolloProvider>

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ import {
 import { Navigator } from './navigation/Navigator';
 import NetInfo from './NetInfo';
 import { NetworkProvider } from './NetworkProvider';
+import { OnboardingManager } from './OnboardingManager';
 import { OrientationProvider } from './OrientationProvider';
 import { getQuery, QUERY_TYPES } from './queries';
 import { SettingsProvider } from './SettingsProvider';
@@ -40,9 +41,6 @@ const MainAppWithApolloProvider = () => {
   const [initialGlobalSettings, setInitialGlobalSettings] = useState({});
   const [initialListTypesSettings, setInitialListTypesSettings] = useState({});
   const [initialLocationSettings, setInitialLocationSettings] = useState({});
-  const [initialOnboardingSettings, setInitialOnboardingSetting] = useState({
-    onboardingComplete: false
-  });
 
   const [authRetried, setAuthRetried] = useState(false);
   const [netInfo, setNetInfo] = useState({
@@ -193,16 +191,10 @@ const MainAppWithApolloProvider = () => {
         defaultAlternativePosition
       );
     }
-    // if there are no onboarding settings yet, set the defaults as fallback
-    // only use the onboarding if it was not already completed, but is enabled on the server
-    const onboardingSettings = (await storageHelper.onboardingSettings()) || {
-      onboardingComplete: false
-    };
 
     setInitialGlobalSettings(globalSettings);
     setInitialListTypesSettings(listTypesSettings);
     setInitialLocationSettings(locationSettings);
-    setInitialOnboardingSetting(onboardingSettings);
   };
 
   // setup global settings if apollo client setup finished
@@ -242,11 +234,12 @@ const MainAppWithApolloProvider = () => {
         {...{
           initialGlobalSettings,
           initialListTypesSettings,
-          initialLocationSettings,
-          initialOnboardingSettings
+          initialLocationSettings
         }}
       >
-        <Navigator />
+        <OnboardingManager>
+          <Navigator />
+        </OnboardingManager>
       </SettingsProvider>
     </ApolloProvider>
   );

--- a/src/jsonValidation/appIntroValidator.ts
+++ b/src/jsonValidation/appIntroValidator.ts
@@ -1,0 +1,34 @@
+import { isArray, isObjectLike, isString } from 'lodash';
+
+import { Initializer, Initializers } from '../helpers/initializationHelper';
+import { AppIntroSlide } from '../types';
+
+type AppIntroSlideData = {
+  image: string;
+  title: string;
+  text: string;
+  onLeaveSlide?: Initializer;
+};
+
+const isValidAppIntroSlideData = (json: unknown): json is AppIntroSlideData => {
+  if (!isObjectLike(json)) {
+    return false;
+  }
+
+  const { image, title, text, onLeaveSlide } = json as AppIntroSlideData;
+
+  const isInitializer = !onLeaveSlide || Object.values(Initializer).includes(onLeaveSlide);
+
+  return isString(image) && isString(title) && isString(text) && isInitializer;
+};
+
+export const parseIntroSlides = (json: unknown): AppIntroSlide[] => {
+  if (!isArray(json)) {
+    return [];
+  }
+
+  return json.filter<AppIntroSlideData>(isValidAppIntroSlideData).map((value) => ({
+    ...value,
+    onLeaveSlide: value.onLeaveSlide ? Initializers[value.onLeaveSlide] : undefined
+  }));
+};

--- a/src/jsonValidation/appIntroValidator.ts
+++ b/src/jsonValidation/appIntroValidator.ts
@@ -17,6 +17,8 @@ const isValidAppIntroSlideData = (json: unknown): json is AppIntroSlideData => {
 
   const { image, title, text, onLeaveSlide } = json as AppIntroSlideData;
 
+  // the purpose is to filter out slides that have invalid onLeaveSlides in them.
+  // that way slides corresponding to features of newer app versions will not be shown.
   const isInitializer = !onLeaveSlide || Object.values(Initializer).includes(onLeaveSlide);
 
   return isString(image) && isString(title) && isString(text) && isInitializer;

--- a/src/jsonValidation/index.ts
+++ b/src/jsonValidation/index.ts
@@ -1,3 +1,4 @@
+export * from './appIntroValidator';
 export * from './constructionSiteValidator';
 export * from './encounter';
 export * from './geoJsonValidator';

--- a/src/navigation/Navigator.tsx
+++ b/src/navigation/Navigator.tsx
@@ -1,23 +1,42 @@
 import { DefaultTheme, NavigationContainer } from '@react-navigation/native';
-import React from 'react';
+import React, { useContext } from 'react';
+import { StatusBar } from 'react-native';
 
 import { linkingConfig, navigatorConfig } from '../config/navigation';
+import { AppIntroScreen } from '../screens';
+import { SettingsContext } from '../SettingsProvider';
 
 import { DrawerNavigator } from './DrawerNavigator';
 import { MainTabNavigator } from './MainTabNavigator';
 
-export const Navigator = () => (
-  <NavigationContainer
-    theme={{
-      dark: DefaultTheme.dark,
-      colors: { ...DefaultTheme.colors, background: '#fff' }
-    }}
-    linking={linkingConfig}
-  >
-    {navigatorConfig.type === 'drawer' ? (
-      <DrawerNavigator />
-    ) : (
-      <MainTabNavigator tabNavigatorConfig={navigatorConfig.config} />
-    )}
-  </NavigationContainer>
-);
+export const Navigator = () => {
+  const {
+    onboardingSettings: { onboardingComplete }
+  } = useContext(SettingsContext);
+
+  if (!onboardingComplete) {
+    return (
+      <>
+        <StatusBar barStyle="dark-content" translucent backgroundColor="transparent" />
+        <AppIntroScreen />
+      </>
+    );
+  }
+
+  return (
+    <NavigationContainer
+      theme={{
+        dark: DefaultTheme.dark,
+        colors: { ...DefaultTheme.colors, background: '#fff' }
+      }}
+      linking={linkingConfig}
+    >
+      <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
+      {navigatorConfig.type === 'drawer' ? (
+        <DrawerNavigator />
+      ) : (
+        <MainTabNavigator tabNavigatorConfig={navigatorConfig.config} />
+      )}
+    </NavigationContainer>
+  );
+};

--- a/src/navigation/Navigator.tsx
+++ b/src/navigation/Navigator.tsx
@@ -1,42 +1,25 @@
 import { DefaultTheme, NavigationContainer } from '@react-navigation/native';
-import React, { useContext } from 'react';
+import React from 'react';
 import { StatusBar } from 'react-native';
 
 import { linkingConfig, navigatorConfig } from '../config/navigation';
-import { AppIntroScreen } from '../screens';
-import { SettingsContext } from '../SettingsProvider';
 
 import { DrawerNavigator } from './DrawerNavigator';
 import { MainTabNavigator } from './MainTabNavigator';
 
-export const Navigator = () => {
-  const {
-    onboardingSettings: { onboardingComplete }
-  } = useContext(SettingsContext);
-
-  if (!onboardingComplete) {
-    return (
-      <>
-        <StatusBar barStyle="dark-content" translucent backgroundColor="transparent" />
-        <AppIntroScreen />
-      </>
-    );
-  }
-
-  return (
-    <NavigationContainer
-      theme={{
-        dark: DefaultTheme.dark,
-        colors: { ...DefaultTheme.colors, background: '#fff' }
-      }}
-      linking={linkingConfig}
-    >
-      <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
-      {navigatorConfig.type === 'drawer' ? (
-        <DrawerNavigator />
-      ) : (
-        <MainTabNavigator tabNavigatorConfig={navigatorConfig.config} />
-      )}
-    </NavigationContainer>
-  );
-};
+export const Navigator = () => (
+  <NavigationContainer
+    theme={{
+      dark: DefaultTheme.dark,
+      colors: { ...DefaultTheme.colors, background: '#fff' }
+    }}
+    linking={linkingConfig}
+  >
+    <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
+    {navigatorConfig.type === 'drawer' ? (
+      <DrawerNavigator />
+    ) : (
+      <MainTabNavigator tabNavigatorConfig={navigatorConfig.config} />
+    )}
+  </NavigationContainer>
+);

--- a/src/pushNotifications/PermissionHandling.ts
+++ b/src/pushNotifications/PermissionHandling.ts
@@ -41,8 +41,16 @@ export const initializePushPermissions = async () => {
 
   inAppPermission && updatePushToken();
 
-  // this will only show the alert if inAppPermission is undefined (or null), but not if it is false
-  inAppPermission ?? showInitialPushAlert();
+  // if inAppPermission is undefined (or null), set it depending on the system permission and trigger a token update
+  if (inAppPermission === undefined || inAppPermission === null) {
+    const newValue = await handleSystemPermissions();
+
+    addToStore(PushNotificationStorageKeys.IN_APP_PERMISSION, newValue);
+
+    if (newValue) {
+      updatePushToken();
+    }
+  }
 };
 
 const registerForPushNotificationsAsync = async () => {
@@ -88,27 +96,6 @@ export const showSystemPermissionMissingDialog = () => {
   const { permissionMissingBody, permissionMissingTitle } = texts.pushNotifications;
 
   Alert.alert(permissionMissingTitle, permissionMissingBody, undefined);
-};
-
-const showInitialPushAlert = () => {
-  const { greetingBody, greetingTitle, approve, decline } = texts.pushNotifications;
-
-  Alert.alert(
-    greetingTitle,
-    greetingBody,
-    [
-      {
-        text: decline,
-        onPress: () => setInAppPermission(false),
-        style: 'cancel'
-      },
-      {
-        text: approve,
-        onPress: () => setInAppPermission(true)
-      }
-    ],
-    { cancelable: false }
-  );
 };
 
 export const showPermissionRequiredAlert = (approveCallback: () => void) => {

--- a/src/screens/AppIntroScreen.tsx
+++ b/src/screens/AppIntroScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { ListRenderItem, ScrollView, StyleSheet, View } from 'react-native';
+import { ListRenderItem, ScrollView, StatusBar, StyleSheet, View } from 'react-native';
 import AppIntroSlider from 'react-native-app-intro-slider';
 
 import { BoldText, Image, RegularText, SafeAreaViewFlex, Wrapper } from '../components';
@@ -62,6 +62,7 @@ export const AppIntroScreen = ({ setOnboardingComplete }: Props) => {
 
   return (
     <SafeAreaViewFlex>
+      <StatusBar barStyle="dark-content" translucent backgroundColor="transparent" />
       <AppIntroSlider<AppIntroSlide>
         renderItem={renderSlide}
         data={slides}
@@ -106,6 +107,6 @@ const styles = StyleSheet.create({
   sliderButton: {
     borderBottomColor: colors.darkText,
     borderBottomWidth: 1,
-    marginTop: 14 // no normalization here as the dots position does not use normalization either
+    marginVertical: 12 // no normalization here as the dots position does not use normalization either
   }
 });

--- a/src/screens/AppIntroScreen.tsx
+++ b/src/screens/AppIntroScreen.tsx
@@ -3,7 +3,7 @@ import { ListRenderItem, ScrollView, StyleSheet, View } from 'react-native';
 import AppIntroSlider from 'react-native-app-intro-slider';
 
 import { BoldText, Image, RegularText, SafeAreaViewFlex, Wrapper } from '../components';
-import { colors, normalize } from '../config';
+import { colors, normalize, texts } from '../config';
 import { useStaticContent } from '../hooks';
 import { parseIntroSlides } from '../jsonValidation';
 import { AppIntroSlide } from '../types';
@@ -12,7 +12,7 @@ const keyExtractor = (slide: AppIntroSlide) => slide.title + slide.text;
 
 const SliderButton = ({ label }: { label: string }) => {
   return (
-    <View style={styles.underline}>
+    <View style={styles.sliderButton}>
       <BoldText>{label.toUpperCase()}</BoldText>
     </View>
   );
@@ -70,8 +70,8 @@ export const AppIntroScreen = ({ setOnboardingComplete }: Props) => {
           slides[index]?.onLeaveSlide?.(true);
         }}
         onDone={setOnboardingComplete}
-        renderDoneButton={() => <SliderButton label="Weiter" />}
-        renderNextButton={() => <SliderButton label="Weiter" />}
+        renderDoneButton={() => <SliderButton label={texts.appIntro.continue} />}
+        renderNextButton={() => <SliderButton label={texts.appIntro.continue} />}
         dotStyle={styles.inactiveDot}
         activeDotStyle={styles.activeDot}
         scrollEnabled={false}
@@ -102,8 +102,9 @@ const styles = StyleSheet.create({
   noPaddingBottom: {
     paddingBottom: 0
   },
-  underline: {
+  sliderButton: {
     borderBottomColor: colors.darkText,
-    borderBottomWidth: 1
+    borderBottomWidth: 1,
+    marginTop: 14 // no normalization here as the dots position does not use normalization either
   }
 });

--- a/src/screens/AppIntroScreen.tsx
+++ b/src/screens/AppIntroScreen.tsx
@@ -1,12 +1,10 @@
-import * as Location from 'expo-location';
-import React, { useContext } from 'react';
+import React from 'react';
 import { ListRenderItem, ScrollView, StyleSheet, View } from 'react-native';
 import AppIntroSlider from 'react-native-app-intro-slider';
 
 import { BoldText, Image, RegularText, SafeAreaViewFlex, Wrapper } from '../components';
 import { colors, normalize } from '../config';
-import { handleSystemPermissions } from '../pushNotifications';
-import { SettingsContext } from '../SettingsProvider';
+import { Initializer, Initializers } from '../helpers/initializationHelper';
 
 /*
  * TODO:
@@ -36,13 +34,13 @@ const slides: SlideInfo[] = [
     image: 'https://www.smurf.com/characters-smurfs/papa.png',
     title: 'Top informiert',
     text: 'Erlaube Push-Notification – Du wirst sofort benachrichtigt, wenn es Neuigkeiten gibt.',
-    onLeaveSlide: handleSystemPermissions
+    onLeaveSlide: Initializers.get(Initializer.PushNotifications)
   },
   {
     image: 'https://www.smurf.com/characters-smurfs/smurfette.png',
     title: 'Gewusst wo',
     text: 'Erlaube Ortungsdienste – bekomme Informationen genau für Deinen Umkreis.',
-    onLeaveSlide: Location.requestForegroundPermissionsAsync
+    onLeaveSlide: Initializers.get(Initializer.LocationService)
   },
   {
     image: 'https://www.smurf.com/characters-smurfs/papa.png',
@@ -59,15 +57,11 @@ const SliderButton = ({ label }: { label: string }) => {
   );
 };
 
-export const AppIntroScreen = () => {
-  // @ts-expect-error SettingsContext is not properly typed
-  const { setOnboardingSettings } = useContext(SettingsContext);
+type Props = {
+  setOnboardingComplete: () => void;
+};
 
-  const onDone = () => {
-    setOnboardingSettings({ onboardingComplete: true });
-    // TODO: add sync to AsyncStorage to avoid it form reappearing on reload/restart of the app
-  };
-
+export const AppIntroScreen = ({ setOnboardingComplete }: Props) => {
   const renderSlide: ListRenderItem<SlideInfo> = ({ item }) => {
     return (
       <ScrollView>
@@ -97,7 +91,7 @@ export const AppIntroScreen = () => {
         onSlideChange={(_, index) => {
           slides[index]?.onLeaveSlide?.();
         }}
-        onDone={onDone}
+        onDone={setOnboardingComplete}
         renderDoneButton={() => <SliderButton label="Weiter" />}
         renderNextButton={() => <SliderButton label="Weiter" />}
         dotStyle={styles.inactiveDot}

--- a/src/screens/AppIntroScreen.tsx
+++ b/src/screens/AppIntroScreen.tsx
@@ -87,7 +87,7 @@ const ACTIVE_DOT_SIZE = INACTIVE_DOT_SIZE * 2;
 const styles = StyleSheet.create({
   activeDot: {
     backgroundColor: colors.darkText,
-    borderRadius: normalize(ACTIVE_DOT_SIZE / 2),
+    borderRadius: normalize(ACTIVE_DOT_SIZE) / 2,
     height: ACTIVE_DOT_SIZE,
     width: ACTIVE_DOT_SIZE
   },
@@ -96,7 +96,7 @@ const styles = StyleSheet.create({
   },
   inactiveDot: {
     backgroundColor: colors.darkText,
-    borderRadius: normalize(INACTIVE_DOT_SIZE / 2),
+    borderRadius: normalize(INACTIVE_DOT_SIZE) / 2,
     height: INACTIVE_DOT_SIZE,
     width: INACTIVE_DOT_SIZE
   },

--- a/src/screens/AppIntroScreen.tsx
+++ b/src/screens/AppIntroScreen.tsx
@@ -34,13 +34,13 @@ const slides: SlideInfo[] = [
     image: 'https://www.smurf.com/characters-smurfs/papa.png',
     title: 'Top informiert',
     text: 'Erlaube Push-Notification – Du wirst sofort benachrichtigt, wenn es Neuigkeiten gibt.',
-    onLeaveSlide: Initializers.get(Initializer.PushNotifications)
+    onLeaveSlide: Initializers[Initializer.PushNotifications]
   },
   {
     image: 'https://www.smurf.com/characters-smurfs/smurfette.png',
     title: 'Gewusst wo',
     text: 'Erlaube Ortungsdienste – bekomme Informationen genau für Deinen Umkreis.',
-    onLeaveSlide: Initializers.get(Initializer.LocationService)
+    onLeaveSlide: Initializers[Initializer.LocationService]
   },
   {
     image: 'https://www.smurf.com/characters-smurfs/papa.png',

--- a/src/screens/AppIntroScreen.tsx
+++ b/src/screens/AppIntroScreen.tsx
@@ -1,0 +1,139 @@
+import React, { useContext } from 'react';
+import { ListRenderItem, ScrollView, StyleSheet, View } from 'react-native';
+import AppIntroSlider from 'react-native-app-intro-slider';
+
+import { BoldText, Image, RegularText, SafeAreaViewFlex, Wrapper } from '../components';
+import { colors, normalize } from '../config';
+import { SettingsContext } from '../SettingsProvider';
+
+/*
+ * TODO:
+ * extract texts
+ * only show slides that are relevant through global settings
+ * rework matomo initialization
+ * rework push initialization
+ * rework location service initialization
+ * add a "you are done with onboarding"-slide
+ */
+
+type SlideInfo = {
+  image: string;
+  title: string;
+  text: string;
+  onLeaveSlide?: () => void;
+};
+const keyExtractor = (slide: SlideInfo) => slide.title + slide.text;
+
+const slides: SlideInfo[] = [
+  {
+    image: 'https://www.smurf.com/characters-smurfs/smurfette.png',
+    title: 'Willkommen!',
+    text: 'Hier im Smart Village findest Du Nachrichten, Veranstaltungen und Services.'
+  },
+  {
+    image: 'https://www.smurf.com/characters-smurfs/papa.png',
+    title: 'Top informiert',
+    text: 'Erlaube Push-Notification – Du wirst sofort benachrichtigt, wenn es Neuigkeiten gibt.',
+    onLeaveSlide: () => {
+      console.log('push notifications');
+    }
+  },
+  {
+    image: 'https://www.smurf.com/characters-smurfs/smurfette.png',
+    title: 'Gewusst wo',
+    text: 'Erlaube Ortungsdienste – bekomme Informationen genau für Deinen Umkreis.',
+    onLeaveSlide: () => {
+      console.log('location services');
+    }
+  },
+  {
+    image: 'https://www.smurf.com/characters-smurfs/papa.png',
+    title: 'Sei dabei',
+    text: 'Erlaube Tracking – über Deine Nutzerreise erfahren wir, wo die App besser werden kann.'
+  }
+];
+
+const SliderButton = ({ label }: { label: string }) => {
+  return (
+    <View style={styles.underline}>
+      <BoldText>{label.toUpperCase()}</BoldText>
+    </View>
+  );
+};
+
+export const AppIntroScreen = () => {
+  // @ts-expect-error SettingsContext is not properly typed
+  const { setOnboardingSettings } = useContext(SettingsContext);
+
+  const onDone = () => {
+    setOnboardingSettings({ onboardingComplete: true });
+    // TODO: add sync to AsyncStorage to avoid it form reappearing on reload/restart of the app
+  };
+
+  const renderSlide: ListRenderItem<SlideInfo> = ({ item }) => {
+    return (
+      <ScrollView>
+        <Image
+          source={{ uri: item.image }}
+          containerStyle={styles.imageContainer}
+          resizeMode="contain"
+        />
+        <Wrapper style={styles.noPaddingBottom}>
+          <BoldText big center>
+            {item.title.toUpperCase()}
+          </BoldText>
+        </Wrapper>
+        <Wrapper>
+          <RegularText center>{item.text}</RegularText>
+        </Wrapper>
+      </ScrollView>
+    );
+  };
+
+  return (
+    <SafeAreaViewFlex>
+      <AppIntroSlider<SlideInfo>
+        renderItem={renderSlide}
+        data={slides}
+        keyExtractor={keyExtractor}
+        onSlideChange={(_, index) => {
+          slides[index]?.onLeaveSlide?.();
+        }}
+        onDone={onDone}
+        renderDoneButton={() => <SliderButton label="Weiter" />}
+        renderNextButton={() => <SliderButton label="Weiter" />}
+        dotStyle={styles.inactiveDot}
+        activeDotStyle={styles.activeDot}
+        scrollEnabled={false}
+      />
+    </SafeAreaViewFlex>
+  );
+};
+
+const INACTIVE_DOT_SIZE = normalize(4);
+const ACTIVE_DOT_SIZE = INACTIVE_DOT_SIZE * 2;
+
+const styles = StyleSheet.create({
+  activeDot: {
+    backgroundColor: colors.darkText,
+    borderRadius: normalize(ACTIVE_DOT_SIZE / 2),
+    height: ACTIVE_DOT_SIZE,
+    width: ACTIVE_DOT_SIZE
+  },
+  imageContainer: {
+    width: '100%'
+  },
+  inactiveDot: {
+    backgroundColor: colors.darkText,
+    borderRadius: normalize(INACTIVE_DOT_SIZE / 2),
+    height: INACTIVE_DOT_SIZE,
+    width: INACTIVE_DOT_SIZE
+  },
+  noPaddingBottom: {
+    paddingBottom: 0
+  },
+  underline: {
+    borderBottomColor: colors.darkText,
+    borderBottomWidth: 1
+  }
+});

--- a/src/screens/AppIntroScreen.tsx
+++ b/src/screens/AppIntroScreen.tsx
@@ -1,3 +1,4 @@
+import * as Location from 'expo-location';
 import React, { useContext } from 'react';
 import { ListRenderItem, ScrollView, StyleSheet, View } from 'react-native';
 import AppIntroSlider from 'react-native-app-intro-slider';
@@ -41,9 +42,7 @@ const slides: SlideInfo[] = [
     image: 'https://www.smurf.com/characters-smurfs/smurfette.png',
     title: 'Gewusst wo',
     text: 'Erlaube Ortungsdienste – bekomme Informationen genau für Deinen Umkreis.',
-    onLeaveSlide: () => {
-      console.log('location services');
-    }
+    onLeaveSlide: Location.requestForegroundPermissionsAsync
   },
   {
     image: 'https://www.smurf.com/characters-smurfs/papa.png',

--- a/src/screens/AppIntroScreen.tsx
+++ b/src/screens/AppIntroScreen.tsx
@@ -4,6 +4,7 @@ import AppIntroSlider from 'react-native-app-intro-slider';
 
 import { BoldText, Image, RegularText, SafeAreaViewFlex, Wrapper } from '../components';
 import { colors, normalize } from '../config';
+import { handleSystemPermissions } from '../pushNotifications';
 import { SettingsContext } from '../SettingsProvider';
 
 /*
@@ -34,9 +35,7 @@ const slides: SlideInfo[] = [
     image: 'https://www.smurf.com/characters-smurfs/papa.png',
     title: 'Top informiert',
     text: 'Erlaube Push-Notification – Du wirst sofort benachrichtigt, wenn es Neuigkeiten gibt.',
-    onLeaveSlide: () => {
-      console.log('push notifications');
-    }
+    onLeaveSlide: handleSystemPermissions
   },
   {
     image: 'https://www.smurf.com/characters-smurfs/smurfette.png',

--- a/src/screens/AppIntroScreen.tsx
+++ b/src/screens/AppIntroScreen.tsx
@@ -1,59 +1,14 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { ListRenderItem, ScrollView, StyleSheet, View } from 'react-native';
 import AppIntroSlider from 'react-native-app-intro-slider';
 
 import { BoldText, Image, RegularText, SafeAreaViewFlex, Wrapper } from '../components';
 import { colors, normalize } from '../config';
-import { Initializer, Initializers } from '../helpers/initializationHelper';
+import { useStaticContent } from '../hooks';
+import { parseIntroSlides } from '../jsonValidation';
+import { AppIntroSlide } from '../types';
 
-/*
- * TODO:
- * extract texts
- * only show slides that are relevant through global settings
- * rework matomo initialization
- * rework push initialization
- * rework location service initialization
- * add a "you are done with onboarding"-slide
- */
-
-type SlideInfo = {
-  image: string;
-  title: string;
-  text: string;
-  onLeaveSlide?: () => void;
-};
-const keyExtractor = (slide: SlideInfo) => slide.title + slide.text;
-
-const slides: SlideInfo[] = [
-  {
-    image: 'https://www.smurf.com/characters-smurfs/smurfette.png',
-    title: 'Willkommen!',
-    text: 'Hier im Smart Village findest Du Nachrichten, Veranstaltungen und Services.'
-  },
-  {
-    image: 'https://www.smurf.com/characters-smurfs/papa.png',
-    title: 'Top informiert',
-    text: 'Erlaube Push-Notification – Du wirst sofort benachrichtigt, wenn es Neuigkeiten gibt.',
-    onLeaveSlide: Initializers[Initializer.PushNotifications]
-  },
-  {
-    image: 'https://www.smurf.com/characters-smurfs/smurfette.png',
-    title: 'Gewusst wo',
-    text: 'Erlaube Ortungsdienste – bekomme Informationen genau für Deinen Umkreis.',
-    onLeaveSlide: Initializers[Initializer.LocationService]
-  },
-  {
-    image: 'https://www.smurf.com/characters-smurfs/papa.png',
-    title: 'Sei dabei',
-    text: 'Erlaube Tracking – über Deine Nutzerreise erfahren wir, wo die App besser werden kann.',
-    onLeaveSlide: Initializers[Initializer.MatomoTracking]
-  },
-  {
-    image: 'https://www.smurf.com/characters-smurfs/smurfette.png',
-    title: 'All Done!',
-    text: 'Das wars auch schon!'
-  }
-];
+const keyExtractor = (slide: AppIntroSlide) => slide.title + slide.text;
 
 const SliderButton = ({ label }: { label: string }) => {
   return (
@@ -67,35 +22,52 @@ type Props = {
   setOnboardingComplete: () => void;
 };
 
+const renderSlide: ListRenderItem<AppIntroSlide> = ({ item }) => {
+  return (
+    <ScrollView>
+      <Image
+        source={{ uri: item.image }}
+        containerStyle={styles.imageContainer}
+        resizeMode="contain"
+      />
+      <Wrapper style={styles.noPaddingBottom}>
+        <BoldText big center>
+          {item.title.toUpperCase()}
+        </BoldText>
+      </Wrapper>
+      <Wrapper>
+        <RegularText center>{item.text}</RegularText>
+      </Wrapper>
+    </ScrollView>
+  );
+};
+
 export const AppIntroScreen = ({ setOnboardingComplete }: Props) => {
-  const renderSlide: ListRenderItem<SlideInfo> = ({ item }) => {
-    return (
-      <ScrollView>
-        <Image
-          source={{ uri: item.image }}
-          containerStyle={styles.imageContainer}
-          resizeMode="contain"
-        />
-        <Wrapper style={styles.noPaddingBottom}>
-          <BoldText big center>
-            {item.title.toUpperCase()}
-          </BoldText>
-        </Wrapper>
-        <Wrapper>
-          <RegularText center>{item.text}</RegularText>
-        </Wrapper>
-      </ScrollView>
-    );
-  };
+  const { data: slides, error, loading } = useStaticContent({
+    name: 'appIntroSlides',
+    type: 'json',
+    parseFromJson: parseIntroSlides,
+    fetchPolicy: 'network-only'
+  });
+
+  useEffect(() => {
+    if (error || (!loading && !slides?.length)) {
+      setOnboardingComplete();
+    }
+  }, [error, loading, slides?.length]);
+
+  if (error || loading || !slides?.length) {
+    return null;
+  }
 
   return (
     <SafeAreaViewFlex>
-      <AppIntroSlider<SlideInfo>
+      <AppIntroSlider<AppIntroSlide>
         renderItem={renderSlide}
         data={slides}
         keyExtractor={keyExtractor}
         onSlideChange={(_, index) => {
-          slides[index]?.onLeaveSlide?.();
+          slides[index]?.onLeaveSlide?.(true);
         }}
         onDone={setOnboardingComplete}
         renderDoneButton={() => <SliderButton label="Weiter" />}

--- a/src/screens/AppIntroScreen.tsx
+++ b/src/screens/AppIntroScreen.tsx
@@ -74,6 +74,7 @@ export const AppIntroScreen = ({ setOnboardingComplete }: Props) => {
         renderNextButton={() => <SliderButton label={texts.appIntro.continue} />}
         dotStyle={styles.inactiveDot}
         activeDotStyle={styles.activeDot}
+        dotClickEnabled={false}
         scrollEnabled={false}
       />
     </SafeAreaViewFlex>

--- a/src/screens/AppIntroScreen.tsx
+++ b/src/screens/AppIntroScreen.tsx
@@ -45,7 +45,13 @@ const slides: SlideInfo[] = [
   {
     image: 'https://www.smurf.com/characters-smurfs/papa.png',
     title: 'Sei dabei',
-    text: 'Erlaube Tracking – über Deine Nutzerreise erfahren wir, wo die App besser werden kann.'
+    text: 'Erlaube Tracking – über Deine Nutzerreise erfahren wir, wo die App besser werden kann.',
+    onLeaveSlide: Initializers[Initializer.MatomoTracking]
+  },
+  {
+    image: 'https://www.smurf.com/characters-smurfs/smurfette.png',
+    title: 'All Done!',
+    text: 'Das wars auch schon!'
   }
 ];
 

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -14,7 +14,7 @@ import {
 } from '../components';
 import { colors, consts, texts } from '../config';
 import { graphqlFetchPolicy, rootRouteName } from '../helpers';
-import { useMatomoAlertOnStartUp, useMatomoTrackScreenView, usePushNotifications } from '../hooks';
+import { useMatomoTrackScreenView, usePushNotifications } from '../hooks';
 import { HOME_REFRESH_EVENT } from '../hooks/HomeRefresh';
 import { NetworkContext } from '../NetworkProvider';
 import { getQueryType, QUERY_TYPES } from '../queries';
@@ -74,7 +74,6 @@ export const HomeScreen = ({ navigation, route }) => {
     undefined,
     globalSettings?.settings?.pushNotifications
   );
-  useMatomoAlertOnStartUp();
   useMatomoTrackScreenView(MATOMO_TRACKING.SCREEN_VIEW.HOME);
 
   useEffect(() => {

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -14,7 +14,7 @@ import {
 } from '../components';
 import { colors, consts, texts } from '../config';
 import { graphqlFetchPolicy, rootRouteName } from '../helpers';
-import { useMatomoTrackScreenView, usePushNotifications, useTrackAppStart } from '../hooks';
+import { useMatomoTrackScreenView, usePushNotifications } from '../hooks';
 import { HOME_REFRESH_EVENT } from '../hooks/HomeRefresh';
 import { NetworkContext } from '../NetworkProvider';
 import { getQueryType, QUERY_TYPES } from '../queries';
@@ -75,7 +75,6 @@ export const HomeScreen = ({ navigation, route }) => {
     globalSettings?.settings?.pushNotifications
   );
 
-  useTrackAppStart();
   useMatomoTrackScreenView(MATOMO_TRACKING.SCREEN_VIEW.HOME);
 
   useEffect(() => {

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -14,7 +14,7 @@ import {
 } from '../components';
 import { colors, consts, texts } from '../config';
 import { graphqlFetchPolicy, rootRouteName } from '../helpers';
-import { useMatomoTrackScreenView, usePushNotifications } from '../hooks';
+import { useMatomoTrackScreenView, usePushNotifications, useTrackAppStart } from '../hooks';
 import { HOME_REFRESH_EVENT } from '../hooks/HomeRefresh';
 import { NetworkContext } from '../NetworkProvider';
 import { getQueryType, QUERY_TYPES } from '../queries';
@@ -74,6 +74,8 @@ export const HomeScreen = ({ navigation, route }) => {
     undefined,
     globalSettings?.settings?.pushNotifications
   );
+
+  useTrackAppStart();
   useMatomoTrackScreenView(MATOMO_TRACKING.SCREEN_VIEW.HOME);
 
   useEffect(() => {

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -2,8 +2,6 @@ import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
 import { ActivityIndicator, Alert, SectionList, View } from 'react-native';
 
-import { SettingsContext } from '../SettingsProvider';
-import { colors, consts, device, texts } from '../config';
 import {
   LoadingContainer,
   RegularText,
@@ -14,11 +12,13 @@ import {
   TitleShadow,
   Wrapper
 } from '../components';
-import { PushNotificationStorageKeys, setInAppPermission } from '../pushNotifications';
-import { createMatomoUserId, readFromStore, removeMatomoUserId, storageHelper } from '../helpers';
-import { useMatomoTrackScreenView } from '../hooks';
 import { IndexFilterWrapperAndList } from '../components/BB-BUS/IndexFilterWrapperAndList';
 import { ListSettings, LocationSettings } from '../components/settings';
+import { colors, consts, device, texts } from '../config';
+import { createMatomoUserId, matomoSettings, readFromStore, removeMatomoUserId } from '../helpers';
+import { useMatomoTrackScreenView } from '../hooks';
+import { PushNotificationStorageKeys, setInAppPermission } from '../pushNotifications';
+import { SettingsContext } from '../SettingsProvider';
 
 const { MATOMO_TRACKING } = consts;
 
@@ -95,7 +95,7 @@ export const SettingsScreen = () => {
 
       // settings should sometimes contain matomo analytics next, depending on server settings
       if (settings.matomo) {
-        const { consent: matomoValue = false } = await storageHelper.matomoSettings();
+        const { consent: matomoValue } = await matomoSettings();
 
         additionalSectionedData.push({
           data: [

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -1,3 +1,4 @@
+export * from './AppIntroScreen';
 export * from './AboutScreen';
 export * from './BookmarkCategoryScreen';
 export * from './BookmarkScreen';

--- a/src/types/AppIntroSlide.ts
+++ b/src/types/AppIntroSlide.ts
@@ -1,0 +1,6 @@
+export type AppIntroSlide = {
+  image: string;
+  title: string;
+  text: string;
+  onLeaveSlide?: (fromAppIntro?: boolean) => void;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export * from './encounter';
 
 export * from './Address';
+export * from './AppIntroSlide';
 export * from './Camera';
 export * from './ConstructionSite';
 export * from './Contact';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10200,6 +10200,11 @@ react-leaflet@^2.6.1:
     hoist-non-react-statics "^3.3.2"
     warning "^4.0.3"
 
+react-native-app-intro-slider@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/react-native-app-intro-slider/-/react-native-app-intro-slider-4.0.4.tgz#fa5cda7057db62c448ac975ffd2ba0cff94cc8d8"
+  integrity sha512-Zkjaol6X3BbZkHUpVDj2LjdidpS6rCgKi0fx80xgGKa0pHxBRd4swWTv2bHnnvu5k1/HXwYk0mY2TbK+2jHl5w==
+
 react-native-autocomplete-input@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/react-native-autocomplete-input/-/react-native-autocomplete-input-4.2.0.tgz#fcfc3d2f19134d4c3394a4e6a5aae13d8c4c9129"


### PR DESCRIPTION
- added new app intro feature
- this app intro will be displayed at app start until completed once
- it can handle the required permission alerts in a more structured way

- the splashscreen and orientation lock handling was moved to the new `OnboardingManager` component
- the handling of system and matomo permissions are now being handled by the new `OnboardingManager` (and if an app intro is configured through that as well)


---

SVA-305

---

## How to test:

- for testing multiple scenarios it is best to not save that the intro was completed at first by commenting out line 58 of the `OnboardingManager`
- by manipulating the conditions in lines 66 and 80 different situations can be simulated