### PR TITLE
chore(text): insert zero width space after dashes

### DIFF
--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -16,11 +16,25 @@ function parseNumericCharacterReferences(text) {
   );
 }
 
+function insertWhiteSpaceAfterDashes(text) {
+  if (!text) return;
+
+  return text.replace('-', '-' + String.fromCharCode(8203));
+}
+
+function parseText(text) {
+  if (!text) return;
+
+  let result = parseNumericCharacterReferences(text);
+
+  result = insertWhiteSpaceAfterDashes(result);
+
+  return result;
+}
+
 export const Text = ({ children, ...props }) => {
   return (
-    <RNText {...props}>
-      {typeof children === 'string' ? parseNumericCharacterReferences(children) : children}
-    </RNText>
+    <RNText {...props}>{typeof children === 'string' ? parseText(children) : children}</RNText>
   );
 };
 


### PR DESCRIPTION
This improves the android line break behaviour

SVA-220

## Screenshots
s. Veranstaltungen-events-lang
| before | after |
|--|--|
|![image](https://user-images.githubusercontent.com/59824597/160403615-7f09cbda-b87a-42fc-a11b-e171d0e48a1f.png)|![image](https://user-images.githubusercontent.com/59824597/160403065-bdea2121-9cc2-44ed-abb5-ea3bee5559ac.png)|
