### PR TITLE
fix(app-intro): fix app intro content below status bar

### DIFF
--- a/src/screens/AppIntroScreen.tsx
+++ b/src/screens/AppIntroScreen.tsx
@@ -62,7 +62,7 @@ export const AppIntroScreen = ({ setOnboardingComplete }: Props) => {
 
   return (
     <SafeAreaViewFlex>
-      <StatusBar barStyle="dark-content" translucent backgroundColor="transparent" />
+      <StatusBar barStyle="dark-content" backgroundColor="transparent" />
       <AppIntroSlider<AppIntroSlide>
         renderItem={renderSlide}
         data={slides}


### PR DESCRIPTION
Solved the issue that the app intro content is under the status bar. The status bar component in the app intro screen is not translucent any more.

SVA-305

---

## How to test:
* [x] Android portrait mode
* [ ] iOS portrait mode
* [ ] Android landscape mode
* [ ] iOS landscape mode
