### PR TITLE
Survey: multilanguage optional

### DIFF
--- a/src/components/CommentSection.tsx
+++ b/src/components/CommentSection.tsx
@@ -7,6 +7,7 @@ import { normalize } from 'react-native-elements';
 
 import { colors, device, texts } from '../config';
 import { momentFormat } from '../helpers';
+import { useSurveyLanguages } from '../hooks';
 import { COMMENT_ON_SURVEY } from '../queries/survey';
 import { Survey } from '../types';
 
@@ -17,16 +18,25 @@ import { Wrapper, WrapperWithOrientation } from './Wrapper';
 type Props = {
   archived?: boolean;
   comments: Survey['comments'];
+  isMultiLanguage?: boolean;
   scrollViewRef: RefObject<ScrollView>;
   surveyId: string;
 };
 
 const MAX_COMMENT_LENGTH = 5000;
 
-export const CommentSection = ({ archived, comments, scrollViewRef, surveyId }: Props) => {
+export const CommentSection = ({
+  archived,
+  comments,
+  isMultiLanguage,
+  scrollViewRef,
+  surveyId
+}: Props) => {
   const refForPosition = useRef<View>(null);
   const [sendComment] = useMutation(COMMENT_ON_SURVEY);
   const [newComment, setNewComment] = useState('');
+
+  const languages = useSurveyLanguages(isMultiLanguage);
 
   const submitComment = useCallback(() => {
     Keyboard.dismiss();
@@ -36,7 +46,7 @@ export const CommentSection = ({ archived, comments, scrollViewRef, surveyId }: 
       setNewComment('');
       Alert.alert(
         texts.survey.commentSubmissionAlertTitle,
-        texts.survey.commentSubmissionAlert.de + '\n\n' + texts.survey.commentSubmissionAlert.pl
+        languages.map((lang) => texts.survey.commentSubmissionAlert[lang]).join('\n\n')
       );
     }
   }, [newComment, sendComment, surveyId]);
@@ -51,16 +61,18 @@ export const CommentSection = ({ archived, comments, scrollViewRef, surveyId }: 
     });
   };
 
-  const buttonTitle = texts.survey.submitComment.de + '\n' + texts.survey.submitComment.pl;
+  const buttonTitle = languages.map((lang) => texts.survey.submitComment[lang]).join('\n');
 
   return (
     <WrapperWithOrientation>
       {(!archived || comments.length > 0) && (
         <Wrapper ref={refForPosition}>
           <RegularText big>{texts.survey.comments.de}</RegularText>
-          <RegularText big italic>
-            {texts.survey.comments.pl}
-          </RegularText>
+          {!!isMultiLanguage && (
+            <RegularText big italic>
+              {texts.survey.comments.pl}
+            </RegularText>
+          )}
         </Wrapper>
       )}
       {!archived && (

--- a/src/components/CommentSection.tsx
+++ b/src/components/CommentSection.tsx
@@ -18,7 +18,7 @@ import { Wrapper, WrapperWithOrientation } from './Wrapper';
 type Props = {
   archived?: boolean;
   comments: Survey['comments'];
-  isMultiLanguage?: boolean;
+  isMultilingual?: boolean;
   scrollViewRef: RefObject<ScrollView>;
   surveyId: string;
 };
@@ -28,7 +28,7 @@ const MAX_COMMENT_LENGTH = 5000;
 export const CommentSection = ({
   archived,
   comments,
-  isMultiLanguage,
+  isMultilingual,
   scrollViewRef,
   surveyId
 }: Props) => {
@@ -36,7 +36,7 @@ export const CommentSection = ({
   const [sendComment] = useMutation(COMMENT_ON_SURVEY);
   const [newComment, setNewComment] = useState('');
 
-  const languages = useSurveyLanguages(isMultiLanguage);
+  const languages = useSurveyLanguages(isMultilingual);
 
   const submitComment = useCallback(() => {
     Keyboard.dismiss();
@@ -68,7 +68,7 @@ export const CommentSection = ({
       {(!archived || comments.length > 0) && (
         <Wrapper ref={refForPosition}>
           <RegularText big>{texts.survey.comments.de}</RegularText>
-          {!!isMultiLanguage && (
+          {!!isMultilingual && (
             <RegularText big italic>
               {texts.survey.comments.pl}
             </RegularText>

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -10,8 +10,13 @@ import { SectionHeader } from './SectionHeader';
 import { BoldText } from './Text';
 import { Wrapper, WrapperHorizontal, WrapperRow } from './Wrapper';
 
-type Props = { responseOptions: ResponseOption[]; selectedOption?: string };
+type Props = {
+  isMultiLanguage?: boolean;
+  responseOptions: ResponseOption[];
+  selectedOption?: string;
+};
 type SingleProps = {
+  isMultiLanguage?: boolean;
   option: ResponseOption & { index: number };
   selected: boolean;
   totalCount: number;
@@ -28,14 +33,14 @@ const getCountLabel = (partial: number, total: number) => {
   return `${partial} / ${getPercent(partial, total)}`;
 };
 
-const SingleResult = ({ option, selected, totalCount }: SingleProps) => {
+const SingleResult = ({ isMultiLanguage, option, selected, totalCount }: SingleProps) => {
   const percentString = getPercent(option.votesCount, totalCount);
   const width = percentString === '0%' ? barBorderRadius * 2 : percentString;
   return (
     <WrapperRow spaceBetween style={styles.container}>
       <View style={styles.labelContainer}>
         <BoldText small>{getAnswerLabel('de', option.index)}</BoldText>
-        <BoldText small>{getAnswerLabel('pl', option.index)}</BoldText>
+        {!!isMultiLanguage && <BoldText small>{getAnswerLabel('pl', option.index)}</BoldText>}
       </View>
       <WrapperHorizontal style={styles.barContainer}>
         <View
@@ -49,15 +54,15 @@ const SingleResult = ({ option, selected, totalCount }: SingleProps) => {
           ]}
         />
       </WrapperHorizontal>
-      <View style={styles.countContainer}>
+      <View style={[styles.countContainer, { top: isMultiLanguage ? normalize(7) : normalize(3) }]}>
         <BoldText>{getCountLabel(option.votesCount, totalCount)}</BoldText>
       </View>
     </WrapperRow>
   );
 };
 
-export const Results = ({ responseOptions, selectedOption }: Props) => {
-  const languages = useSurveyLanguages();
+export const Results = ({ isMultiLanguage, responseOptions, selectedOption }: Props) => {
+  const languages = useSurveyLanguages(isMultiLanguage);
   const sortedOptions = responseOptions
     .map((option, index) => ({ ...option, index }))
     // deepcode ignore NoZeroReturnedInSort: The callback provided to sort does return 0 implicitly if the compared values are equal.
@@ -77,6 +82,7 @@ export const Results = ({ responseOptions, selectedOption }: Props) => {
         {sortedOptions.map((option) => (
           <SingleResult
             key={option.id}
+            isMultiLanguage={isMultiLanguage}
             option={option}
             selected={selectedOption === option.id}
             totalCount={totalCount}
@@ -104,10 +110,10 @@ const styles = StyleSheet.create({
   },
   countContainer: {
     position: 'absolute',
-    right: 0,
-    top: normalize(7)
+    right: 0
   },
   labelContainer: {
+    justifyContent: 'center',
     width: 100 // this fixes the width of the left labels, so that all bars start at a common line
   },
   noHorizontalPadding: {

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -11,12 +11,12 @@ import { BoldText } from './Text';
 import { Wrapper, WrapperHorizontal, WrapperRow } from './Wrapper';
 
 type Props = {
-  isMultiLanguage?: boolean;
+  isMultilingual?: boolean;
   responseOptions: ResponseOption[];
   selectedOption?: string;
 };
 type SingleProps = {
-  isMultiLanguage?: boolean;
+  isMultilingual?: boolean;
   option: ResponseOption & { index: number };
   selected: boolean;
   totalCount: number;
@@ -33,14 +33,14 @@ const getCountLabel = (partial: number, total: number) => {
   return `${partial} / ${getPercent(partial, total)}`;
 };
 
-const SingleResult = ({ isMultiLanguage, option, selected, totalCount }: SingleProps) => {
+const SingleResult = ({ isMultilingual, option, selected, totalCount }: SingleProps) => {
   const percentString = getPercent(option.votesCount, totalCount);
   const width = percentString === '0%' ? barBorderRadius * 2 : percentString;
   return (
     <WrapperRow spaceBetween style={styles.container}>
       <View style={styles.labelContainer}>
         <BoldText small>{getAnswerLabel('de', option.index)}</BoldText>
-        {!!isMultiLanguage && <BoldText small>{getAnswerLabel('pl', option.index)}</BoldText>}
+        {!!isMultilingual && <BoldText small>{getAnswerLabel('pl', option.index)}</BoldText>}
       </View>
       <WrapperHorizontal style={styles.barContainer}>
         <View
@@ -54,15 +54,15 @@ const SingleResult = ({ isMultiLanguage, option, selected, totalCount }: SingleP
           ]}
         />
       </WrapperHorizontal>
-      <View style={[styles.countContainer, { top: isMultiLanguage ? normalize(7) : normalize(3) }]}>
+      <View style={[styles.countContainer, { top: isMultilingual ? normalize(7) : normalize(3) }]}>
         <BoldText>{getCountLabel(option.votesCount, totalCount)}</BoldText>
       </View>
     </WrapperRow>
   );
 };
 
-export const Results = ({ isMultiLanguage, responseOptions, selectedOption }: Props) => {
-  const languages = useSurveyLanguages(isMultiLanguage);
+export const Results = ({ isMultilingual, responseOptions, selectedOption }: Props) => {
+  const languages = useSurveyLanguages(isMultilingual);
   const sortedOptions = responseOptions
     .map((option, index) => ({ ...option, index }))
     // deepcode ignore NoZeroReturnedInSort: The callback provided to sort does return 0 implicitly if the compared values are equal.
@@ -82,7 +82,7 @@ export const Results = ({ isMultiLanguage, responseOptions, selectedOption }: Pr
         {sortedOptions.map((option) => (
           <SingleResult
             key={option.id}
-            isMultiLanguage={isMultiLanguage}
+            isMultilingual={isMultilingual}
             option={option}
             selected={selectedOption === option.id}
             totalCount={totalCount}

--- a/src/components/SurveyAnswer.tsx
+++ b/src/components/SurveyAnswer.tsx
@@ -15,6 +15,7 @@ type Props = {
   archived?: boolean;
   faded: boolean;
   index: number;
+  isMultiLanguage?: boolean;
   responseOption: ResponseOption;
   selected: boolean;
   setSelection: (id: string) => void;
@@ -24,11 +25,12 @@ export const SurveyAnswer = ({
   archived,
   faded,
   index,
+  isMultiLanguage,
   responseOption,
   selected,
   setSelection
 }: Props) => {
-  const languages = useSurveyLanguages();
+  const languages = useSurveyLanguages(isMultiLanguage);
 
   const { id } = responseOption;
   const onPress = useCallback(() => setSelection(id), [id, setSelection]);
@@ -46,7 +48,7 @@ export const SurveyAnswer = ({
             <Wrapper style={styles.answerContainer}>
               <BoldText>{getAnswerLabel('de', index)}</BoldText>
               <RegularText>{responseOption.title[languages[0]]}</RegularText>
-              {!!responseOption.title[languages[1]] && (
+              {!!isMultiLanguage && !!responseOption.title[languages[1]] && (
                 <>
                   <BoldText italic>{getAnswerLabel('pl', index)}</BoldText>
                   <RegularText italic>{responseOption.title[languages[1]]}</RegularText>

--- a/src/components/SurveyAnswer.tsx
+++ b/src/components/SurveyAnswer.tsx
@@ -15,7 +15,7 @@ type Props = {
   archived?: boolean;
   faded: boolean;
   index: number;
-  isMultiLanguage?: boolean;
+  isMultilingual?: boolean;
   responseOption: ResponseOption;
   selected: boolean;
   setSelection: (id: string) => void;
@@ -25,12 +25,12 @@ export const SurveyAnswer = ({
   archived,
   faded,
   index,
-  isMultiLanguage,
+  isMultilingual,
   responseOption,
   selected,
   setSelection
 }: Props) => {
-  const languages = useSurveyLanguages(isMultiLanguage);
+  const languages = useSurveyLanguages(isMultilingual);
 
   const { id } = responseOption;
   const onPress = useCallback(() => setSelection(id), [id, setSelection]);
@@ -48,7 +48,7 @@ export const SurveyAnswer = ({
             <Wrapper style={styles.answerContainer}>
               <BoldText>{getAnswerLabel('de', index)}</BoldText>
               <RegularText>{responseOption.title[languages[0]]}</RegularText>
-              {!!isMultiLanguage && !!responseOption.title[languages[1]] && (
+              {!!isMultilingual && !!responseOption.title[languages[1]] && (
                 <>
                   <BoldText italic>{getAnswerLabel('pl', index)}</BoldText>
                   <RegularText italic>{responseOption.title[languages[1]]}</RegularText>

--- a/src/hooks/surveyHooks.ts
+++ b/src/hooks/surveyHooks.ts
@@ -7,8 +7,8 @@ import { addToStore, readFromStore } from '../helpers';
 import { SUBMIT_SURVEY_RESPONSE } from '../queries/survey';
 
 // TODO: implement properly
-export const useSurveyLanguages = (isMultiLanguage?: boolean) =>
-  (isMultiLanguage ? ['de', 'pl'] : ['de']) as ('de' | 'pl')[];
+export const useSurveyLanguages = (isMultilingual?: boolean) =>
+  (isMultilingual ? ['de', 'pl'] : ['de']) as ('de' | 'pl')[];
 
 const SURVEY_ANSWERS_STORAGE_PREFIX = 'SVA_SURVEY_ANSWERS_';
 

--- a/src/hooks/surveyHooks.ts
+++ b/src/hooks/surveyHooks.ts
@@ -7,7 +7,8 @@ import { addToStore, readFromStore } from '../helpers';
 import { SUBMIT_SURVEY_RESPONSE } from '../queries/survey';
 
 // TODO: implement properly
-export const useSurveyLanguages = () => ['de', 'pl'];
+export const useSurveyLanguages = (isMultiLanguage?: boolean) =>
+  (isMultiLanguage ? ['de', 'pl'] : ['de']) as ('de' | 'pl')[];
 
 const SURVEY_ANSWERS_STORAGE_PREFIX = 'SVA_SURVEY_ANSWERS_';
 

--- a/src/queries/survey.js
+++ b/src/queries/survey.js
@@ -22,6 +22,7 @@ export const DETAILED_SURVEY = gql`
         createdAt
         message
       }
+      isMultilingual
     }
   }
 `;

--- a/src/screens/SurveyDetailScreen.tsx
+++ b/src/screens/SurveyDetailScreen.tsx
@@ -30,11 +30,11 @@ type Props = {
 const DateComponent = ({
   start,
   date,
-  isMultiLanguage
+  isMultilingual
 }: {
   start?: boolean;
   date: string;
-  isMultiLanguage?: boolean;
+  isMultilingual?: boolean;
 }) => {
   return (
     <Wrapper style={styles.noPaddingBottom}>
@@ -43,7 +43,7 @@ const DateComponent = ({
           <RegularText small>
             {start ? texts.survey.dateStart.de : texts.survey.dateEnd.de}
           </RegularText>
-          {!!isMultiLanguage && (
+          {!!isMultilingual && (
             <RegularText italic small>
               {start ? texts.survey.dateStart.pl : texts.survey.dateEnd.pl}
             </RegularText>
@@ -71,7 +71,7 @@ export const SurveyDetailScreen = ({ route }: Props) => {
   const archived = route.params?.archived;
   const surveyId = route.params?.id;
   const { refetch, survey } = useSurvey(surveyId);
-  const languages = useSurveyLanguages(survey?.isMultiLanguage);
+  const languages = useSurveyLanguages(survey?.isMultilingual);
   const { previousSubmission, selection, setSelection, submitSelection } = useAnswerSelection(
     surveyId,
     refetch
@@ -123,7 +123,7 @@ export const SurveyDetailScreen = ({ route }: Props) => {
                 archived={archived}
                 faded={!!selection && selection !== responseOption.id}
                 index={index}
-                isMultiLanguage={survey.isMultiLanguage}
+                isMultilingual={survey.isMultilingual}
                 responseOption={responseOption}
                 selected={selection === responseOption.id}
                 setSelection={setSelection}
@@ -146,7 +146,7 @@ export const SurveyDetailScreen = ({ route }: Props) => {
                     <RegularText error small>
                       {texts.survey.hint.de}
                     </RegularText>
-                    {!!survey?.isMultiLanguage && (
+                    {!!survey?.isMultilingual && (
                       <RegularText error italic small>
                         {texts.survey.hint.pl}
                       </RegularText>
@@ -157,7 +157,7 @@ export const SurveyDetailScreen = ({ route }: Props) => {
             )}
             {(previousSubmission || archived) && (
               <Results
-                isMultiLanguage={survey.isMultiLanguage}
+                isMultilingual={survey.isMultilingual}
                 responseOptions={survey.responseOptions}
                 selectedOption={previousSubmission}
               />
@@ -166,7 +166,7 @@ export const SurveyDetailScreen = ({ route }: Props) => {
           <CommentSection
             archived={archived}
             comments={survey.comments}
-            isMultiLanguage={survey.isMultiLanguage}
+            isMultilingual={survey.isMultilingual}
             scrollViewRef={scrollViewRef}
             surveyId={surveyId}
           />

--- a/src/screens/SurveyDetailScreen.tsx
+++ b/src/screens/SurveyDetailScreen.tsx
@@ -27,7 +27,15 @@ type Props = {
   route: RouteProp<any, any>;
 };
 
-const DateComponent = ({ start, date }: { start?: boolean; date: string }) => {
+const DateComponent = ({
+  start,
+  date,
+  isMultiLanguage
+}: {
+  start?: boolean;
+  date: string;
+  isMultiLanguage?: boolean;
+}) => {
   return (
     <Wrapper style={styles.noPaddingBottom}>
       <WrapperRow center spaceBetween>
@@ -35,9 +43,11 @@ const DateComponent = ({ start, date }: { start?: boolean; date: string }) => {
           <RegularText small>
             {start ? texts.survey.dateStart.de : texts.survey.dateEnd.de}
           </RegularText>
-          <RegularText italic small>
-            {start ? texts.survey.dateStart.pl : texts.survey.dateEnd.pl}
-          </RegularText>
+          {!!isMultiLanguage && (
+            <RegularText italic small>
+              {start ? texts.survey.dateStart.pl : texts.survey.dateEnd.pl}
+            </RegularText>
+          )}
         </View>
         <RegularText>{momentFormat(date)}</RegularText>
       </WrapperRow>
@@ -61,7 +71,7 @@ export const SurveyDetailScreen = ({ route }: Props) => {
   const archived = route.params?.archived;
   const surveyId = route.params?.id;
   const { refetch, survey } = useSurvey(surveyId);
-  const languages = useSurveyLanguages();
+  const languages = useSurveyLanguages(survey?.isMultiLanguage);
   const { previousSubmission, selection, setSelection, submitSelection } = useAnswerSelection(
     surveyId,
     refetch
@@ -79,8 +89,8 @@ export const SurveyDetailScreen = ({ route }: Props) => {
   const shownTitle = title?.length ? title : questionTitle;
 
   const buttonText = previousSubmission
-    ? texts.survey.changeAnswer.de + '\n' + texts.survey.changeAnswer.pl
-    : texts.survey.submitAnswer.de + '\n' + texts.survey.submitAnswer.pl;
+    ? languages.map((lang) => texts.survey.changeAnswer[lang]).join('\n')
+    : languages.map((lang) => texts.survey.submitAnswer[lang]).join('\n');
 
   return (
     <SafeAreaViewFlex>
@@ -113,6 +123,7 @@ export const SurveyDetailScreen = ({ route }: Props) => {
                 archived={archived}
                 faded={!!selection && selection !== responseOption.id}
                 index={index}
+                isMultiLanguage={survey.isMultiLanguage}
                 responseOption={responseOption}
                 selected={selection === responseOption.id}
                 setSelection={setSelection}
@@ -135,15 +146,18 @@ export const SurveyDetailScreen = ({ route }: Props) => {
                     <RegularText error small>
                       {texts.survey.hint.de}
                     </RegularText>
-                    <RegularText error italic small>
-                      {texts.survey.hint.pl}
-                    </RegularText>
+                    {!!survey?.isMultiLanguage && (
+                      <RegularText error italic small>
+                        {texts.survey.hint.pl}
+                      </RegularText>
+                    )}
                   </Wrapper>
                 )}
               </>
             )}
             {(previousSubmission || archived) && (
               <Results
+                isMultiLanguage={survey.isMultiLanguage}
                 responseOptions={survey.responseOptions}
                 selectedOption={previousSubmission}
               />
@@ -152,6 +166,7 @@ export const SurveyDetailScreen = ({ route }: Props) => {
           <CommentSection
             archived={archived}
             comments={survey.comments}
+            isMultiLanguage={survey.isMultiLanguage}
             scrollViewRef={scrollViewRef}
             surveyId={surveyId}
           />

--- a/src/screens/SurveyDetailScreen.tsx
+++ b/src/screens/SurveyDetailScreen.tsx
@@ -102,8 +102,12 @@ export const SurveyDetailScreen = ({ route }: Props) => {
         >
           <WrapperWithOrientation>
             {!!shownTitle?.length && <SectionHeader title={shownTitle} />}
-            <DateComponent start date={survey.date.dateStart} />
-            <DateComponent date={survey.date.dateEnd} />
+            <DateComponent
+              date={survey.date.dateStart}
+              isMultilingual={survey.isMultilingual}
+              start
+            />
+            <DateComponent date={survey.date.dateEnd} isMultilingual={survey.isMultilingual} />
             {!!survey.description?.[languages[0]]?.length && (
               <Wrapper style={styles.noPaddingBottom}>
                 <RegularText>{survey.description[languages[0]]}</RegularText>

--- a/src/screens/SurveyOverviewScreen.tsx
+++ b/src/screens/SurveyOverviewScreen.tsx
@@ -36,11 +36,12 @@ const useSurveySections = () => {
 };
 
 const parseSurveyToItem = (survey: Survey & { archived?: true }, languages: string[]) => {
-  const langTitle = combineLanguages(languages, survey.title);
+  const languagesForSurvey = survey.isMultiLanguage ? languages : [languages[0]];
+  const langTitle = combineLanguages(languagesForSurvey, survey.title);
 
   // we know there will be at least one language for the question
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const langQuestion = combineLanguages(languages, survey.questionTitle)!;
+  const langQuestion = combineLanguages(languagesForSurvey, survey.questionTitle)!;
 
   const title = langTitle?.length ? langTitle : langQuestion;
 

--- a/src/screens/SurveyOverviewScreen.tsx
+++ b/src/screens/SurveyOverviewScreen.tsx
@@ -36,7 +36,7 @@ const useSurveySections = () => {
 };
 
 const parseSurveyToItem = (survey: Survey & { archived?: true }, languages: string[]) => {
-  const languagesForSurvey = survey.isMultiLanguage ? languages : [languages[0]];
+  const languagesForSurvey = survey.isMultilingual ? languages : [languages[0]];
   const langTitle = combineLanguages(languagesForSurvey, survey.title);
 
   // we know there will be at least one language for the question

--- a/src/types/Survey.ts
+++ b/src/types/Survey.ts
@@ -14,6 +14,7 @@ export type Survey = {
     dateEnd: string;
   };
   responseOptions: ResponseOption[];
+  isMultiLanguage?: boolean;
   comments: Array<{
     id: string;
     createdAt: string;

--- a/src/types/Survey.ts
+++ b/src/types/Survey.ts
@@ -14,7 +14,7 @@ export type Survey = {
     dateEnd: string;
   };
   responseOptions: ResponseOption[];
-  isMultiLanguage?: boolean;
+  isMultilingual?: boolean;
   comments: Array<{
     id: string;
     createdAt: string;


### PR DESCRIPTION
- added new flag `isMultiLanguage` to `Survey` type
- when used no polish texts are displayed
- adjusted some string constructions
- adjusted `useLanguages` hook to accept `isMultiLanguage`
- slight adjustments to styling of answers where needed

- [x] adjust query

---

SVA-362

## Screenshots:

![Simulator Screen Shot - iPhone 12 Pro - 2021-11-23 at 16 24 46](https://user-images.githubusercontent.com/59824597/143052667-9748399d-2e6f-4bff-8d55-a3c2601531e6.png)
![Simulator Screen Shot - iPhone 12 Pro - 2021-11-23 at 16 24 20](https://user-images.githubusercontent.com/59824597/143052694-e38f7bcd-b2a4-499c-a161-e4993a5e3b40.png)
![Simulator Screen Shot - iPhone 12 Pro - 2021-11-23 at 16 25 58](https://user-images.githubusercontent.com/59824597/143052886-71444446-081b-475c-911e-23beab71f3f4.png)


