### PR TITLE
feat(consul): add poll results

### DIFF
--- a/src/components/consul/detail/ConsulQuestionsList.js
+++ b/src/components/consul/detail/ConsulQuestionsList.js
@@ -9,7 +9,7 @@ import { Wrapper } from '../../Wrapper';
 import { ConsulQuestionsDescriptionListItem } from './ConsulQuestionsDescriptionListItem';
 import { ConsulQuestionsListItem } from './ConsulQuestionsListItem';
 
-export const ConsulQuestionsList = ({ data, refetch, token, disabled }) => {
+export const ConsulQuestionsList = ({ data, refetch, token, disabled, resultsReadyToBeShown }) => {
   const [isUserAnswer, setIsUserAnswer] = useState(false);
 
   useEffect(() => {
@@ -36,11 +36,12 @@ export const ConsulQuestionsList = ({ data, refetch, token, disabled }) => {
         data={data}
         renderItem={({ item, index }) => (
           <ConsulQuestionsListItem
-            questionItem={item}
-            index={index}
-            refetch={refetch}
-            token={token}
             disabled={disabled}
+            index={index}
+            questionItem={item}
+            refetch={refetch}
+            resultsReadyToBeShown={resultsReadyToBeShown}
+            token={token}
           />
         )}
       />
@@ -70,5 +71,6 @@ ConsulQuestionsList.propTypes = {
   data: PropTypes.array,
   disabled: PropTypes.bool,
   refetch: PropTypes.func,
+  resultsReadyToBeShown: PropTypes.bool,
   token: PropTypes.string
 };

--- a/src/components/consul/detail/ConsulQuestionsListItem.js
+++ b/src/components/consul/detail/ConsulQuestionsListItem.js
@@ -61,15 +61,12 @@ export const ConsulQuestionsListItem = ({
           style={[
             styles.answerContainer,
             (resultsReadyToBeShown && highestVote === item.totalVotesPercentage) ||
-            (!resultsReadyToBeShown &&
-              answersGivenByCurrentUser[0] &&
-              answersGivenByCurrentUser[0].answer === item.title)
+            (!resultsReadyToBeShown && answersGivenByCurrentUser?.[0]?.answer === item.title)
               ? styles.selectedContainer
               : null,
             !resultsReadyToBeShown &&
               !disabled &&
-              answersGivenByCurrentUser[0] &&
-              answersGivenByCurrentUser[0].answer !== item.title &&
+              answersGivenByCurrentUser?.[0]?.answer === item.title &&
               styles.disabledAnswerContainer
           ]}
         >

--- a/src/components/screens/consul/Polls/PollDetail.js
+++ b/src/components/screens/consul/Polls/PollDetail.js
@@ -24,6 +24,7 @@ export const PollDetail = ({ data, refetch, route, navigation }) => {
   const [userId, setUserId] = useState();
 
   const {
+    resultsReadyToBeShown,
     comments,
     commentsCount,
     description,
@@ -96,9 +97,10 @@ export const PollDetail = ({ data, refetch, route, navigation }) => {
       {!!questions && (
         <ConsulQuestionsList
           data={questions}
-          refetch={refetch}
-          token={token}
           disabled={endsDate >= currentDate}
+          refetch={refetch}
+          resultsReadyToBeShown={resultsReadyToBeShown}
+          token={token}
         />
       )}
 

--- a/src/queries/consul/Polls/polls.js
+++ b/src/queries/consul/Polls/polls.js
@@ -30,6 +30,7 @@ export const GET_POLL = gql`
       endsAt
       createdAt
       token
+      resultsReadyToBeShown
       comments {
         id
         parentId
@@ -55,6 +56,8 @@ export const GET_POLL = gql`
           id
           title
           description
+          totalVotes
+          totalVotesPercentage
         }
         answersGivenByCurrentUser {
           id


### PR DESCRIPTION
- added new fields to the `poll query to show the
  results of the poll
- added `resultsReadyToBeShown` prop to
  `ConsulQuestionsList` and `ConsulQuestionsListItem`
  which allows us to see if it wants to show poll results
- added `totalVotes` and `totalVotesPercentage` data to
  `ConsulQuestionsListItem.js` to show poll results on
  the screen according to `resultsReadyToBeShown` data
- used the `Math.max()` function to select the highest
  rated answer


## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode


## Screenshots:


|||
|--|--|
![Simulator Screen Shot - iPhone 13 - 2022-05-27 at 15 10 53](https://user-images.githubusercontent.com/11755668/170705895-f9ad09a1-6706-43a0-a9b4-e56a9e3eda99.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-27 at 15 10 32](https://user-images.githubusercontent.com/11755668/170705902-b3d89e9d-232d-4d18-82b2-5b8daa475183.png)
|Poll not expired and answered|Expired and the winning answer is poll|


SVA-597
