### PR TITLE
feat(consul): filter draft proposal

### DIFF
--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -68,6 +68,7 @@ export const texts = {
     comments: 'Kommentare',
     delete: 'Löschen',
     documents: 'Unterlagen',
+    draft: 'Entwurf',
     email: 'E-Mail',
     emailError: 'E-Mail muss korrekt ausgefüllt werden',
     emailInvalid: 'E-Mail ungültig',

--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -270,7 +270,7 @@ const parseConsulData = (data, query, skipLastDivider) => {
     }
 
     if (query === QUERY_TYPES.CONSUL.PUBLIC_PROPOSALS && !consulData.published) {
-      title = `${texts.consul.draft} - ${consulData.title ?? consulData.body}`;
+      title = `${texts.consul.draft} - ${title}`;
     }
 
     return {

--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -257,9 +257,8 @@ const querySwitcherForDetail = (query) => {
 
 const parseConsulData = (data, query, skipLastDivider) => {
   return data?.nodes?.map((consulData, index) => {
-    let subtitle = momentFormatUtcToLocal(
-      consulData.publicCreatedAt ? consulData.publicCreatedAt : consulData.createdAt
-    );
+    let subtitle = momentFormatUtcToLocal(consulData.publicCreatedAt ?? consulData.createdAt);
+    let title = consulData.title ?? consulData.body;
 
     if (query === QUERY_TYPES.CONSUL.PUBLIC_COMMENTS) {
       subtitle = consulData.commentableTitle;
@@ -270,13 +269,18 @@ const parseConsulData = (data, query, skipLastDivider) => {
         momentFormatUtcToLocal(consulData.endsAt);
     }
 
+    if (query === QUERY_TYPES.CONSUL.PUBLIC_PROPOSALS && !consulData.published) {
+      title = `${texts.consul.draft} - ${consulData.title ?? consulData.body}`;
+    }
+
     return {
       id: consulData.id,
-      title: consulData.title ? consulData.title : consulData.body,
+      title,
       createdAt: consulData.publicCreatedAt,
       cachedVotesUp: consulData.cachedVotesUp,
       subtitle,
       routeName: ScreenName.ConsulDetailScreen,
+      published: consulData.published,
       params: {
         title: getTitleForQuery(query),
         query: querySwitcherForDetail(query),

--- a/src/hooks/listHooks.js
+++ b/src/hooks/listHooks.js
@@ -62,6 +62,8 @@ export const useRenderItem = (query, navigation, options = {}) => {
     }
     default: {
       renderItem = ({ item, index, section }) => {
+        if (query === QUERY_TYPES.CONSUL.PROPOSALS && !item.published) return;
+
         if (query === QUERY_TYPES.VOLUNTEER.POSTS) {
           return (
             <VolunteerPostListItem

--- a/src/hooks/listHooks.js
+++ b/src/hooks/listHooks.js
@@ -62,8 +62,6 @@ export const useRenderItem = (query, navigation, options = {}) => {
     }
     default: {
       renderItem = ({ item, index, section }) => {
-        if (query === QUERY_TYPES.CONSUL.PROPOSALS && !item.published) return;
-
         if (query === QUERY_TYPES.VOLUNTEER.POSTS) {
           return (
             <VolunteerPostListItem

--- a/src/queries/consul/Proposals/proposals.js
+++ b/src/queries/consul/Proposals/proposals.js
@@ -9,6 +9,7 @@ export const GET_PROPOSALS = gql`
         publicCreatedAt
         commentsCount
         cachedVotesUp
+        published
       }
     }
   }

--- a/src/queries/consul/User/user.js
+++ b/src/queries/consul/User/user.js
@@ -18,8 +18,9 @@ export const USER = gql`
         nodes {
           id
           title
-          publicCreatedAt
           commentsCount
+          publicCreatedAt
+          published
         }
       }
       publicComments {

--- a/src/screens/consul/ConsulIndexScreen.js
+++ b/src/screens/consul/ConsulIndexScreen.js
@@ -79,6 +79,10 @@ export const ConsulIndexScreen = ({ navigation, route }) => {
       if (query !== QUERY_TYPES.CONSUL.USER || query !== QUERY_TYPES.CONSUL.POLLS)
         listItems = sortingHelper(selectedSortingType.id, listItems);
 
+      if (query === QUERY_TYPES.CONSUL.PROPOSALS) {
+        listItems = listItems.filter(({ published }) => published);
+      }
+
       return listItems;
     },
     [sortingType, filterType, isLoading]


### PR DESCRIPTION
- added a new `published` field to the `proposals` and
  `user` query to see if the `Proposal` is drafted
- added the published field to listItemParser to
  be able to use it in list item
- added if condition to `listItemParser` to add
  `draft` text to `title` according to `Public Proposals`
  query and according to `published` data
- add a new if condition to `listHooks` to not show it on
  proposal data listing page in draft state
- edited subtitle in `listItemParser` to improve
  readability
- added draft text to `texts.js`

SVA-617

## How to test:
* [ ] Android portrait mode
* [x] iOS portrait mode
* [ ] Android landscape mode
* [x] iOS landscape mode


## Screenshots:

|Before List|After List|My Content|
|--|--|--|
![Simulator Screen Shot - iPhone 13 - 2022-05-27 at 10 39 53](https://user-images.githubusercontent.com/11755668/170663925-1172a9b4-830b-4745-b0a8-c09bb6b5e47e.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-27 at 10 39 23](https://user-images.githubusercontent.com/11755668/170663933-b6d92fe6-23f6-421b-b809-055537aa9230.png) |  ![Simulator Screen Shot - iPhone 13 - 2022-05-27 at 10 39 18](https://user-images.githubusercontent.com/11755668/170663936-97d6063a-be65-4ac5-87bb-51d8fb397cb8.png) | 
|Proposals.js|Proposals.js||



