### PR TITLE
feature: nested services

### DIFF
--- a/src/components/screens/ServiceTiles.js
+++ b/src/components/screens/ServiceTiles.js
@@ -75,12 +75,9 @@ export const ServiceTiles = ({ navigation, staticJsonName, title }) => {
                     dimensions={dimensions}
                   >
                     <TouchableOpacity
-                      onPress={() =>
-                        navigation.navigate({
-                          name: item.routeName,
-                          params: item.params
-                        })
-                      }
+                      onPress={() => {
+                        navigation.push(item.routeName, item.params);
+                      }}
                     >
                       <View>
                         {item.iconName ? (

--- a/src/config/navigation/defaultStackConfig.tsx
+++ b/src/config/navigation/defaultStackConfig.tsx
@@ -32,6 +32,7 @@ import {
   SettingsScreen,
   SurveyDetailScreen,
   SurveyOverviewScreen,
+  TilesScreen,
   WasteCollectionScreen,
   WasteReminderScreen,
   WeatherScreen,
@@ -238,6 +239,10 @@ export const defaultStackConfig = ({
       routeName: ScreenName.SurveyOverview,
       screenComponent: SurveyOverviewScreen,
       screenOptions: { title: texts.screenTitles.surveys }
+    },
+    {
+      routeName: ScreenName.TilesScreen,
+      screenComponent: TilesScreen
     },
     {
       routeName: ScreenName.WasteCollection,

--- a/src/screens/TilesScreen.js
+++ b/src/screens/TilesScreen.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 
 import { ServiceTiles } from '../components';
 import { useMatomoTrackScreenView } from '../hooks';
@@ -21,4 +21,12 @@ export const getTilesScreen = ({ matomoString, staticJsonName, titleFallback, ti
   };
 
   return TilesScreen;
+};
+
+export const TilesScreen = ({ route, navigation }) => {
+  useEffect(() => {
+    route.params?.screenTitle && navigation.setOptions({ title: route.params.screenTitle });
+  }, [navigation, route.params?.screenTitle]);
+
+  return getTilesScreen(route.params)({ navigation });
 };

--- a/src/types/Navigation.ts
+++ b/src/types/Navigation.ts
@@ -37,6 +37,7 @@ export enum ScreenName {
   Settings = 'Settings',
   SurveyDetail = 'SurveyDetail',
   SurveyOverview = 'SurveyOverview',
+  TilesScreen = 'TilesScreen',
   WasteCollection = 'WasteCollection',
   WasteReminder = 'WasteReminder',
   Weather = 'Weather',


### PR DESCRIPTION
- added a generic TilesScreen that recieves necessary info through route params
  - this makes it possible to nest a TilesScreen into any route

HDVT-40

---

### How to test:

- added new service link "Tiles" on home screen of internal test app