### PR TITLE
fix(consul): error for cities without consul

### DIFF
--- a/src/ConsulClient.tsx
+++ b/src/ConsulClient.tsx
@@ -8,7 +8,7 @@ import { getConsulAuthToken } from './helpers';
 
 const httpLink = createHttpLink({
   // @ts-expect-error expo slug is typed as a string, which is insufficient for type checking here.
-  uri: `${secrets[namespace]?.consul.serverUrl}${secrets[namespace]?.consul.graphqlEndpoint}`
+  uri: `${secrets[namespace]?.consul?.serverUrl}${secrets[namespace]?.consul?.graphqlEndpoint}`
 });
 
 const authLink = setContext(async () => {

--- a/src/components/screens/consul/Debates/NewDebate.js
+++ b/src/components/screens/consul/Debates/NewDebate.js
@@ -122,7 +122,7 @@ export const NewDebate = ({ navigation, data, query }) => {
         <WrapperHorizontal>
           <Checkbox
             title={texts.consul.startNew.termsOfServiceLabel}
-            link={`${secrets[namespace]?.consul.serverUrl}${secrets[namespace]?.consul.termsOfService}`}
+            link={`${secrets[namespace]?.consul?.serverUrl}${secrets[namespace]?.consul?.termsOfService}`}
             linkDescription={texts.consul.startNew.termsOfServiceLinkLabel}
             checkedIcon="check-square-o"
             uncheckedIcon="square-o"

--- a/src/components/screens/consul/Proposals/NewProposal.js
+++ b/src/components/screens/consul/Proposals/NewProposal.js
@@ -237,7 +237,7 @@ export const NewProposal = ({ navigation, data, query }) => {
         <WrapperHorizontal>
           <Checkbox
             title={texts.consul.startNew.termsOfServiceLabel}
-            link={`${secrets[namespace]?.consul.serverUrl}${secrets[namespace]?.consul.termsOfService}`}
+            link={`${secrets[namespace]?.consul?.serverUrl}${secrets[namespace]?.consul?.termsOfService}`}
             linkDescription={texts.consul.startNew.termsOfServiceLinkLabel}
             checkedIcon="check-square-o"
             uncheckedIcon="square-o"

--- a/src/helpers/consul/homeData.js
+++ b/src/helpers/consul/homeData.js
@@ -94,7 +94,7 @@ export const homeData = (id) => [
           title: texts.consul.homeScreen.settings,
           query: QUERY_TYPES.CONSUL.USER_SETTINGS,
           queryVariables: {
-            link: `${secrets[namespace]?.consul.serverUrl}${secrets[namespace]?.consul.settings}`
+            link: `${secrets[namespace]?.consul?.serverUrl}${secrets[namespace]?.consul?.settings}`
           },
           rootRouteName: ScreenName.ConsulHomeScreen
         },

--- a/src/screens/consul/LoginRegister/ConsulRegisterScreen.js
+++ b/src/screens/consul/LoginRegister/ConsulRegisterScreen.js
@@ -164,7 +164,7 @@ export const ConsulRegisterScreen = ({ navigation }) => {
             <WrapperHorizontal>
               <Checkbox
                 linkDescription={texts.consul.privacyCheckLink}
-                link={`${secrets[namespace]?.consul.serverUrl}${secrets[namespace]?.consul.termsOfService}`}
+                link={`${secrets[namespace]?.consul?.serverUrl}${secrets[namespace]?.consul?.termsOfService}`}
                 title={texts.consul.privacyChecked}
                 checkedIcon="check-square-o"
                 uncheckedIcon="square-o"


### PR DESCRIPTION
- added conditional chaining for access of `consul` values
  from secrets, because cities without consul will not have
  something or consul configured, thus chaining would break

SVA-403