### PR TITLE
fix(waste calendar): Fixed the missing time zone

### DIFF
--- a/src/components/wasteCalendar/WasteReminderSettings.tsx
+++ b/src/components/wasteCalendar/WasteReminderSettings.tsx
@@ -217,7 +217,7 @@ export const WasteReminderSettings = ({
           const id = await updateReminderSettings({
             ...locationData,
             onDayBefore: state.onDayBefore,
-            reminderTime: `${state.reminderTime.getHours()}:${state.reminderTime.getMinutes()}`,
+            reminderTime: reminderTime.toISOString(),
             wasteType: typeKey
           });
 


### PR DESCRIPTION
The time send to the API only contained the hours and minutes so that the server assumed it is UTC while the user sees the time in their local time zone

SVA-467
