### PR TITLE
WebViews: add props for extended usage

### DIFF
--- a/src/screens/WebScreen.js
+++ b/src/screens/WebScreen.js
@@ -35,6 +35,8 @@ export const WebScreen = ({ route }) => {
               <ActivityIndicator color={colors.accent} />
             </LoadingContainer>
           )}
+          // https://github.com/react-native-webview/react-native-webview/blob/19980d888d66554875f3ac64b3e8a35bd7ad998b/src/WebViewTypes.ts#L378-L389
+          decelerationRate="normal"
         />
       </WrapperWithOrientation>
     </SafeAreaViewFlex>

--- a/src/screens/WebScreen.js
+++ b/src/screens/WebScreen.js
@@ -3,10 +3,11 @@ import React, { useContext, useEffect } from 'react';
 import { ActivityIndicator } from 'react-native';
 import { WebView } from 'react-native-webview';
 
-import { colors, consts } from '../config';
+import appJson from '../../app.json';
 import { LoadingContainer, SafeAreaViewFlex, WrapperWithOrientation } from '../components';
-import { NetworkContext } from '../NetworkProvider';
+import { colors, consts } from '../config';
 import { useTrackScreenViewAsync } from '../hooks';
+import { NetworkContext } from '../NetworkProvider';
 
 const { MATOMO_TRACKING } = consts;
 
@@ -37,6 +38,8 @@ export const WebScreen = ({ route }) => {
           )}
           // https://github.com/react-native-webview/react-native-webview/blob/19980d888d66554875f3ac64b3e8a35bd7ad998b/src/WebViewTypes.ts#L378-L389
           decelerationRate="normal"
+          // https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#applicationnameforuseragent
+          applicationNameForUserAgent={appJson.expo.scheme}
         />
       </WrapperWithOrientation>
     </SafeAreaViewFlex>


### PR DESCRIPTION
feat: optimize webview scroll behavior

- added `decelerationRate="normal"` to WebScreen to increase speed of scrolling like user are used to from the browser

Closes #300

feat: add custom useragent string to identify app requests on web servers

- auto organized imports
- used scheme string to pass as application name for user agent that can be used on web servers
  - first use case is bbnavi, where the user agent will be used

BBNAV-61