### PR TITLE
fix(categories): consider possible `location` param correctly

### DIFF
--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -173,7 +173,7 @@ const parseTours = (data, skipLastDivider) => {
   }));
 };
 
-const parseCategories = (data, skipLastDivider, routeName = ScreenName.Category) => {
+const parseCategories = (data, skipLastDivider, routeName, queryVariables) => {
   return data?.map((category, index) => ({
     id: category.id,
     title: category.name,
@@ -185,10 +185,20 @@ const parseCategories = (data, skipLastDivider, routeName = ScreenName.Category)
     parent: category.parent,
     params: {
       title: category.name,
-      categories: parseCategories(category.children, skipLastDivider, ScreenName.Index),
+      categories: parseCategories(
+        category.children,
+        skipLastDivider,
+        ScreenName.Index,
+        queryVariables
+      ),
       query:
         category.pointsOfInterestTreeCount > 0 ? QUERY_TYPES.POINTS_OF_INTEREST : QUERY_TYPES.TOURS,
-      queryVariables: { limit: 15, order: 'name_ASC', category: `${category.name}` },
+      queryVariables: {
+        limit: 15,
+        order: 'name_ASC',
+        category: `${category.name}`,
+        location: queryVariables?.location
+      },
       rootRouteName: ROOT_ROUTE_NAMES.POINTS_OF_INTEREST_AND_TOURS
     },
     bottomDivider: !skipLastDivider || index !== data.length - 1
@@ -213,7 +223,7 @@ const parsePointsOfInterestAndTours = (data) => {
 export const parseListItemsFromQuery = (query, data, titleDetail, options = {}) => {
   if (!data) return;
 
-  const { bookmarkable = true, skipLastDivider = false, withDate = true } = options;
+  const { bookmarkable = true, skipLastDivider = false, withDate = true, queryVariables } = options;
 
   switch (query) {
     case QUERY_TYPES.EVENT_RECORDS:
@@ -227,7 +237,7 @@ export const parseListItemsFromQuery = (query, data, titleDetail, options = {}) 
     case QUERY_TYPES.TOURS:
       return parseTours(data[query], skipLastDivider);
     case QUERY_TYPES.CATEGORIES:
-      return parseCategories(data[query], skipLastDivider);
+      return parseCategories(data[query], skipLastDivider, ScreenName.Category, queryVariables);
     case QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS:
       return parsePointsOfInterestAndTours(data);
   }

--- a/src/queries/categories.js
+++ b/src/queries/categories.js
@@ -1,59 +1,59 @@
 import gql from 'graphql-tag';
 
 export const GET_CATEGORIES = gql`
-  query Categories($ids: [ID!], $excludeIds: [ID!]) {
+  query Categories($ids: [ID!], $excludeIds: [ID!], $location: String) {
     categories(ids: $ids, excludeIds: $excludeIds) {
       id
       name
-      pointsOfInterestCount
-      pointsOfInterestTreeCount
-      toursCount
-      toursTreeCount
+      pointsOfInterestCount(location: $location)
+      pointsOfInterestTreeCount(location: $location)
+      toursCount(location: $location)
+      toursTreeCount(location: $location)
       parent {
         id
       }
       children {
         id
         name
-        pointsOfInterestCount
-        pointsOfInterestTreeCount
-        toursCount
-        toursTreeCount
+        pointsOfInterestCount(location: $location)
+        pointsOfInterestTreeCount(location: $location)
+        toursCount(location: $location)
+        toursTreeCount(location: $location)
         children {
           id
           name
-          pointsOfInterestCount
-          pointsOfInterestTreeCount
-          toursCount
-          toursTreeCount
+          pointsOfInterestCount(location: $location)
+          pointsOfInterestTreeCount(location: $location)
+          toursCount(location: $location)
+          toursTreeCount(location: $location)
           children {
             id
             name
-            pointsOfInterestCount
-            pointsOfInterestTreeCount
-            toursCount
-            toursTreeCount
+            pointsOfInterestCount(location: $location)
+            pointsOfInterestTreeCount(location: $location)
+            toursCount(location: $location)
+            toursTreeCount(location: $location)
             children {
               id
               name
-              pointsOfInterestCount
-              pointsOfInterestTreeCount
-              toursCount
-              toursTreeCount
+              pointsOfInterestCount(location: $location)
+              pointsOfInterestTreeCount(location: $location)
+              toursCount(location: $location)
+              toursTreeCount(location: $location)
               children {
                 id
                 name
-                pointsOfInterestCount
-                pointsOfInterestTreeCount
-                toursCount
-                toursTreeCount
+                pointsOfInterestCount(location: $location)
+                pointsOfInterestTreeCount(location: $location)
+                toursCount(location: $location)
+                toursTreeCount(location: $location)
                 children {
                   id
                   name
-                  pointsOfInterestCount
-                  pointsOfInterestTreeCount
-                  toursCount
-                  toursTreeCount
+                  pointsOfInterestCount(location: $location)
+                  pointsOfInterestTreeCount(location: $location)
+                  toursCount(location: $location)
+                  toursTreeCount(location: $location)
                 }
               }
             }

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -235,7 +235,8 @@ export const IndexScreen = ({ navigation, route }) => {
 
             let listItems = parseListItemsFromQuery(query, data, titleDetail, {
               bookmarkable,
-              withDate: false
+              withDate: false,
+              queryVariables
             });
 
             if (filterByOpeningTimes) {


### PR DESCRIPTION
- added possible `location` to the query when clicking on a category
  in the category list to also filter the points of interest or tours
  on that location
  - therefore passed through the query variables from the highest level
    which contain the wanted location
- added the location param to the categories query in order to
  get correct counts for listed categories

SVA-628