### PR TITLE
setup eas build

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,6 +10,7 @@
       "android"
     ],
     "version": "2.6.0",
+    "runtimeVersion": "nativeVersion",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "scheme": "smart-village-app",

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,18 @@
+{
+  "cli": {
+    "version": ">= 0.53.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {}
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/eas.json
+++ b/eas.json
@@ -3,14 +3,27 @@
     "version": ">= 0.53.0"
   },
   "build": {
-    "development": {
-      "developmentClient": true,
-      "distribution": "internal"
+    "production": {
+      "node": "14.18.1",
+      "yarn": "1.22.4",
+      "releaseChannel": "production"
     },
     "preview": {
+      "extends": "production",
+      "releaseChannel": "preview",
       "distribution": "internal"
     },
-    "production": {}
+    "development": {
+      "extends": "preview",
+      "releaseChannel": "development",
+      "developmentClient": true
+    },
+    "development-simulator": {
+      "extends": "development",
+      "ios": {
+        "simulator": true
+      }
+    }
   },
   "submit": {
     "production": {}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+import { registerRootComponent } from 'expo';
+
+import App from './App';
+
+registerRootComponent(App);

--- a/package.json
+++ b/package.json
@@ -1,16 +1,17 @@
 {
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
-    "android": "expo start --android",
-    "eject": "expo eject",
-    "ios": "expo start --ios",
-    "lint": "./node_modules/.bin/eslint __tests__ src --ext .js,.jsx,.ts,.tsx",
     "start": "expo start",
+    "start:android": "expo start --android",
+    "start:ios": "expo start --ios",
+    "build:android": "eas build --platform android",
+    "build:ios": "eas build --platform ios",
+    "submit:android": "eas submit --platform android",
+    "submit:ios": "eas submit --platform ios",
+    "lint": "./node_modules/.bin/eslint __tests__ src --ext .js,.jsx,.ts,.tsx",
     "test": "./node_modules/.bin/jest",
     "test:debug": "node --inspect-brk node_modules/jest/bin/jest.js --runInBand",
-    "test:coverage": "node_modules/.bin/jest --coverage",
-    "build:android": "expo build:android",
-    "build:ios": "expo build:ios"
+    "test:coverage": "node_modules/.bin/jest --coverage"
   },
   "jest": {
     "preset": "jest-expo",


### PR DESCRIPTION
setup(eas build): initial configuration

  - ran `eas build:configure` after installing the cli tool per `npm install -g eas-cli`

setup(eas build): individual configuration

  - adjusted the configs to our build tools and versions from `.nvmrc` and `.yvmrc`, see https://docs.expo.dev/build/eas-json/#configuring-your-build-tools and https://docs.expo.dev/build/eas-json/#build-profiles
    - `production` builds will be submitted to app stores, for release to the general public or as part of a store-facilitated testing process
    - `preview` builds don't include developer tools, they are intended to be installed by your team and other stakeholders, to test out the app in production-like circumstances
    - `development` builds include developer tools, and they are never submitted to an app store
      - `development-simulator` alternatively prefer the development build to run in an simulator
        - note: for android there is no such special key needed
  - changed (yarn) scripts to new eas commands and sorted them accordingly

setup(eas build): create main `index.js`

  - created main entry point file as described here: https://docs.expo.dev/build-reference/migrating/#custom--main--entry-point-in

setup(eas build): specify expo `runtimeVersion`

  - specified a `runtimeVersion` to ensure that future updates are delivered only to compatible builds, see https://docs.expo.dev/distribution/runtime-versions
    - this way we avoid that live apps receives updates too early, which was the case with `expo build`/`expo publish`
  - the value must be one of https://docs.expo.dev/eas-update/runtime-versions
    - `nativeVersion` sounds as best fit for us right now
  - this `runtimeVersion` should be updated at least whenever native modules or JS–native interfaces changes
  - the `runtimeVersion` could theoretically differ for iOS and Android

SVA-444