### PR TITLE
fix(home screen): render button for all points of interest and tours

### DIFF
--- a/src/components/HomeSection.tsx
+++ b/src/components/HomeSection.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useQuery } from 'react-apollo';
 
 import { useHomeRefresh } from '../hooks';
-import { getQuery } from '../queries';
+import { getQuery, QUERY_TYPES } from '../queries';
 
 import { DataListSection } from './DataListSection';
 
@@ -43,6 +43,13 @@ export const HomeSection = ({
 
   useHomeRefresh(refetch);
 
+  let showButton = !!data?.[query]?.length;
+
+  if (query === QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS) {
+    showButton =
+      !!data?.[QUERY_TYPES.POINTS_OF_INTEREST]?.length || !!data?.[QUERY_TYPES.TOURS]?.length;
+  }
+
   return (
     <DataListSection
       buttonTitle={buttonTitle}
@@ -56,7 +63,7 @@ export const HomeSection = ({
       sectionData={data}
       sectionTitle={title}
       sectionTitleDetail={titleDetail}
-      showButton={!!data?.[query]?.length}
+      showButton={showButton}
     />
   );
 };

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -146,6 +146,7 @@ export const HomeScreen = ({ navigation, route }) => {
           publicJsonFile="homeCarousel"
           refreshTimeKey="publicJsonFile-homeCarousel"
         />
+
         <Widgets widgetConfigs={widgetConfigs} />
 
         {showNews &&
@@ -197,13 +198,14 @@ export const HomeScreen = ({ navigation, route }) => {
           <HomeSection
             buttonTitle={buttonEvents}
             title={headlineEvents}
+            fetchPolicy={fetchPolicy}
             navigate={() => navigation.navigate(NAVIGATION.EVENT_RECORDS_INDEX)}
             navigation={navigation}
             query={QUERY_TYPES.EVENT_RECORDS}
             queryVariables={{ limit: 3, order: 'listDate_ASC' }}
-            fetchPolicy={fetchPolicy}
           />
         )}
+
         {route.params?.isDrawer && (
           <>
             <Service navigation={navigation} />


### PR DESCRIPTION
- adjusted condition to set `showButton` depending on correct `query`
  in order to check the received data length
- reordered `fetchPolicy` for consistency

SVA-614

|before|after|
|---|---|
|![IMG_0072](https://user-images.githubusercontent.com/1942953/171195727-09c8116b-b5cd-486e-8d0e-eb8b4160de00.PNG)|![IMG_0073](https://user-images.githubusercontent.com/1942953/171195807-0c8ff2f8-7a12-42b6-b9ec-b6ee8ca0d615.PNG)|