### PR TITLE
fix(consul): multiple error messages

### DIFF
--- a/src/components/screens/consul/Debates/NewDebate.js
+++ b/src/components/screens/consul/Debates/NewDebate.js
@@ -113,7 +113,7 @@ export const NewDebate = ({ navigation, data, query }) => {
             control={control}
             {...item}
             validate={item.rules.required}
-            errorMessage={errors[item.name] && item.errorMessage}
+            errorMessage={errors[item.name] && `${errors[item.name].message}`}
           />
         </Wrapper>
       ))}
@@ -171,10 +171,9 @@ const INPUTS = [
     autoCompleteType: 'off',
     autoCapitalize: 'none',
     rules: {
-      required: true,
+      required: texts.consul.startNew.leerError,
       minLength: { value: 4, message: 'ist zu kurz (minimum 4 Zeichen)' }
-    },
-    errorMessage: texts.consul.startNew.leerError
+    }
   },
   {
     name: 'description',
@@ -187,10 +186,9 @@ const INPUTS = [
     autoCompleteType: 'off',
     autoCapitalize: 'none',
     rules: {
-      required: true,
+      required: texts.consul.startNew.leerError,
       minLength: { value: 10, message: 'ist zu kurz (minimum 10 Zeichen)' }
-    },
-    errorMessage: texts.consul.startNew.leerError
+    }
   },
   {
     name: 'tagList',

--- a/src/components/screens/consul/Debates/NewDebate.js
+++ b/src/components/screens/consul/Debates/NewDebate.js
@@ -113,7 +113,7 @@ export const NewDebate = ({ navigation, data, query }) => {
             control={control}
             {...item}
             validate={item.rules.required}
-            errorMessage={errors[item.name] && `${errors[item.name].message}`}
+            errorMessage={errors[item.name] && errors[item.name].message}
           />
         </Wrapper>
       ))}
@@ -171,7 +171,7 @@ const INPUTS = [
     autoCompleteType: 'off',
     autoCapitalize: 'none',
     rules: {
-      required: texts.consul.startNew.leerError,
+      required: texts.consul.startNew.emptyError,
       minLength: { value: 4, message: 'ist zu kurz (minimum 4 Zeichen)' }
     }
   },
@@ -186,7 +186,7 @@ const INPUTS = [
     autoCompleteType: 'off',
     autoCapitalize: 'none',
     rules: {
-      required: texts.consul.startNew.leerError,
+      required: texts.consul.startNew.emptyError,
       minLength: { value: 10, message: 'ist zu kurz (minimum 10 Zeichen)' }
     }
   },

--- a/src/components/screens/consul/Proposals/NewProposal.js
+++ b/src/components/screens/consul/Proposals/NewProposal.js
@@ -183,7 +183,7 @@ export const NewProposal = ({ navigation, data, query }) => {
               control={control}
               {...item}
               validate={item.rules.required}
-              errorMessage={errors[item.name] && item.errorMessage}
+              errorMessage={errors[item.name] && `${errors[item.name].message}`}
             />
           )}
 
@@ -302,10 +302,9 @@ const INPUTS = [
     autoCompleteType: 'off',
     autoCapitalize: 'none',
     rules: {
-      required: true,
+      required: texts.consul.startNew.leerError,
       minLength: { value: 4, message: texts.consul.startNew.titleShortError }
-    },
-    errorMessage: texts.consul.startNew.leerError
+    }
   },
   {
     type: ITEM_TYPES.INPUT,
@@ -318,10 +317,9 @@ const INPUTS = [
     autoCompleteType: 'off',
     autoCapitalize: 'none',
     rules: {
-      required: true,
+      required: texts.consul.startNew.leerError,
       maxLength: { value: 200, message: texts.consul.startNew.proposalSummaryInfo }
-    },
-    errorMessage: texts.consul.startNew.leerError
+    }
   },
   {
     type: ITEM_TYPES.INPUT,
@@ -335,10 +333,9 @@ const INPUTS = [
     autoCapitalize: 'none',
     minHeight: 150,
     rules: {
-      required: true,
+      required: texts.consul.startNew.leerError,
       minLength: { value: 10, message: texts.consul.startNew.descriptionShortError }
-    },
-    errorMessage: texts.consul.startNew.leerError
+    }
   },
   {
     type: ITEM_TYPES.INPUT,

--- a/src/components/screens/consul/Proposals/NewProposal.js
+++ b/src/components/screens/consul/Proposals/NewProposal.js
@@ -183,7 +183,7 @@ export const NewProposal = ({ navigation, data, query }) => {
               control={control}
               {...item}
               validate={item.rules.required}
-              errorMessage={errors[item.name] && `${errors[item.name].message}`}
+              errorMessage={errors[item.name] && errors[item.name].message}
             />
           )}
 
@@ -302,7 +302,7 @@ const INPUTS = [
     autoCompleteType: 'off',
     autoCapitalize: 'none',
     rules: {
-      required: texts.consul.startNew.leerError,
+      required: texts.consul.startNew.emptyError,
       minLength: { value: 4, message: texts.consul.startNew.titleShortError }
     }
   },
@@ -317,7 +317,7 @@ const INPUTS = [
     autoCompleteType: 'off',
     autoCapitalize: 'none',
     rules: {
-      required: texts.consul.startNew.leerError,
+      required: texts.consul.startNew.emptyError,
       maxLength: { value: 200, message: texts.consul.startNew.proposalSummaryInfo }
     }
   },
@@ -333,7 +333,7 @@ const INPUTS = [
     autoCapitalize: 'none',
     minHeight: 150,
     rules: {
-      required: texts.consul.startNew.leerError,
+      required: texts.consul.startNew.emptyError,
       minLength: { value: 10, message: texts.consul.startNew.descriptionShortError }
     }
   },

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -132,7 +132,7 @@ export const texts = {
       categoriesTitle: 'Kategorien',
       descriptionShortError: 'ist zu kurz (minimum 10 Zeichen)',
       editButtonLabelOnDetailScreen: 'Bearbeiten',
-      leerError: 'darf nicht leer sein',
+      emptyError: 'darf nicht leer sein',
       newDebateDescriptionLabel: 'Initialer Debattenbeitrag',
       newDebateStartButtonLabel: 'Eine Diskussion starten',
       newDebateTagLabel: 'Trennen Sie die Tags mit einem Komma (,)',

--- a/src/screens/consul/LoginRegister/ConsulLoginScreen.js
+++ b/src/screens/consul/LoginRegister/ConsulLoginScreen.js
@@ -92,7 +92,7 @@ export const ConsulLoginScreen = ({ navigation }) => {
                 autoCapitalize="none"
                 validate
                 rules={{ required: texts.consul.usernameOrEmailError }}
-                errorMessage={errors.email && `${errors.email.message}`}
+                errorMessage={errors.email && errors.email.message}
                 control={control}
               />
             </Wrapper>
@@ -111,7 +111,7 @@ export const ConsulLoginScreen = ({ navigation }) => {
                   required: texts.consul.passwordError,
                   minLength: { value: 8, message: texts.consul.passwordLengthError }
                 }}
-                errorMessage={errors.password && `${errors.password.message}`}
+                errorMessage={errors.password && errors.password.message}
                 control={control}
               />
             </Wrapper>

--- a/src/screens/consul/LoginRegister/ConsulLoginScreen.js
+++ b/src/screens/consul/LoginRegister/ConsulLoginScreen.js
@@ -91,8 +91,8 @@ export const ConsulLoginScreen = ({ navigation }) => {
                 autoCompleteType="email"
                 autoCapitalize="none"
                 validate
-                rules={{ required: true }}
-                errorMessage={errors.email && `${texts.consul.usernameOrEmailError}`}
+                rules={{ required: texts.consul.usernameOrEmailError }}
+                errorMessage={errors.email && `${errors.email.message}`}
                 control={control}
               />
             </Wrapper>
@@ -108,10 +108,10 @@ export const ConsulLoginScreen = ({ navigation }) => {
                 rightIcon={rightIcon(secureTextEntry, setSecureTextEntry)}
                 validate
                 rules={{
-                  required: true,
+                  required: texts.consul.passwordError,
                   minLength: { value: 8, message: texts.consul.passwordLengthError }
                 }}
-                errorMessage={errors.password && `${texts.consul.passwordError}`}
+                errorMessage={errors.password && `${errors.password.message}`}
                 control={control}
               />
             </Wrapper>

--- a/src/screens/consul/LoginRegister/ConsulRegisterScreen.js
+++ b/src/screens/consul/LoginRegister/ConsulRegisterScreen.js
@@ -98,7 +98,7 @@ export const ConsulRegisterScreen = ({ navigation }) => {
                 autoCapitalize="none"
                 validate
                 rules={{ required: texts.consul.usernameError }}
-                errorMessage={errors.name && `${errors.name.message}`}
+                errorMessage={errors.name && errors.name.message}
                 control={control}
               />
             </Wrapper>
@@ -117,7 +117,7 @@ export const ConsulRegisterScreen = ({ navigation }) => {
                   required: texts.consul.emailError,
                   pattern: { value: EMAIL_REGEX, message: texts.consul.emailInvalid }
                 }}
-                errorMessage={errors.email && `${errors.email.message}`}
+                errorMessage={errors.email && errors.email.message}
                 control={control}
               />
             </Wrapper>
@@ -136,7 +136,7 @@ export const ConsulRegisterScreen = ({ navigation }) => {
                   required: texts.consul.passwordError,
                   minLength: { value: 8, message: texts.consul.passwordLengthError }
                 }}
-                errorMessage={errors.password && `${errors.password.message}`}
+                errorMessage={errors.password && errors.password.message}
                 control={control}
               />
             </Wrapper>
@@ -156,7 +156,7 @@ export const ConsulRegisterScreen = ({ navigation }) => {
                   minLength: { value: 8, message: texts.consul.passwordLengthError },
                   validate: (value) => value === pwd || texts.consul.passwordDoNotMatch
                 }}
-                errorMessage={errors['password-repeat'] && `${errors['password-repeat'].message}`}
+                errorMessage={errors['password-repeat'] && errors['password-repeat'].message}
                 control={control}
               />
             </Wrapper>

--- a/src/screens/consul/LoginRegister/ConsulRegisterScreen.js
+++ b/src/screens/consul/LoginRegister/ConsulRegisterScreen.js
@@ -97,8 +97,8 @@ export const ConsulRegisterScreen = ({ navigation }) => {
                 placeholder={texts.consul.name}
                 autoCapitalize="none"
                 validate
-                rules={{ required: true }}
-                errorMessage={errors.password && `${texts.consul.usernameError}`}
+                rules={{ required: texts.consul.usernameError }}
+                errorMessage={errors.name && `${errors.name.message}`}
                 control={control}
               />
             </Wrapper>
@@ -114,10 +114,10 @@ export const ConsulRegisterScreen = ({ navigation }) => {
                 autoCapitalize="none"
                 validate
                 rules={{
-                  required: true,
+                  required: texts.consul.emailError,
                   pattern: { value: EMAIL_REGEX, message: texts.consul.emailInvalid }
                 }}
-                errorMessage={errors.email && `${texts.consul.emailError}`}
+                errorMessage={errors.email && `${errors.email.message}`}
                 control={control}
               />
             </Wrapper>
@@ -133,10 +133,10 @@ export const ConsulRegisterScreen = ({ navigation }) => {
                 rightIcon={rightIcon(secureTextEntry, setSecureTextEntry)}
                 validate
                 rules={{
-                  required: true,
+                  required: texts.consul.passwordError,
                   minLength: { value: 8, message: texts.consul.passwordLengthError }
                 }}
-                errorMessage={errors.password && `${texts.consul.passwordError}`}
+                errorMessage={errors.password && `${errors.password.message}`}
                 control={control}
               />
             </Wrapper>
@@ -152,11 +152,11 @@ export const ConsulRegisterScreen = ({ navigation }) => {
                 rightIcon={rightIcon(secureTextEntry, setSecureTextEntry)}
                 validate
                 rules={{
-                  required: true,
+                  required: texts.consul.passwordError,
                   minLength: { value: 8, message: texts.consul.passwordLengthError },
                   validate: (value) => value === pwd || texts.consul.passwordDoNotMatch
                 }}
-                errorMessage={errors['password-repeat'] && `${texts.consul.passwordError}`}
+                errorMessage={errors['password-repeat'] && `${errors['password-repeat'].message}`}
                 control={control}
               />
             </Wrapper>


### PR DESCRIPTION
Errors set in rules come in `errors[ITEM_NAME].messages`. In this way, you can display more than one error message on the screen.

---

## Screenshots:

||||
|--|--|--
|  ![Simulator Screen Shot - iPhone 13 - 2022-04-28 at 13 29 04](https://user-images.githubusercontent.com/11755668/165742902-3b679fb9-14ec-4a06-8a92-fe70127b4d16.png) | ![Simulator Screen Shot - iPhone 13 - 2022-04-28 at 13 29 14](https://user-images.githubusercontent.com/11755668/165742901-a8ea0cb5-ee1b-4107-8af4-1add92640179.png) | ![Simulator Screen Shot - iPhone 13 - 2022-04-28 at 13 29 37](https://user-images.githubusercontent.com/11755668/165742898-2f8e5284-d89b-4ed5-a31e-46e53c35db51.png)
|`rules:require` | `rules:minLength`  | `rules:validate`

SVA-574