### PR TITLE
feat(bus bb): remove teaser and fix order typo

### DIFF
--- a/src/screens/BB-BUS/DetailScreen.js
+++ b/src/screens/BB-BUS/DetailScreen.js
@@ -32,7 +32,7 @@ const TEXT_BLOCKS_SORTER = {
   Verfahrensablauf: 6,
   Formulare: 7,
   Fristen: 8,
-  'Kosten (Gebühren, Auslagen,etc.)': 9,
+  'Kosten (Gebühren, Auslagen, etc.)': 9,
   'Rechtsgrundlage(n)': 10,
   'Hinweise (Besonderheiten)': 11,
   Urheber: 12,
@@ -80,6 +80,7 @@ const parseTextBlocks = (service) => {
     // filter text blocks, we do not want to render
     _remove(sortedTextBlocks, (textBlock) => {
       return (
+        textBlock.name.toUpperCase() === 'TEASER' ||
         textBlock.name.toUpperCase() === 'FACHLICH FREIGEGEBEN DURCH' ||
         textBlock.name.toUpperCase() === 'FACHLICH FREIGEGEBEN AM'
       );


### PR DESCRIPTION
- adjusted title for "Kosten..." to match the api response
  in order to be sorted correctly
- added `TEASER` as block to be removed from rendering

SVA-576

|before|after|
|---|---|
|![IMG_0068](https://user-images.githubusercontent.com/1942953/171187170-dcf78678-7459-47c4-9deb-a4518c86e538.PNG)|![IMG_0067](https://user-images.githubusercontent.com/1942953/171187186-94b1d78f-df6b-48c2-af73-ebba7be0afd1.PNG)|