### PR TITLE
fix: public json contents

### DIFF
--- a/src/hooks/staticContent.ts
+++ b/src/hooks/staticContent.ts
@@ -78,7 +78,7 @@ export const useStaticContent = <T>({
 
     try {
       if (data) {
-        const json = JSON.parse(data?.publicJsonFile?.content);
+        const json = data?.publicJsonFile?.content;
 
         return parseFromJson ? parseFromJson(json) : json;
       }

--- a/src/index.js
+++ b/src/index.js
@@ -166,13 +166,7 @@ const MainAppWithApolloProvider = () => {
       }
     }
 
-    let globalSettingsPublicJsonFileContent = [];
-
-    try {
-      globalSettingsPublicJsonFileContent = JSON.parse(globalSettingsData?.publicJsonFile?.content);
-    } catch (error) {
-      console.warn(error, globalSettingsData);
-    }
+    const globalSettingsPublicJsonFileContent = globalSettingsData?.publicJsonFile?.content;
 
     if (!_isEmpty(globalSettingsPublicJsonFileContent)) {
       globalSettings = globalSettingsPublicJsonFileContent;

--- a/src/queries/BB-BUS/getTop10Ids.js
+++ b/src/queries/BB-BUS/getTop10Ids.js
@@ -1,9 +1,11 @@
 import gql from 'graphql-tag';
 
-// TODO: replace this by using useStaticContent with versioning after 2.4.0
+import appJson from '../../../app.json';
+
+// TODO: refactor to use useStaticContent
 export const GET_TOP_10_IDS = gql`
   query PublicJsonFile {
-    publicJsonFile(name: "bb-bus-top10-2.4.0") {
+    publicJsonFile(name: "bb-bus-top10", version: "${appJson.expo.version}") {
       content
     }
   }

--- a/src/screens/BB-BUS/IndexScreen.js
+++ b/src/screens/BB-BUS/IndexScreen.js
@@ -142,7 +142,7 @@ export const IndexScreen = ({ navigation }) => {
               );
             }
 
-            const top10Ids = data && data.publicJsonFile && JSON.parse(data.publicJsonFile.content);
+            const top10Ids = data?.publicJsonFile?.content;
 
             return (
               <Query


### PR DESCRIPTION
- removed `JSON.parse`s around public json contents because the
  `publicJsonFile` query now returns proper json instead of a string
  - therefore we also do not need the try catch bocks for possible
    errors with `JSON.parse` anymore

---

ℹ️ i will bring this to int/development demo app directly per `expo publish`