### PR TITLE
fix(static content): add condition for setting error

### DIFF
--- a/src/hooks/staticContent.ts
+++ b/src/hooks/staticContent.ts
@@ -68,23 +68,25 @@ export const useStaticContent = <T>({
   );
 
   const refetchCallback = useCallback(async () => {
-    setError(false);
     return await refetch?.();
   }, [refetch]);
 
   const publicFileData = useMemo(() => {
+    setError(false);
+
     if (type === 'html') {
       return data?.publicHtmlFile?.content;
     }
 
     try {
-      if (!_isEmpty(data?.publicJsonFile?.content)) {
-        const json = data?.publicJsonFile?.content;
+      const json = data?.publicJsonFile?.content;
 
+      if (!_isEmpty(json)) {
         return parseFromJson ? parseFromJson(json) : json;
-      } else if (data || queryError) {
-        // set error true if there is bad data without `publicJsonFile.content` or some `queryError`
+      } else if (!loading && data) {
+        // set error true if there is bad data without `publicJsonFile.content`
         setError(true);
+        console.warn(error, data);
       }
     } catch (error) {
       setError(true);
@@ -95,9 +97,10 @@ export const useStaticContent = <T>({
   return {
     data: publicFileData,
     error: error || !!queryError,
-    // add the extra condition to avoid weird rendering states, where loading is false, but the publicFileData is not yet set.
-    // this way we can safely manipulate data and then update the publicFileData with it, after the query has finished loading.
-    loading: loading || (publicFileData === undefined && !error && !skip),
+    // add the extra condition to avoid weird rendering states, where `loading` is false, but the
+    // `publicFileData` is not yet set. this way we can safely manipulate `data` and then update the
+    // `publicFileData` with it, after the query has finished loading.
+    loading: loading || (publicFileData === undefined && !error && !queryError && !skip),
     refetch: refetchCallback
   };
 };

--- a/src/hooks/staticContent.ts
+++ b/src/hooks/staticContent.ts
@@ -82,7 +82,8 @@ export const useStaticContent = <T>({
         const json = data?.publicJsonFile?.content;
 
         return parseFromJson ? parseFromJson(json) : json;
-      } else {
+      } else if (data || queryError) {
+        // set error true if there is bad data without `publicJsonFile.content` or some `queryError`
         setError(true);
       }
     } catch (error) {

--- a/src/screens/MultiButtonScreen.tsx
+++ b/src/screens/MultiButtonScreen.tsx
@@ -46,11 +46,7 @@ export const MultiButtonScreen = ({ navigation, route }: StackScreenProps<any>) 
     [navigation]
   );
 
-  if (!name || error) {
-    return null;
-  }
-
-  if (loading) {
+  if (loading && !error) {
     return <LoadingSpinner loading />;
   }
 


### PR DESCRIPTION
- follow up for #469
- set error true if there is bad data without `publicJsonFile.content`
  or some `queryError`, otherwise it would be always true for the time
  data is not yet fetched entirely