### PR TITLE
fix(leaflet-crash): switch to another fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-native-snap-carousel": "~3.9.0",
     "react-native-svg": "12.1.1",
     "react-native-webview": "11.13.0",
-    "react-native-webview-leaflet": "https://github.com/digorath/react-native-webview-leaflet#c5579e2fe46c35f3cc8b307c4794e9a0f11ab436",
+    "react-native-webview-leaflet": "https://github.com/okwast/react-native-webview-leaflet#d1914b1b02dc7a9faad45f23abadbf1fd3958abc",
     "sentry-expo": "^4.0.0",
     "styled-components": "~4.4.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10737,9 +10737,9 @@ react-native-swipe-gestures@^1.0.5:
   resolved "https://registry.yarnpkg.com/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz#a172cb0f3e7478ccd681fd36b8bfbcdd098bde7c"
   integrity sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==
 
-"react-native-webview-leaflet@https://github.com/digorath/react-native-webview-leaflet#c5579e2fe46c35f3cc8b307c4794e9a0f11ab436":
+"react-native-webview-leaflet@https://github.com/okwast/react-native-webview-leaflet#d1914b1b02dc7a9faad45f23abadbf1fd3958abc":
   version "5.0.2"
-  resolved "https://github.com/digorath/react-native-webview-leaflet#c5579e2fe46c35f3cc8b307c4794e9a0f11ab436"
+  resolved "https://github.com/okwast/react-native-webview-leaflet#d1914b1b02dc7a9faad45f23abadbf1fd3958abc"
   dependencies:
     expo-asset "~8.4.3"
     expo-asset-utils "^3.0.0"


### PR DESCRIPTION
- added a new commit to the fork of @digorath to disable hardware accelerration on android to prevent android devices from crashing when navigating to a screen containing a map

SVA-404

## Changes proposed in this PR:

This PR updates the dependency to react-native-webview-leaflet to another custom fork which contains a change to disable hardware acceleration on android devices as this causes crashes on some Android devices when showing the map

---

SVA-404

---

## How to test:
* [X] Android portrait mode
* [ ] iOS portrait mode
* [ ] Android landscape mode
* [ ] iOS landscape mode

Open the app, open the drawer menu, open the app settings.
The app should crash at this point.

*NOTE:* The crash only happens sometimes and only on some devices. We could trigger the crash on two Pixel devices and a Samsung Galaxy S8