### PR TITLE
Survey: hide comment section when disabled

### DIFF
--- a/src/queries/survey.js
+++ b/src/queries/survey.js
@@ -4,6 +4,7 @@ export const DETAILED_SURVEY = gql`
   query Surveys($id: ID!) {
     surveys(ids: [$id]) {
       id
+      canComment
       title
       questionTitle
       questionAllowMultipleResponses

--- a/src/screens/SurveyDetailScreen.tsx
+++ b/src/screens/SurveyDetailScreen.tsx
@@ -187,13 +187,15 @@ export const SurveyDetailScreen = ({ route }: Props) => {
               />
             )}
           </WrapperWithOrientation>
-          <CommentSection
-            archived={archived}
-            comments={survey.comments}
-            isMultilingual={survey.isMultilingual}
-            scrollViewRef={scrollViewRef}
-            surveyId={surveyId}
-          />
+          {!!survey.canComment && (
+            <CommentSection
+              archived={archived}
+              comments={survey.comments}
+              isMultilingual={survey.isMultilingual}
+              scrollViewRef={scrollViewRef}
+              surveyId={surveyId}
+            />
+          )}
         </ScrollView>
       </DefaultKeyboardAvoidingView>
     </SafeAreaViewFlex>

--- a/src/types/Survey.ts
+++ b/src/types/Survey.ts
@@ -21,4 +21,5 @@ export type Survey = {
     createdAt: string;
     message: string;
   }>;
+  canComment?: boolean;
 };


### PR DESCRIPTION
- updated `Survey` type to include `canComment` flag
- hide `CommentSection` if `canComment` flag is not equal to `true`

- [x] update query

---

SVA-363
