### PR TITLE
feat(feedback footer): check global setting for rendering

### DIFF
--- a/src/SettingsProvider.js
+++ b/src/SettingsProvider.js
@@ -4,7 +4,8 @@ import React, { createContext, useState } from 'react';
 export const SettingsContext = createContext({
   globalSettings: {
     filter: {},
-    sections: {}
+    sections: {},
+    settings: {}
   }
 });
 

--- a/src/components/FeedbackFooter.tsx
+++ b/src/components/FeedbackFooter.tsx
@@ -1,14 +1,19 @@
 import { useNavigation } from '@react-navigation/native';
-import React, { FC } from 'react';
+import React, { FC, useContext } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 
 import { texts } from '../config';
+import { SettingsContext } from '../SettingsProvider';
 import { ScreenName } from '../types';
 
 import { BoldText } from './Text';
 
 export const FeedbackFooter: FC = () => {
   const navigation = useNavigation();
+  // @ts-expect-error settings are not properly typed
+  const feedbackFooter = useContext(SettingsContext).globalSettings.settings?.feedbackFooter;
+
+  if (!feedbackFooter) return null;
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
- added a new check for global settings `settings.feedbackFooter`
  in order to render the feedback footer or not, default: false
- added an missing initial empty settings object to the global settings type
  in the context to satisfy its types, which would need to go deeper in detail

SVA-613

---

example global settings on main-server:

```
"settings": {
  ...
  "pushNotifications": false,
  "feedbackFooter": true
  ...
}
```