### PR TITLE
feat(intro): repeat app intro

### DIFF
--- a/src/OnboardingManager.tsx
+++ b/src/OnboardingManager.tsx
@@ -8,7 +8,7 @@ import { Initializer, Initializers } from './helpers/initializationHelper';
 import { AppIntroScreen } from './screens';
 import { SettingsContext } from './SettingsProvider';
 
-const ONBOARDING_STORE_KEY = 'ONBOARDING_STORE_KEY';
+export const ONBOARDING_STORE_KEY = 'ONBOARDING_STORE_KEY';
 
 // this hook ensures that all settings will be properly initialized, even when onboarding was completed before the settings where available, or an error occured
 const useInitializeAfterOnboarding = (onboardingComplete: boolean) => {

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -476,7 +476,7 @@ export const texts = {
     onboarding: {
       onActivate: 'Beim nächsten Start wird die App-Einführung angezeigt.',
       onDeactivate: 'Die App-Einführung wird beim nächsten Start nicht angezeigt.',
-      ok: 'OK'
+      ok: 'Ok'
     },
     permanentFilter: {
       sectionHeader: 'Datenquellen'

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -473,6 +473,11 @@ export const texts = {
       save: 'Speichern',
       sectionHeader: 'Standort'
     },
+    onboarding: {
+      onActivate: 'Beim nächsten Start wird die App-Einführung angezeigt.',
+      onDeactivate: 'Die App-Einführung wird beim nächsten Start nicht angezeigt.',
+      ok: 'OK'
+    },
     permanentFilter: {
       sectionHeader: 'Datenquellen'
     }
@@ -492,6 +497,7 @@ export const texts = {
       textList: 'Textliste'
     },
     locationService: 'Ortungsdienste',
+    onboarding: 'App-Einführung',
     pushNotifications: 'Push-Benachrichtigungen',
     tabs: {
       general: 'Allgemein',

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -23,6 +23,7 @@ import {
 import { useMatomoTrackScreenView } from '../hooks';
 import { PushNotificationStorageKeys, setInAppPermission } from '../pushNotifications';
 import { SettingsContext } from '../SettingsProvider';
+import { ONBOARDING_STORE_KEY } from '../OnboardingManager';
 
 const { MATOMO_TRACKING } = consts;
 
@@ -57,8 +58,6 @@ const INITIAL_FILTER = [
   { id: TOP_FILTER.GENERAL, title: texts.settingsTitles.tabs.general, selected: true },
   { id: TOP_FILTER.LIST_TYPES, title: texts.settingsTitles.tabs.listTypes, selected: false }
 ];
-
-const ONBOARDING_STORE_KEY = 'ONBOARDING_STORE_KEY';
 
 export const SettingsScreen = () => {
   const { globalSettings } = useContext(SettingsContext);
@@ -147,8 +146,8 @@ export const SettingsScreen = () => {
           data: [
             {
               title: texts.settingsTitles.onboarding,
-              topDivider: false,
-              value: onboarding === 'complete' ? false : true,
+              topDivider: true,
+              value: onboarding === 'incomplete',
               onActivate: () =>
                 Alert.alert(
                   texts.settingsTitles.onboarding,

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -13,7 +13,13 @@ import {
 } from '../components';
 import { ListSettings, LocationSettings, PermanentFilterSettings } from '../components/settings';
 import { colors, consts, texts } from '../config';
-import { createMatomoUserId, matomoSettings, readFromStore, removeMatomoUserId } from '../helpers';
+import {
+  addToStore,
+  createMatomoUserId,
+  matomoSettings,
+  readFromStore,
+  removeMatomoUserId
+} from '../helpers';
 import { useMatomoTrackScreenView } from '../hooks';
 import { PushNotificationStorageKeys, setInAppPermission } from '../pushNotifications';
 import { SettingsContext } from '../SettingsProvider';
@@ -51,6 +57,8 @@ const INITIAL_FILTER = [
   { id: TOP_FILTER.GENERAL, title: texts.settingsTitles.tabs.general, selected: true },
   { id: TOP_FILTER.LIST_TYPES, title: texts.settingsTitles.tabs.listTypes, selected: false }
 ];
+
+const ONBOARDING_STORE_KEY = 'ONBOARDING_STORE_KEY';
 
 export const SettingsScreen = () => {
   const { globalSettings } = useContext(SettingsContext);
@@ -126,6 +134,42 @@ export const SettingsScreen = () => {
                     }
                   ],
                   { cancelable: false }
+                )
+            }
+          ]
+        });
+      }
+
+      if (settings.onboarding) {
+        const onboarding = await readFromStore(ONBOARDING_STORE_KEY);
+
+        additionalSectionedData.push({
+          data: [
+            {
+              title: texts.settingsTitles.onboarding,
+              topDivider: false,
+              value: onboarding === 'complete' ? false : true,
+              onActivate: () =>
+                Alert.alert(
+                  texts.settingsTitles.onboarding,
+                  texts.settingsContents.onboarding.onActivate,
+                  [
+                    {
+                      text: texts.settingsContents.onboarding.ok,
+                      onPress: () => addToStore(ONBOARDING_STORE_KEY, 'incomplete')
+                    }
+                  ]
+                ),
+              onDeactivate: () =>
+                Alert.alert(
+                  texts.settingsTitles.onboarding,
+                  texts.settingsContents.onboarding.onDeactivate,
+                  [
+                    {
+                      text: texts.settingsContents.onboarding.ok,
+                      onPress: () => addToStore(ONBOARDING_STORE_KEY, 'complete')
+                    }
+                  ]
                 )
             }
           ]


### PR DESCRIPTION
- added an option to the `SettingsScreen` so that
  users can see the intro of the application again
- added new texts to the `texts` file for the intro
  option in the settings

---

## How to test:
* [ ] Android portrait mode
* [x] iOS portrait mode
* [ ] Android landscape mode
* [x] iOS landscape mode

## Screenshots:

|SettingsScreen.js|SettingsScreen.js|SettingsScreen.js|AppIntroScreen.js|
|--|--|--|--|
![Simulator Screen Shot - iPhone 13 - 2022-05-04 at 10 36 26](https://user-images.githubusercontent.com/11755668/166648028-5d47c18d-00f1-4b6d-a347-6f5b8aa29bbd.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-04 at 10 36 30](https://user-images.githubusercontent.com/11755668/166648062-4f923bcf-2e29-49c3-a1e3-b3ebebc80e4d.png) |  ![Simulator Screen Shot - iPhone 13 - 2022-05-04 at 10 36 34](https://user-images.githubusercontent.com/11755668/166648096-46928fa1-16a8-4abe-8e5e-36c5d7099dc8.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-04 at 10 36 45](https://user-images.githubusercontent.com/11755668/166648168-8606df11-75c1-4d43-8e92-7599ca4f412d.png)
|Settings Screen|If the user turns on this option, they will see an alert|If the user turns this option off, they will see an alert|If the application is restarted with the option turned on, the intro will appear on the screen|

SVA-458