### PR TITLE
fix(waste reminder): send notify_at always in winter time

### DIFF
--- a/src/components/wasteCalendar/WasteReminderSettings.tsx
+++ b/src/components/wasteCalendar/WasteReminderSettings.tsx
@@ -217,7 +217,7 @@ export const WasteReminderSettings = ({
           const id = await updateReminderSettings({
             ...locationData,
             onDayBefore: state.onDayBefore,
-            reminderTime: reminderTime.toISOString(),
+            reminderTime,
             wasteType: typeKey
           });
 

--- a/src/components/wasteCalendar/WasteReminderSettings.tsx
+++ b/src/components/wasteCalendar/WasteReminderSettings.tsx
@@ -28,13 +28,13 @@ import { ReminderSettings, WasteTypeData } from '../../types';
 import { Button } from '../Button';
 import { areValidReminderSettings, parseReminderSettings } from '../../jsonValidation';
 import { SectionHeader } from '../SectionHeader';
+import { FeedbackFooter } from '../FeedbackFooter';
 
 import {
   ReminderSettingsAction,
   ReminderSettingsActionType,
   reminderSettingsReducer
 } from './ReminderSettingsReducer';
-import { FeedbackFooter } from '../FeedbackFooter';
 
 const showErrorAlert = () => {
   Alert.alert(texts.wasteCalendar.errorOnUpdateTitle, texts.wasteCalendar.errorOnUpdateBody);
@@ -245,7 +245,7 @@ export const WasteReminderSettings = ({
 
   return (
     <ScrollView
-      keyboardShouldPersistTaps="always"
+      keyboardShouldPersistTaps="handled"
       refreshControl={
         <RefreshControl
           refreshing={loading}

--- a/src/pushNotifications/WasteReminder.ts
+++ b/src/pushNotifications/WasteReminder.ts
@@ -9,7 +9,7 @@ const namespace = appJson.expo.slug as keyof typeof secrets;
 
 type SettingInfo = {
   city: string;
-  reminderTime: string;
+  reminderTime: Date;
   onDayBefore: boolean;
   street: string;
   wasteType: string;
@@ -39,7 +39,7 @@ export const updateReminderSettings = async ({
     },
     body: JSON.stringify({
       waste_registration: {
-        notify_at: reminderTime,
+        notify_at: `${reminderTime.getHours()}:${reminderTime.getMinutes()}+01:00`,
         notify_for_waste_type: wasteType,
         street,
         city,


### PR DESCRIPTION
- the database time field is always represented at 01.01.2000 so when saving, we need to force a winter time even if we have summer
  - this way the server should always be able to take the right time into account across the whole year regarding one database entry
  - sending a `"notify_at": "16:00+01:00"` results in `"notify_at_time": "16:00"`
  - sending a `"notify_at": "16:00+02:00"` would result in `"notify_at_time": "15:00"`
- adjusted code for consistency
  - we always use `keyboardShouldPersistTaps="handled"` so it should here as well

SVA-467