### PR TITLE
Feature: versioned static contents

### DIFF
--- a/src/components/ImagesCarousel.js
+++ b/src/components/ImagesCarousel.js
@@ -5,15 +5,26 @@ import { ActivityIndicator, StyleSheet } from 'react-native';
 import { Query } from 'react-apollo';
 
 import { colors } from '../config';
-import { imageWidth, isActive, shareMessage } from '../helpers';
+import { graphqlFetchPolicy, imageWidth, isActive, shareMessage } from '../helpers';
 import { getQuery } from '../queries';
 import { OrientationContext } from '../OrientationProvider';
+import { NetworkContext } from '../NetworkProvider';
+import { useRefreshTime } from '../hooks';
 
 import { ImagesCarouselItem } from './ImagesCarouselItem';
 import { LoadingContainer } from './LoadingContainer';
 
-export const ImagesCarousel = ({ data, navigation, fetchPolicy, aspectRatio }) => {
+export const ImagesCarousel = ({ data, navigation, refreshTimeKey, aspectRatio }) => {
   const { dimensions } = useContext(OrientationContext);
+  const { isConnected, isMainserverUp } = useContext(NetworkContext);
+
+  const refreshTime = useRefreshTime(refreshTimeKey);
+
+  const fetchPolicy = graphqlFetchPolicy({
+    isConnected,
+    isMainserverUp,
+    refreshTime
+  });
   const itemWidth = imageWidth();
 
   const renderItem = useCallback(
@@ -118,6 +129,6 @@ const styles = StyleSheet.create({
 ImagesCarousel.propTypes = {
   data: PropTypes.array.isRequired,
   navigation: PropTypes.object,
-  fetchPolicy: PropTypes.string,
+  refreshTimeKey: PropTypes.string,
   aspectRatio: PropTypes.object
 };

--- a/src/helpers/graphqlHelper.js
+++ b/src/helpers/graphqlHelper.js
@@ -4,7 +4,7 @@
  * If online, the graphql server should be queried.
  *
  * https://medium.com/@galen.corey/understanding-apollo-fetch-policies-705b5ad71980
- * @param  {{ isConnected: any, isMainserverUp: any, refreshTime: number | undefined }} arg
+ * @param  {{ isConnected: any, isMainserverUp: any, refreshTime?: number | undefined }} arg
  * @return {'cache-first' | 'cache-only' | 'network-only'} a graphql fetch policy depending on the network status
  */
 export const graphqlFetchPolicy = ({ isConnected, isMainserverUp, refreshTime = undefined }) => {

--- a/src/hooks/staticContent.ts
+++ b/src/hooks/staticContent.ts
@@ -24,6 +24,11 @@ type StaticContentArgs<T = unknown> = {
     }
 );
 
+/**
+ * Gets static content by type and name. Automatically generates refresh interval, refresh time key and fetch policy if not provided.
+ * @param options Options for the query.
+ * @returns result error: if there is an error for the query or the parsing; loading: if the query is initializing or loading
+ */
 export const useStaticContent = <T>({
   fetchPolicy: overrideFetchPolicy,
   name,

--- a/src/hooks/staticContent.ts
+++ b/src/hooks/staticContent.ts
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useMemo, useState } from 'react';
 import { useQuery } from 'react-apollo';
 
+import appJson from '../../app.json';
 import { graphqlFetchPolicy } from '../helpers';
 import { NetworkContext } from '../NetworkProvider';
 import { getQuery, QUERY_TYPES } from '../queries';
@@ -59,7 +60,7 @@ export const useStaticContent = <T>({
   const { data, error: queryError, loading, refetch } = useQuery(
     getQuery(type === 'json' ? QUERY_TYPES.PUBLIC_JSON_FILE : QUERY_TYPES.PUBLIC_HTML_FILE),
     {
-      variables: { name },
+      variables: { name, version: appJson.expo.version },
       fetchPolicy,
       skip: !refreshTime || skip
     }

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,8 @@ import { ApolloProvider } from 'react-apollo';
 import { ActivityIndicator } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
+import appJson from '../app.json';
+
 import { auth } from './auth';
 import { BookmarkProvider } from './BookmarkProvider';
 import { LoadingContainer } from './components';
@@ -148,7 +150,7 @@ const MainAppWithApolloProvider = () => {
     try {
       const response = await client.query({
         query: getQuery(QUERY_TYPES.PUBLIC_JSON_FILE),
-        variables: { name: 'globalSettings' },
+        variables: { name: 'globalSettings', version: appJson.expo.version },
         fetchPolicy
       });
 

--- a/src/queries/publicHtmlFiles.js
+++ b/src/queries/publicHtmlFiles.js
@@ -1,8 +1,8 @@
 import gql from 'graphql-tag';
 
 export const GET_PUBLIC_HTML_FILE = gql`
-  query PublicHtmlFile($name: String!) {
-    publicHtmlFile(name: $name) {
+  query PublicHtmlFile($name: String!, $version: String) {
+    publicHtmlFile(name: $name, version: $version) {
       content
     }
   }

--- a/src/queries/publicJsonFiles.js
+++ b/src/queries/publicJsonFiles.js
@@ -1,8 +1,8 @@
 import gql from 'graphql-tag';
 
 export const GET_PUBLIC_JSON_FILE = gql`
-  query PublicJsonFile($name: String!) {
-    publicJsonFile(name: $name) {
+  query PublicJsonFile($name: String!, $version: String) {
+    publicJsonFile(name: $name, version: $version) {
       content
     }
   }

--- a/src/screens/HtmlScreen.js
+++ b/src/screens/HtmlScreen.js
@@ -42,7 +42,7 @@ export const HtmlScreen = ({ navigation, route }) => {
     setRefreshing(true);
     isConnected && (await refetch?.());
     setRefreshing(false);
-  }, [refetch]);
+  }, [isConnected, refetch]);
   const subQuery = route.params?.subQuery ?? '';
   const rootRouteName = route.params?.rootRouteName ?? '';
 

--- a/src/screens/HtmlScreen.js
+++ b/src/screens/HtmlScreen.js
@@ -1,21 +1,20 @@
 import PropTypes from 'prop-types';
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { RefreshControl, ScrollView } from 'react-native';
-import { Query } from 'react-apollo';
 
-import { NetworkContext } from '../NetworkProvider';
 import { auth } from '../auth';
-import { colors, consts } from '../config';
 import { Button, HtmlView, SafeAreaViewFlex, Wrapper, WrapperWithOrientation } from '../components';
-import { graphqlFetchPolicy, trimNewLines } from '../helpers';
-import { getQuery } from '../queries';
-import { useRefreshTime, useTrackScreenViewAsync } from '../hooks';
 import { LoadingSpinner } from '../components/LoadingSpinner';
+import { colors, consts } from '../config';
+import { trimNewLines } from '../helpers';
+import { useStaticContent, useTrackScreenViewAsync } from '../hooks';
+import { NetworkContext } from '../NetworkProvider';
 
 const { MATOMO_TRACKING } = consts;
 
+// eslint-disable-next-line complexity
 export const HtmlScreen = ({ navigation, route }) => {
-  const { isConnected, isMainserverUp } = useContext(NetworkContext);
+  const { isConnected } = useContext(NetworkContext);
   const query = route.params?.query ?? '';
   const queryVariables = route.params?.queryVariables ?? {};
   const title = route.params?.title ?? '';
@@ -24,7 +23,11 @@ export const HtmlScreen = ({ navigation, route }) => {
 
   if (!query || !queryVariables?.name) return null;
 
-  const refreshTime = useRefreshTime(`${query}-${queryVariables.name}`);
+  const { data, loading, refetch } = useStaticContent({
+    name: queryVariables.name,
+    type: 'html',
+    refreshTimeKey: `${query}-${queryVariables.name}`
+  });
 
   useEffect(() => {
     isConnected && auth();
@@ -35,22 +38,13 @@ export const HtmlScreen = ({ navigation, route }) => {
     isConnected && title && trackScreenViewAsync(`${MATOMO_TRACKING.SCREEN_VIEW.HTML} / ${title}`);
   }, [title]);
 
-  if (!refreshTime) {
-    return <LoadingSpinner loading />;
-  }
-
-  const refresh = async (refetch) => {
+  const refresh = useCallback(async () => {
     setRefreshing(true);
-    isConnected && (await refetch());
+    isConnected && (await refetch?.());
     setRefreshing(false);
-  };
+  }, [refetch]);
   const subQuery = route.params?.subQuery ?? '';
   const rootRouteName = route.params?.rootRouteName ?? '';
-  const fetchPolicy = graphqlFetchPolicy({
-    isConnected,
-    isMainserverUp,
-    refreshTime
-  });
 
   // action to open source urls or navigate to sub screens
   const navigate = (param) => {
@@ -93,65 +87,51 @@ export const HtmlScreen = ({ navigation, route }) => {
     });
   };
 
+  if (loading) {
+    return <LoadingSpinner loading />;
+  }
+
+  if (!data) return null;
+
   return (
-    <Query
-      query={getQuery(query)}
-      variables={{ name: queryVariables.name }}
-      fetchPolicy={fetchPolicy}
-    >
-      {({ data, loading, refetch }) => {
-        if (loading) {
-          return <LoadingSpinner loading />;
+    <SafeAreaViewFlex>
+      <ScrollView
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={() => refresh(refetch)}
+            colors={[colors.accent]}
+            tintColor={colors.accent}
+          />
         }
-
-        if (!data?.publicHtmlFile?.content) return null;
-
-        return (
-          <SafeAreaViewFlex>
-            <ScrollView
-              refreshControl={
-                <RefreshControl
-                  refreshing={refreshing}
-                  onRefresh={() => refresh(refetch)}
-                  colors={[colors.accent]}
-                  tintColor={colors.accent}
+      >
+        <WrapperWithOrientation>
+          <Wrapper>
+            <HtmlView html={trimNewLines(data)} openWebScreen={navigate} navigation={navigation} />
+            {!!subQuery && !!subQuery.routeName && (!!subQuery.webUrl || subQuery.params) && (
+              <Button
+                title={subQuery.buttonTitle || `${title} öffnen`}
+                onPress={() => navigate()}
+              />
+            )}
+            {!!subQuery &&
+              !!subQuery.buttons &&
+              subQuery.buttons.map((button, index) => (
+                <Button
+                  key={`${index}-${button.webUrl}`}
+                  title={button.buttonTitle || `${title} öffnen`}
+                  onPress={() =>
+                    navigate({
+                      routeName: button.routeName,
+                      webUrl: button.webUrl
+                    })
+                  }
                 />
-              }
-            >
-              <WrapperWithOrientation>
-                <Wrapper>
-                  <HtmlView
-                    html={trimNewLines(data.publicHtmlFile.content)}
-                    openWebScreen={navigate}
-                    navigation={navigation}
-                  />
-                  {!!subQuery && !!subQuery.routeName && (!!subQuery.webUrl || subQuery.params) && (
-                    <Button
-                      title={subQuery.buttonTitle || `${title} öffnen`}
-                      onPress={() => navigate()}
-                    />
-                  )}
-                  {!!subQuery &&
-                    !!subQuery.buttons &&
-                    subQuery.buttons.map((button, index) => (
-                      <Button
-                        key={`${index}-${button.webUrl}`}
-                        title={button.buttonTitle || `${title} öffnen`}
-                        onPress={() =>
-                          navigate({
-                            routeName: button.routeName,
-                            webUrl: button.webUrl
-                          })
-                        }
-                      />
-                    ))}
-                </Wrapper>
-              </WrapperWithOrientation>
-            </ScrollView>
-          </SafeAreaViewFlex>
-        );
-      }}
-    </Query>
+              ))}
+          </Wrapper>
+        </WrapperWithOrientation>
+      </ScrollView>
+    </SafeAreaViewFlex>
   );
 };
 


### PR DESCRIPTION
- refactored all places where we use static contents to use the `useStaticContent` hook
- added app.json version  to `queryVariables` used in the `useStaticContent` hook
- added app.json version to `queryVariables` of the `globalSettings` query in `src/index.js`

---

SVA-150

---

## How to test

- added versioned static content to internal development server
  - for nested info json (loop) referenced in home about
  - for table referenced in navigation

- by changing the version string in app.json you can get different contents