### PR TITLE
Update base components

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -25,7 +25,7 @@ export const Button = ({ title, onPress, invert, disabled }) => {
       ]}
       disabledStyle={styles.buttonStyleDisabled}
       disabledTitleStyle={styles.titleStyle}
-      buttonStyle={invert ? styles.buttonStyleInvert : undefined}
+      buttonStyle={[styles.buttonStyle, invert && styles.buttonStyleInvert]}
       containerStyle={[styles.containerStyle, needLandscapeStyle && styles.containerStyleLandscape]}
       ViewComponent={invert || disabled ? undefined : DiagonalGradient}
       useForeground={!invert}
@@ -36,19 +36,7 @@ export const Button = ({ title, onPress, invert, disabled }) => {
 };
 
 const styles = StyleSheet.create({
-  titleStyle: {
-    color: colors.lightestText,
-    fontFamily: 'bold'
-  },
-  titleStyleLandscape: {
-    paddingHorizontal: normalize(14)
-  },
-  containerStyle: {
-    marginBottom: normalize(21)
-  },
-  titleStyleInvert: {
-    color: colors.primary
-  },
+  buttonStyle: {},
   buttonStyleDisabled: {
     backgroundColor: colors.placeholder
   },
@@ -57,9 +45,22 @@ const styles = StyleSheet.create({
     borderStyle: 'solid',
     borderWidth: 2
   },
+  containerStyle: {
+    marginBottom: normalize(21)
+  },
   containerStyleLandscape: {
     alignItems: 'center',
     justifyContent: 'center'
+  },
+  titleStyle: {
+    color: colors.lightestText,
+    fontFamily: 'bold'
+  },
+  titleStyleInvert: {
+    color: colors.primary
+  },
+  titleStyleLandscape: {
+    paddingHorizontal: normalize(14)
   }
 });
 

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -115,13 +115,6 @@ export const BoldText = styled(RegularText)`
   font-family: bold;
 
   ${(props) =>
-    props.big &&
-    css`
-      font-size: ${normalize(20)};
-      line-height: ${normalize(26)};
-    `};
-
-  ${(props) =>
     props.italic &&
     css`
       font-family: bold-italic;


### PR DESCRIPTION
feat: remove `big` prop for `BoldText`

- the `big` definition is already existing for `RegularText`
  thus was a duplication

feat: add smarter button style

- some apps already have a custom button style set
  which should be possible right from master, therefore
  a `buttonStyle` is added
- for `invert` buttons both styles should be applied,
  therefore the condition on `invert` is removed and
  the styles passed per array
- sorted styles alphabetically per key for better overview