### PR TITLE
feat(feedback): Added feedback to bbbus detail and waste screens

### DIFF
--- a/src/components/wasteCalendar/WasteReminderSettings.tsx
+++ b/src/components/wasteCalendar/WasteReminderSettings.tsx
@@ -34,6 +34,7 @@ import {
   ReminderSettingsActionType,
   reminderSettingsReducer
 } from './ReminderSettingsReducer';
+import { FeedbackFooter } from '../FeedbackFooter';
 
 const showErrorAlert = () => {
   Alert.alert(texts.wasteCalendar.errorOnUpdateTitle, texts.wasteCalendar.errorOnUpdateBody);
@@ -366,6 +367,7 @@ export const WasteReminderSettings = ({
           </Wrapper>
         </>
       )}
+      <FeedbackFooter />
     </ScrollView>
   );
 };

--- a/src/screens/BB-BUS/DetailScreen.js
+++ b/src/screens/BB-BUS/DetailScreen.js
@@ -10,6 +10,7 @@ import { BackToTop, Button, SafeAreaViewFlex } from '../../components';
 import { Authority } from '../../components/BB-BUS/Authority';
 import { Persons } from '../../components/BB-BUS/Persons';
 import { TextBlock } from '../../components/BB-BUS/TextBlock';
+import { FeedbackFooter } from '../../components/FeedbackFooter';
 import { LoadingSpinner } from '../../components/LoadingSpinner';
 import { colors, consts, device, namespace, normalize, secrets } from '../../config';
 import { matomoTrackingString, openLink } from '../../helpers';
@@ -204,6 +205,7 @@ export const DetailScreen = ({ route }) => {
             }
           />
         )}
+        <FeedbackFooter />
       </ScrollView>
     </SafeAreaViewFlex>
   );

--- a/src/screens/WasteCollectionScreen.js
+++ b/src/screens/WasteCollectionScreen.js
@@ -25,6 +25,7 @@ import {
   Wrapper,
   WrapperWithOrientation
 } from '../components';
+import { FeedbackFooter } from '../components/FeedbackFooter';
 import { colors, device, namespace, normalize, secrets, staticRestSuffix, texts } from '../config';
 import { graphqlFetchPolicy, openLink, setupLocales } from '../helpers';
 import { useRefreshTime, useStaticContent } from '../hooks';
@@ -271,6 +272,7 @@ export const WasteCollectionScreen = ({ navigation }) => {
             </Wrapper>
           )}
         </WrapperWithOrientation>
+        <FeedbackFooter />
       </ScrollView>
     </SafeAreaViewFlex>
   );


### PR DESCRIPTION
* Added feedback footer to the screens of
  * BB-Bus/DetailsScreen
  * WasteCollectionScreen
  * WasteReminderSettingsScreen

SVA-327

## Changes proposed in this PR:

It was requested to add the feedback to the waste calendar and bb bus screens.

---

SVA-327

---

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode

Examples of the new feedback placements.

| Portrait | Landscape |
| --------------- | --------------- |
| ![Simulator Screen Shot - iPhone 13 mini - 2022-02-11 at 14 13 22](https://user-images.githubusercontent.com/13070135/153597941-ac06fb45-2315-4741-b872-bd267a7f1011.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-02-11 at 14 13 34](https://user-images.githubusercontent.com/13070135/153597978-4ebaab1c-bdbe-43de-ae82-729668b259f4.png) |
| ![Simulator Screen Shot - iPhone 13 mini - 2022-02-11 at 14 14 09](https://user-images.githubusercontent.com/13070135/153598028-68b247b1-1006-45b9-b1b7-b38e2ad85b02.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-02-11 at 14 14 18](https://user-images.githubusercontent.com/13070135/153598052-af5d20d5-f5c9-4f19-bff4-67fc5763d0b4.png) |
