### PR TITLE
fix(consul): warning with empty `html` for `HtmlView`

### DIFF
--- a/src/components/consul/detail/ConsulQuestionsDescriptionListItem.js
+++ b/src/components/consul/detail/ConsulQuestionsDescriptionListItem.js
@@ -19,7 +19,9 @@ export const ConsulQuestionsDescriptionListItem = ({ questionDescriptionItem }) 
         {questionAnswers.map((item, index) => (
           <View key={index}>
             <BoldText small>{item.title}</BoldText>
-            <HtmlView html={item.description} openWebScreen={openWebScreen} />
+            {!!item.description && (
+              <HtmlView html={item.description} openWebScreen={openWebScreen} />
+            )}
           </View>
         ))}
       </Wrapper>


### PR DESCRIPTION
- added condition to check for `item.description` for not passing empty `html`, due to
  "react-native-render-html, Please provide the html or uri prop."