### PR TITLE
fix(theming): Set the text color for the date picker of waste reminder

### DIFF
--- a/src/components/wasteCalendar/WasteReminderSettings.tsx
+++ b/src/components/wasteCalendar/WasteReminderSettings.tsx
@@ -347,6 +347,7 @@ export const WasteReminderSettings = ({
                           mode="time"
                           onChange={onDatePickerChange}
                           value={localSelectedTime || new Date()}
+                          textColor={colors.darkText}
                         />
                       </SafeAreaView>
                     </View>


### PR DESCRIPTION
* The settings of the waste calendar have a time picker to select when to be notified. The time within the picker was invisible when the iPhone was on DarkMode as it was light text on white background. The text color is now set to be textDark to be visible again

discovered while working on SVA-327

---

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode

| Before | After |
| --- | --- |
| ![IMG_A39F21564079-1](https://user-images.githubusercontent.com/13070135/153595411-493be50d-e92b-457a-b2b1-efb2fe104b41.jpeg) | ![IMG_E8D6326B6C00-1](https://user-images.githubusercontent.com/13070135/153595440-3863956e-89ce-417b-947e-39550e352265.jpeg) |