### PR TITLE
fix(static content): check for content emptiness

### DIFF
--- a/src/components/screens/ServiceTiles.js
+++ b/src/components/screens/ServiceTiles.js
@@ -46,6 +46,7 @@ export const ServiceTiles = ({ navigation, staticJsonName, title }) => {
       </LoadingContainer>
     );
   }
+
   return (
     <SafeAreaViewFlex>
       <>

--- a/src/hooks/staticContent.ts
+++ b/src/hooks/staticContent.ts
@@ -1,3 +1,4 @@
+import _isEmpty from 'lodash/isEmpty';
 import { useCallback, useContext, useMemo, useState } from 'react';
 import { useQuery } from 'react-apollo';
 
@@ -77,10 +78,12 @@ export const useStaticContent = <T>({
     }
 
     try {
-      if (data) {
+      if (!_isEmpty(data?.publicJsonFile?.content)) {
         const json = data?.publicJsonFile?.content;
 
         return parseFromJson ? parseFromJson(json) : json;
+      } else {
+        setError(true);
       }
     } catch (error) {
       setError(true);


### PR DESCRIPTION
- if a json static content is not found there could be
  a `content: {}` which we assume as error now
  - without it this crashed the app