### PR TITLE
fix(location service): missing android permissions

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,6 +33,8 @@
     },
     "android": {
       "permissions": [
+        "ACCESS_FINE_LOCATION",
+        "ACCESS_COARSE_LOCATION",
         "CAMERA",
         "READ_EXTERNAL_STORAGE",
         "WRITE_EXTERNAL_STORAGE"


### PR DESCRIPTION
despite documentation specifying otherwise, the android permissions for location services need to be added explicitly

SVA-387