### PR TITLE
feat(volunteer): read/unread status of conversations

### DIFF
--- a/src/components/TextListItem.tsx
+++ b/src/components/TextListItem.tsx
@@ -12,14 +12,14 @@ import { BoldText, RegularText } from './Text';
 import { Touchable } from './Touchable';
 
 type ItemData = {
-  routeName: string;
+  bottomDivider?: boolean;
+  onPress?: (navigation: any) => void;
   params: Record<string, unknown>;
+  picture?: { url: string };
+  routeName: string;
   subtitle?: string;
   title: string;
-  bottomDivider?: boolean;
   topDivider?: boolean;
-  picture?: { url: string };
-  onPress?: (navigation: any) => void;
 };
 
 type Props = {
@@ -38,16 +38,16 @@ export const TextListItem: NamedExoticComponent<Props> & {
   leftImage?: boolean;
   navigation: StackNavigationProp<Record<string, any>>;
   noSubtitle?: boolean;
-}>(({ navigation, item, noSubtitle, leftImage }) => {
+}>(({ item, leftImage, navigation, noSubtitle }) => {
   const {
-    routeName: name,
+    bottomDivider,
+    onPress,
     params,
+    picture,
+    routeName: name,
     subtitle,
     title,
-    bottomDivider,
-    topDivider,
-    picture,
-    onPress
+    topDivider
   } = item;
   const titleText = <BoldText>{trimNewLines(title)}</BoldText>;
   const navigate = () => navigation && navigation.push(name, params);
@@ -95,13 +95,13 @@ const styles = StyleSheet.create({
 TextListItem.displayName = 'TextListItem';
 
 TextListItem.propTypes = {
-  navigation: PropTypes.object,
   item: PropTypes.object.isRequired,
-  noSubtitle: PropTypes.bool,
-  leftImage: PropTypes.bool
+  leftImage: PropTypes.bool,
+  navigation: PropTypes.object,
+  noSubtitle: PropTypes.bool
 };
 
 TextListItem.defaultProps = {
-  noSubtitle: false,
-  leftImage: false
+  leftImage: false,
+  noSubtitle: false
 };

--- a/src/components/volunteer/VolunteerConversationListItem.tsx
+++ b/src/components/volunteer/VolunteerConversationListItem.tsx
@@ -1,0 +1,77 @@
+import { StackNavigationProp } from '@react-navigation/stack';
+import PropTypes from 'prop-types';
+import React, { memo, NamedExoticComponent, Validator } from 'react';
+import { StyleSheet } from 'react-native';
+import { ListItem } from 'react-native-elements';
+
+import { colors, consts, Icon, normalize } from '../../config';
+import { trimNewLines } from '../../helpers';
+import { BoldText, RegularText } from '../Text';
+import { Touchable } from '../Touchable';
+
+type ItemData = {
+  bottomDivider?: boolean;
+  onPress?: (navigation: any) => void;
+  params: Record<string, unknown>;
+  routeName: string;
+  status: 'read' | 'unread';
+  subtitle?: string;
+  title: string;
+};
+
+type Props = {
+  item: ItemData;
+  navigation: StackNavigationProp<Record<string, any>>;
+};
+
+export const VolunteerConversationListItem: NamedExoticComponent<Props> & {
+  propTypes?: Record<string, Validator<any>>;
+} = memo<{
+  item: ItemData;
+  navigation: StackNavigationProp<Record<string, any>>;
+}>(({ item, navigation }) => {
+  const { routeName: name, params, subtitle, title, bottomDivider, onPress, status } = item;
+  const titleText = trimNewLines(title);
+  const navigate = () => navigation && navigation.push(name, params);
+
+  return (
+    <ListItem
+      title={
+        status === 'unread' ? (
+          <BoldText small>{subtitle}</BoldText>
+        ) : (
+          <RegularText small>{subtitle}</RegularText>
+        )
+      }
+      subtitle={
+        status === 'unread' ? (
+          <BoldText>{titleText}</BoldText>
+        ) : (
+          <RegularText>{titleText}</RegularText>
+        )
+      }
+      bottomDivider={bottomDivider}
+      containerStyle={listItemStyles.contentContainerStyle}
+      rightIcon={<Icon.ArrowRight />}
+      onPress={() => (onPress ? onPress(navigation) : navigate())}
+      disabled={!navigation}
+      delayPressIn={0}
+      Component={Touchable}
+      accessibilityLabel={`(${title}) ${consts.a11yLabel.button}`}
+    />
+  );
+});
+
+const listItemStyles = StyleSheet.create({
+  contentContainerStyle: {
+    backgroundColor: colors.transparent,
+    paddingVertical: normalize(12)
+  }
+});
+
+VolunteerConversationListItem.displayName = 'VolunteerConversationListItem';
+
+VolunteerConversationListItem.propTypes = {
+  item: PropTypes.object.isRequired,
+  navigation: PropTypes.object
+};

--- a/src/components/volunteer/index.ts
+++ b/src/components/volunteer/index.ts
@@ -1,6 +1,7 @@
 export * from './VolunteerAppointmentsCard';
 export * from './VolunteerAvatar';
 export * from './VolunteerCalendar';
+export * from './VolunteerConversationListItem';
 export * from './VolunteerConversationsSection';
 export * from './VolunteerEventAttending';
 export * from './VolunteerEventRecord';

--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -214,6 +214,7 @@ const parseVolunteers = (data, query, skipLastDivider, withDate, isSectioned) =>
     routeName: ScreenName.VolunteerDetail,
     onPress: volunteer.onPress,
     listDate: volunteer.listDate,
+    status: volunteer.status,
     params: {
       title: getTitleForQuery(query, volunteer),
       query,

--- a/src/hooks/listHooks.js
+++ b/src/hooks/listHooks.js
@@ -4,6 +4,7 @@ import React, { useCallback, useContext } from 'react';
 
 import { CardListItem } from '../components/CardListItem';
 import { TextListItem } from '../components/TextListItem';
+import { VolunteerConversationListItem } from '../components/volunteer/VolunteerConversationListItem';
 import { VolunteerPostListItem } from '../components/volunteer/VolunteerPostListItem';
 import { consts } from '../config';
 import { QUERY_TYPES } from '../queries';
@@ -67,6 +68,20 @@ export const useRenderItem = (query, navigation, options = {}) => {
               post={item}
               bottomDivider={isArray(section?.data) ? section.data.length - 1 !== index : undefined}
               openWebScreen={options.openWebScreen}
+            />
+          );
+        }
+
+        if (query === QUERY_TYPES.VOLUNTEER.CONVERSATIONS) {
+          return (
+            <VolunteerConversationListItem
+              item={{
+                ...item,
+                bottomDivider: isArray(section?.data)
+                  ? section.data.length - 1 !== index
+                  : undefined
+              }}
+              navigation={navigation}
             />
           );
         }

--- a/src/queries/volunteer/conversation.ts
+++ b/src/queries/volunteer/conversation.ts
@@ -1,4 +1,8 @@
-import { volunteerApiV1Url, volunteerAuthToken } from '../../helpers/volunteerHelper';
+import {
+  volunteerApiV1Url,
+  volunteerApiV2Url,
+  volunteerAuthToken
+} from '../../helpers/volunteerHelper';
 import { VolunteerConversation } from '../../types';
 
 export const conversations = async () => {
@@ -13,7 +17,7 @@ export const conversations = async () => {
     }
   };
 
-  return (await fetch(`${volunteerApiV1Url}mail`, fetchObj)).json();
+  return (await fetch(`${volunteerApiV2Url}mail`, fetchObj)).json();
 };
 
 export const conversation = async (id: number) => {
@@ -28,7 +32,7 @@ export const conversation = async (id: number) => {
     }
   };
 
-  return (await fetch(`${volunteerApiV1Url}mail/${id}/entries`, fetchObj)).json();
+  return (await fetch(`${volunteerApiV2Url}mail/${id}/entries`, fetchObj)).json();
 };
 
 export const conversationRecipients = async (id: number) => {


### PR DESCRIPTION
- updated api endpoints to v2 for new conversation/mail
  functionalities to mark conversations read and get the status
  read/unread
- created a new list item for conversations that are aware of
  conversation statuses and render bold texts if unread
  and regular texts if read
  - based on `TextListItem` with adjustments
- restructured code in `TextListItem` to match
  our best practices

HDVT-23

|unread|read|
|---|---|
|![IMG_0057](https://user-images.githubusercontent.com/1942953/168838389-f2db33c5-2fc8-4e55-9740-5472fb169263.PNG)|![IMG_0058](https://user-images.githubusercontent.com/1942953/168838415-dc33338c-9258-44a7-866a-0f33b50cbd14.PNG)|

there is a bug which causes the date/time to update to the date/time when a message is read.
i already opened an issue for this: https://github.com/ikuseiGmbH/smart-village-app-humhub-ext/issues/21