### PR TITLE
feat(service tiles): new option for bigger tiles

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -139,7 +139,7 @@ Image.propTypes = {
   source: PropTypes.oneOfType([PropTypes.object, PropTypes.number]).isRequired,
   message: PropTypes.string,
   containerStyle: PropTypes.object,
-  style: PropTypes.object,
+  style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   PlaceholderContent: PropTypes.object,
   aspectRatio: PropTypes.object,
   resizeMode: PropTypes.string,

--- a/src/components/ServiceBox.js
+++ b/src/components/ServiceBox.js
@@ -1,25 +1,26 @@
 import styled, { css } from 'styled-components/native';
 
-import { consts, normalize } from '../config';
+import { normalize } from '../config';
+
+const flexBasis = (props) => {
+  const { orientation, bigTile } = props;
+  const numberOfTiles = orientation === 'landscape' ? 5 : 3;
+  const tileFactor = bigTile ? 0.3 : 1;
+
+  return 100 / (numberOfTiles + 0.3 * tileFactor);
+};
 
 export const ServiceBox = styled.View`
-  flex-basis: ${100 / 3.3}%;
   margin: ${normalize(14)}px 0;
 
   ${(props) =>
-    props.dimensions.width > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH &&
     css`
-      /*
-        need to add slightly more than 5.3 like on landscape in order to re-render
-        on orientation change. with the same values in this condition and for landscape,
-        it seems that the styled component is memoized and a re-rendering does not take place.
-      */
-      flex-basis: ${100 / 5.301}%;
+      flex-basis: ${flexBasis(props)}%;
     `};
 
   ${(props) =>
-    props.orientation === 'landscape' &&
+    props.bigTile &&
     css`
-      flex-basis: ${100 / 5.3}%;
+      margin: 0 0 ${normalize(1)}px 0;
     `};
 `;

--- a/src/components/screens/Service.js
+++ b/src/components/screens/Service.js
@@ -1,20 +1,17 @@
 import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
-import { colors, consts, device, Icon, normalize, texts } from '../../config';
+import { consts, device, normalize, texts } from '../../config';
 import { useHomeRefresh, useStaticContent } from '../../hooks';
-import { OrientationContext } from '../../OrientationProvider';
 import { SettingsContext } from '../../SettingsProvider';
 import { DiagonalGradient } from '../DiagonalGradient';
-import { Image } from '../Image';
-import { ServiceBox } from '../ServiceBox';
-import { BoldText } from '../Text';
 import { Title, TitleContainer, TitleShadow } from '../Title';
 import { WrapperWrap } from '../Wrapper';
 
+import { ServiceTile } from './ServiceTile';
+
 export const Service = ({ navigation }) => {
-  const { orientation, dimensions } = useContext(OrientationContext);
   const { globalSettings } = useContext(SettingsContext);
 
   const { data, loading, refetch } = useStaticContent({
@@ -40,52 +37,16 @@ export const Service = ({ navigation }) => {
         </TitleContainer>
       )}
       {!!headlineService && device.platform === 'ios' && <TitleShadow />}
-      <DiagonalGradient style={{ padding: normalize(14) }}>
+      <DiagonalGradient style={styles.padding}>
         <WrapperWrap spaceBetween>
-          {data.map((item, index) => {
-            return (
-              <ServiceBox
-                key={index + item.title}
-                orientation={orientation}
-                dimensions={dimensions}
-              >
-                <TouchableOpacity
-                  onPress={() =>
-                    navigation.navigate({
-                      name: item.routeName,
-                      params: item.params
-                    })
-                  }
-                >
-                  <View>
-                    {item.iconName ? (
-                      <Icon.NamedIcon
-                        color={colors.lightestText}
-                        name={item.iconName}
-                        size={30}
-                        style={styles.serviceIcon}
-                      />
-                    ) : (
-                      <Image
-                        source={{ uri: item.icon }}
-                        style={styles.serviceImage}
-                        PlaceholderContent={null}
-                        resizeMode="contain"
-                      />
-                    )}
-                    <BoldText
-                      small
-                      lightest
-                      center
-                      accessibilityLabel={`(${item.title}) ${consts.a11yLabel.button}`}
-                    >
-                      {item.title}
-                    </BoldText>
-                  </View>
-                </TouchableOpacity>
-              </ServiceBox>
-            );
-          })}
+          {data.map((item, index) => (
+            <ServiceTile
+              key={index + item.title}
+              navigation={navigation}
+              item={item}
+              hasDiagonalGradientBackground
+            />
+          ))}
         </WrapperWrap>
       </DiagonalGradient>
     </View>
@@ -93,15 +54,8 @@ export const Service = ({ navigation }) => {
 };
 
 const styles = StyleSheet.create({
-  serviceIcon: {
-    alignSelf: 'center',
-    paddingVertical: normalize(7.5)
-  },
-  serviceImage: {
-    alignSelf: 'center',
-    height: normalize(40),
-    marginBottom: normalize(7),
-    width: '100%'
+  padding: {
+    padding: normalize(14)
   }
 });
 

--- a/src/components/screens/ServiceTile.tsx
+++ b/src/components/screens/ServiceTile.tsx
@@ -23,11 +23,7 @@ export const ServiceTile = ({
   const safeAreaInsets = useSafeAreaInsets();
 
   return (
-    <ServiceBox
-      orientation={orientation}
-      dimensions={dimensions}
-      style={[!!item.tile && styles.bigTileBox]}
-    >
+    <ServiceBox orientation={orientation} dimensions={dimensions} bigTile={!!item.tile}>
       <TouchableOpacity
         onPress={() => navigation.push(item.routeName, item.params)}
         accessibilityLabel={
@@ -82,10 +78,6 @@ const styles = StyleSheet.create({
     height: normalize(40),
     marginBottom: normalize(7),
     width: '100%'
-  },
-  bigTileBox: {
-    marginBottom: normalize(14),
-    marginTop: 0
   }
 });
 
@@ -104,8 +96,7 @@ const stylesWithProps = ({
 
   // calculate tile sizes based on device orientation, safe are insets and padding
   const tileSize =
-    ((orientation === 'landscape' ? deviceHeight : device.width) -
-      (numberOfTiles + 1) * containerPadding) /
+    ((orientation === 'landscape' ? deviceHeight : device.width) - 2 * containerPadding) /
     numberOfTiles;
 
   return StyleSheet.create({

--- a/src/components/screens/ServiceTile.tsx
+++ b/src/components/screens/ServiceTile.tsx
@@ -1,0 +1,72 @@
+import { StackNavigationProp } from '@react-navigation/stack';
+import React, { useContext } from 'react';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { normalize } from 'react-native-elements';
+
+import { colors, consts, Icon } from '../../config';
+import { OrientationContext } from '../../OrientationProvider';
+import { Image } from '../Image';
+import { ServiceBox } from '../ServiceBox';
+import { BoldText } from '../Text';
+
+export const ServiceTile = ({
+  navigation,
+  item,
+  hasDiagonalGradientBackground = false
+}: {
+  navigation: StackNavigationProp<any>;
+  item: any;
+  hasDiagonalGradientBackground?: boolean;
+}) => {
+  const { orientation, dimensions } = useContext(OrientationContext);
+
+  return (
+    <ServiceBox orientation={orientation} dimensions={dimensions}>
+      <TouchableOpacity
+        onPress={() => {
+          navigation.push(item.routeName, item.params);
+        }}
+      >
+        <View>
+          {item.iconName ? (
+            <Icon.NamedIcon
+              color={hasDiagonalGradientBackground ? colors.lightestText : undefined}
+              name={item.iconName}
+              size={30}
+              style={styles.serviceIcon}
+            />
+          ) : (
+            <Image
+              source={{ uri: item.icon }}
+              style={styles.serviceImage}
+              PlaceholderContent={null}
+              resizeMode="contain"
+            />
+          )}
+          <BoldText
+            small
+            lightest={hasDiagonalGradientBackground}
+            primary={!hasDiagonalGradientBackground}
+            center
+            accessibilityLabel={`(${item.title}) ${consts.a11yLabel.button}`}
+          >
+            {item.title}
+          </BoldText>
+        </View>
+      </TouchableOpacity>
+    </ServiceBox>
+  );
+};
+
+const styles = StyleSheet.create({
+  serviceIcon: {
+    alignSelf: 'center',
+    paddingVertical: normalize(7.5)
+  },
+  serviceImage: {
+    alignSelf: 'center',
+    height: normalize(40),
+    marginBottom: normalize(7),
+    width: '100%'
+  }
+});

--- a/src/components/screens/ServiceTile.tsx
+++ b/src/components/screens/ServiceTile.tsx
@@ -21,11 +21,18 @@ export const ServiceTile = ({
   const { orientation, dimensions } = useContext(OrientationContext);
 
   return (
-    <ServiceBox orientation={orientation} dimensions={dimensions}>
+    <ServiceBox
+      orientation={orientation}
+      dimensions={dimensions}
+      style={[!!item.tile && styles.bigTileBox]}
+    >
       <TouchableOpacity
-        onPress={() => {
-          navigation.push(item.routeName, item.params);
-        }}
+        onPress={() => navigation.push(item.routeName, item.params)}
+        accessibilityLabel={
+          item.accessibilityLabel
+            ? `(${item.accessibilityLabel}) ${consts.a11yLabel.button}`
+            : undefined
+        }
       >
         <View>
           {item.iconName ? (
@@ -37,21 +44,23 @@ export const ServiceTile = ({
             />
           ) : (
             <Image
-              source={{ uri: item.icon }}
-              style={styles.serviceImage}
+              source={{ uri: item.icon || item.tile }}
+              style={[styles.serviceImage, !!item.tile && stylesWithProps({ orientation }).bigTile]}
               PlaceholderContent={null}
               resizeMode="contain"
             />
           )}
-          <BoldText
-            small
-            lightest={hasDiagonalGradientBackground}
-            primary={!hasDiagonalGradientBackground}
-            center
-            accessibilityLabel={`(${item.title}) ${consts.a11yLabel.button}`}
-          >
-            {item.title}
-          </BoldText>
+          {!!item.title && (
+            <BoldText
+              small
+              lightest={hasDiagonalGradientBackground}
+              primary={!hasDiagonalGradientBackground}
+              center
+              accessibilityLabel={`(${item.title}) ${consts.a11yLabel.button}`}
+            >
+              {item.title}
+            </BoldText>
+          )}
         </View>
       </TouchableOpacity>
     </ServiceBox>
@@ -68,5 +77,21 @@ const styles = StyleSheet.create({
     height: normalize(40),
     marginBottom: normalize(7),
     width: '100%'
+  },
+  bigTileBox: {
+    marginBottom: 0,
+    marginTop: 0
   }
 });
+
+/* eslint-disable react-native/no-unused-styles */
+/* this works properly, we do not want that warning */
+const stylesWithProps = ({ orientation }: { orientation: string }) => {
+  return StyleSheet.create({
+    bigTile: {
+      height: orientation === 'landscape' ? normalize(94) : normalize(80),
+      marginBottom: 0
+    }
+  });
+};
+/* eslint-enable react-native/no-unused-styles */

--- a/src/components/screens/ServiceTile.tsx
+++ b/src/components/screens/ServiceTile.tsx
@@ -2,8 +2,9 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import React, { useContext } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import { normalize } from 'react-native-elements';
+import { EdgeInsets, useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { colors, consts, Icon } from '../../config';
+import { colors, consts, device, Icon } from '../../config';
 import { OrientationContext } from '../../OrientationProvider';
 import { Image } from '../Image';
 import { ServiceBox } from '../ServiceBox';
@@ -19,6 +20,7 @@ export const ServiceTile = ({
   hasDiagonalGradientBackground?: boolean;
 }) => {
   const { orientation, dimensions } = useContext(OrientationContext);
+  const safeAreaInsets = useSafeAreaInsets();
 
   return (
     <ServiceBox
@@ -45,7 +47,10 @@ export const ServiceTile = ({
           ) : (
             <Image
               source={{ uri: item.icon || item.tile }}
-              style={[styles.serviceImage, !!item.tile && stylesWithProps({ orientation }).bigTile]}
+              style={[
+                styles.serviceImage,
+                !!item.tile && stylesWithProps({ orientation, safeAreaInsets }).bigTile
+              ]}
               PlaceholderContent={null}
               resizeMode="contain"
             />
@@ -79,17 +84,34 @@ const styles = StyleSheet.create({
     width: '100%'
   },
   bigTileBox: {
-    marginBottom: 0,
+    marginBottom: normalize(14),
     marginTop: 0
   }
 });
 
 /* eslint-disable react-native/no-unused-styles */
 /* this works properly, we do not want that warning */
-const stylesWithProps = ({ orientation }: { orientation: string }) => {
+const stylesWithProps = ({
+  orientation,
+  safeAreaInsets
+}: {
+  orientation: string;
+  safeAreaInsets: EdgeInsets;
+}) => {
+  const containerPadding = normalize(14);
+  const numberOfTiles = orientation === 'landscape' ? 5 : 3;
+  const deviceHeight = device.height - safeAreaInsets.left - safeAreaInsets.right;
+
+  // calculate tile sizes based on device orientation, safe are insets and padding
+  const tileSize =
+    ((orientation === 'landscape' ? deviceHeight : device.width) -
+      (numberOfTiles + 1) * containerPadding) /
+    numberOfTiles;
+
   return StyleSheet.create({
     bigTile: {
-      height: orientation === 'landscape' ? normalize(94) : normalize(80),
+      height: tileSize,
+      width: tileSize,
       marginBottom: 0
     }
   });

--- a/src/components/screens/ServiceTiles.js
+++ b/src/components/screens/ServiceTiles.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
 import React, { useCallback, useContext, useState } from 'react';
-import { ActivityIndicator, RefreshControl, ScrollView, StyleSheet, View } from 'react-native';
+import { RefreshControl, ScrollView, StyleSheet, View } from 'react-native';
 import { normalize } from 'react-native-elements';
 
 import { colors, consts, device } from '../../config';
 import { useStaticContent } from '../../hooks';
 import { NetworkContext } from '../../NetworkProvider';
-import { LoadingContainer } from '../LoadingContainer';
+import { LoadingSpinner } from '../LoadingSpinner';
 import { SafeAreaViewFlex } from '../SafeAreaViewFlex';
 import { Title, TitleContainer, TitleShadow } from '../Title';
 import { WrapperWrap } from '../Wrapper';
@@ -30,11 +30,7 @@ export const ServiceTiles = ({ navigation, staticJsonName, title }) => {
   }, [refetch, isConnected]);
 
   if (loading) {
-    return (
-      <LoadingContainer>
-        <ActivityIndicator color={colors.accent} />
-      </LoadingContainer>
-    );
+    return <LoadingSpinner loading />;
   }
 
   return (
@@ -59,7 +55,11 @@ export const ServiceTiles = ({ navigation, staticJsonName, title }) => {
           <View style={styles.padding}>
             <WrapperWrap spaceBetween>
               {data?.map((item, index) => (
-                <ServiceTile key={index + item.title} navigation={navigation} item={item} />
+                <ServiceTile
+                  key={index + (item.title || item.accessibilityLabel)}
+                  navigation={navigation}
+                  item={item}
+                />
               ))}
             </WrapperWrap>
           </View>

--- a/src/components/screens/ServiceTiles.js
+++ b/src/components/screens/ServiceTiles.js
@@ -1,30 +1,20 @@
 import PropTypes from 'prop-types';
 import React, { useCallback, useContext, useState } from 'react';
-import {
-  ActivityIndicator,
-  RefreshControl,
-  ScrollView,
-  StyleSheet,
-  TouchableOpacity,
-  View
-} from 'react-native';
+import { ActivityIndicator, RefreshControl, ScrollView, StyleSheet, View } from 'react-native';
 import { normalize } from 'react-native-elements';
 
-import { colors, consts, device, Icon } from '../../config';
+import { colors, consts, device } from '../../config';
 import { useStaticContent } from '../../hooks';
 import { NetworkContext } from '../../NetworkProvider';
-import { OrientationContext } from '../../OrientationProvider';
-import { Image } from '../Image';
 import { LoadingContainer } from '../LoadingContainer';
 import { SafeAreaViewFlex } from '../SafeAreaViewFlex';
-import { ServiceBox } from '../ServiceBox';
-import { BoldText } from '../Text';
 import { Title, TitleContainer, TitleShadow } from '../Title';
 import { WrapperWrap } from '../Wrapper';
 
+import { ServiceTile } from './ServiceTile';
+
 export const ServiceTiles = ({ navigation, staticJsonName, title }) => {
   const { isConnected } = useContext(NetworkContext);
-  const { orientation, dimensions } = useContext(OrientationContext);
   const [refreshing, setRefreshing] = useState(false);
 
   const { data, loading, refetch } = useStaticContent({
@@ -66,48 +56,11 @@ export const ServiceTiles = ({ navigation, staticJsonName, title }) => {
             />
           }
         >
-          <View style={{ padding: normalize(14) }}>
+          <View style={styles.padding}>
             <WrapperWrap spaceBetween>
-              {data?.map((item, index) => {
-                return (
-                  <ServiceBox
-                    key={index + item.title}
-                    orientation={orientation}
-                    dimensions={dimensions}
-                  >
-                    <TouchableOpacity
-                      onPress={() => {
-                        navigation.push(item.routeName, item.params);
-                      }}
-                    >
-                      <View>
-                        {item.iconName ? (
-                          <Icon.NamedIcon
-                            name={item.iconName}
-                            size={30}
-                            style={styles.serviceIcon}
-                          />
-                        ) : (
-                          <Image
-                            source={{ uri: item.icon }}
-                            style={styles.serviceImage}
-                            PlaceholderContent={null}
-                            resizeMode="contain"
-                          />
-                        )}
-                        <BoldText
-                          small
-                          primary
-                          center
-                          accessibilityLabel={`(${item.title}) ${consts.a11yLabel.button}`}
-                        >
-                          {item.title}
-                        </BoldText>
-                      </View>
-                    </TouchableOpacity>
-                  </ServiceBox>
-                );
-              })}
+              {data?.map((item, index) => (
+                <ServiceTile key={index + item.title} navigation={navigation} item={item} />
+              ))}
             </WrapperWrap>
           </View>
         </ScrollView>
@@ -117,15 +70,8 @@ export const ServiceTiles = ({ navigation, staticJsonName, title }) => {
 };
 
 const styles = StyleSheet.create({
-  serviceIcon: {
-    alignSelf: 'center',
-    paddingVertical: normalize(7.5)
-  },
-  serviceImage: {
-    alignSelf: 'center',
-    height: normalize(40),
-    marginBottom: normalize(7),
-    width: '100%'
+  padding: {
+    padding: normalize(14)
   }
 });
 

--- a/src/components/screens/index.js
+++ b/src/components/screens/index.js
@@ -9,5 +9,6 @@ export * from './OperatingCompany';
 export * from './PointOfInterest';
 export * from './PriceCard';
 export * from './Service';
+export * from './ServiceTile';
 export * from './ServiceTiles';
 export * from './Tour';


### PR DESCRIPTION
refactor(service tiles): reduce duplication

- crated new `ServiceTile` that combine duplicated code
  for `Service` and `ServiceTiles` with condition for coloring
  based on `hasDiagonalGradientBackground`

feat(service tiles): new possibility for big tiles

- added option for big tiles with an image `tile`
  that is styled bigger (orientation aware) and
  with less spacings to each other in the grid
- added option for `accessibilityLabel` in order
  has `tile`-image has text on it and no separate
  title rendered

feat(service tiles): increase size

- updated calculation of tile sizes based on device orientation,
  safe are insets and paddings

feat(service tiles): increase size even more

- updated `ServiceBox`s flex basis to result in bigger tiles
  conditionally
  - refactored conditions for the flex basis to be more readable
    and maintainable
  - removed exception for dimension change as it was not needed
    anymore in my tests -> recalculation worked without it
- moved big tile box margin styles to `ServiceBox`
- corrected calculation of `tileSize` with fixed container padding
  value to `2 *` because we have it twice (left and right of the screen)
- extended allowed prop types of `Image` style to object and array
  to be able to pass multiple styles conditionally

refactor(service tiles): loading spinner and key in map

- replaced the `LoadingContainer` and `ActivityIndicator`
  by its identical component `LoadingSpinner` to reduce and 
  reuse code properly
- updated `key` in map because `title` could be undefined for
  situations with big tiles, when `accessibilityLabel` should be used

SVA-639