### PR TITLE
Feature: make OParl file urls open externally

### DIFF
--- a/src/components/oParl/File.tsx
+++ b/src/components/oParl/File.tsx
@@ -2,7 +2,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import React from 'react';
 
 import { texts } from '../../config';
-import { formatSize, momentFormat } from '../../helpers';
+import { formatSize, momentFormat, openLink } from '../../helpers';
 import { FileData } from '../../types';
 import { SectionHeader } from '../SectionHeader';
 import { Wrapper, WrapperHorizontal } from '../Wrapper';
@@ -90,13 +90,21 @@ export const File = ({ data, navigation }: Props) => {
           <SimpleRow
             left={fileTexts.accessUrl}
             right={accessUrl !== downloadUrl ? accessUrl : undefined}
+            onPress={() => openLink(accessUrl)}
             selectable
             fullText
           />
-          <SimpleRow left={fileTexts.downloadUrl} right={downloadUrl} selectable fullText />
+          <SimpleRow
+            left={fileTexts.downloadUrl}
+            right={downloadUrl}
+            onPress={() => openLink(downloadUrl)}
+            selectable
+            fullText
+          />
           <SimpleRow
             left={fileTexts.externalServiceUrl}
             right={externalServiceUrl}
+            onPress={() => openLink(externalServiceUrl)}
             selectable
             fullText
           />

--- a/src/components/oParl/Row.tsx
+++ b/src/components/oParl/Row.tsx
@@ -74,6 +74,7 @@ export const SimpleRow = ({ fullText, left, lineThrough, onPress, right, selecta
         lineThrough={lineThrough}
         primary={!!onPress}
         selectable={selectable}
+        underline={!!onPress}
       >
         {right}
       </RegularText>


### PR DESCRIPTION
- changed styling of clickable links to be underlined
- made download, access and externalService urls of oparl files open externally on press

SVA-498
