### PR TITLE
feat(image): check status of image uri before using it

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -92,7 +92,7 @@ export const Image = ({
     return () => (mounted = false);
   }, [timestamp, refreshInterval, sourceProp, setSource]);
 
-  if (source?.uri === 'NO_IMAGE') return null;
+  if (source?.uri === NO_IMAGE.uri) return null;
 
   return (
     <View>


### PR DESCRIPTION
- if an image uri responses with problematic state like 404
  we had an infinite loading spinner
- added a `fetch` for the image uri to check if it is available
  (status 200) before using it
- added a `NO_IMAGE` fallback source to identify problematic
  uris and render nothing for that cases

|before|after|
|---|---|
|![Simulator Screen Shot - iPhone 11 Pro - 2022-03-02 at 15 33 10](https://user-images.githubusercontent.com/1942953/156385528-7f717344-dc34-419d-bb3f-de47aa17164d.png)|![Simulator Screen Shot - iPhone 11 Pro - 2022-03-02 at 15 33 20](https://user-images.githubusercontent.com/1942953/156385540-a77e2aa3-3765-40b8-8630-e033cbd0f492.png)|

