### PR TITLE
fix(categories): avoid intro text on sub category lists

### DIFF
--- a/src/components/CategoryList.js
+++ b/src/components/CategoryList.js
@@ -29,7 +29,7 @@ export class CategoryList extends React.PureComponent {
   };
 
   render() {
-    const { data, navigation, noSubtitle, refreshControl } = this.props;
+    const { data, navigation, noSubtitle, refreshControl, hasSectionHeader } = this.props;
 
     // Sorting data alphabetically
     data.sort((a, b) => a.title.localeCompare(b.title));
@@ -64,6 +64,7 @@ export class CategoryList extends React.PureComponent {
         )}
         renderSectionHeader={this.renderSectionHeader}
         ListHeaderComponent={
+          hasSectionHeader &&
           !!texts.categoryList.intro && (
             <Wrapper>
               <RegularText>{texts.categoryList.intro}</RegularText>


### PR DESCRIPTION
- added check for `hasSectionHeader` in order to render the
  intro text, because only the first category list screen has sections
  and sub category list screen receives always `false`
  - in order to test this, `texts.categoryList.intro` needs some test string

SVA-615

|first category list screen|sub category list before|sub category list after|
|---|---|---|
|![IMG_0070](https://user-images.githubusercontent.com/1942953/171191228-b9ac43c4-4055-4fa2-bb67-57d1a5796aa1.PNG)|![IMG_0069](https://user-images.githubusercontent.com/1942953/171191240-12cbed55-bc4b-4574-bc5b-66e0e6d9f1f9.PNG)|![IMG_F56A90110032-1](https://user-images.githubusercontent.com/1942953/171191257-0fbeee79-b30d-4ba1-8efa-02d2dfdf5daf.jpeg)|