### PR TITLE
Fix: location overview ignoring opening times filter

### DIFF
--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -167,6 +167,7 @@ export const IndexScreen = ({ navigation, route }) => {
       ) : null}
       {query === QUERY_TYPES.POINTS_OF_INTEREST && showMap ? (
         <LocationOverview
+          filterByOpeningTimes={filterByOpeningTimes}
           navigation={navigation}
           route={route}
           position={position}


### PR DESCRIPTION
- `LocationOverview` was not passed any prop to handle the state of the opening filter switch while fetching and displaying data internally
- a new prop was added to the `LocationOverview`, which causes the filter for opening times to be applied according to the toggle state

--

SVA-319
