### PR TITLE
fix(global settings): initializations and accesses

### DIFF
--- a/src/SettingsProvider.js
+++ b/src/SettingsProvider.js
@@ -5,7 +5,8 @@ export const SettingsContext = createContext({
   globalSettings: {
     filter: {},
     sections: {},
-    settings: {}
+    settings: {},
+    widgets: []
   }
 });
 

--- a/src/components/FeedbackFooter.tsx
+++ b/src/components/FeedbackFooter.tsx
@@ -11,7 +11,7 @@ import { BoldText } from './Text';
 export const FeedbackFooter: FC = () => {
   const navigation = useNavigation();
   // @ts-expect-error settings are not properly typed
-  const feedbackFooter = useContext(SettingsContext).globalSettings.settings?.feedbackFooter;
+  const feedbackFooter = useContext(SettingsContext).globalSettings?.settings?.feedbackFooter;
 
   if (!feedbackFooter) return null;
 

--- a/src/components/infoCard/AddressSection.tsx
+++ b/src/components/infoCard/AddressSection.tsx
@@ -55,7 +55,7 @@ const getBBNaviUrl = (baseUrl: string, address: Address, currentPosition?: Locat
 
 export const AddressSection = ({ address, addresses, openWebScreen }: Props) => {
   // @ts-expect-error global settings are not properly typed
-  const bbNaviBaseUrl = useContext(SettingsContext).globalSettings.settings?.['bbnavi'];
+  const bbNaviBaseUrl = useContext(SettingsContext).globalSettings?.settings?.['bbnavi'];
   const { position } = usePosition();
   const { position: lastKnownPosition } = useLastKnownPosition();
 

--- a/src/components/settings/ListSettings.js
+++ b/src/components/settings/ListSettings.js
@@ -9,7 +9,7 @@ import { ListSettingsItem } from '../ListSettingsItem';
 const renderItem = ({ item }) => <ListSettingsItem item={item} />;
 
 export const ListSettings = () => {
-  const categoriesNews = useContext(SettingsContext).globalSettings.sections?.categoriesNews ?? [
+  const categoriesNews = useContext(SettingsContext).globalSettings?.sections?.categoriesNews ?? [
     {
       categoryTitle: texts.settingsTitles.listLayouts.newsItemsTitle
     }

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,12 @@ const { LIST_TYPES } = consts;
 const MainAppWithApolloProvider = () => {
   const [loading, setLoading] = useState(true);
   const [client, setClient] = useState();
-  const [initialGlobalSettings, setInitialGlobalSettings] = useState({});
+  const [initialGlobalSettings, setInitialGlobalSettings] = useState({
+    filter: {},
+    sections: {},
+    settings: {},
+    widgets: []
+  });
   const [initialListTypesSettings, setInitialListTypesSettings] = useState({});
   const [initialLocationSettings, setInitialLocationSettings] = useState({});
 
@@ -137,8 +142,7 @@ const MainAppWithApolloProvider = () => {
     const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
 
     // rehydrate data from the async storage to the global state
-    // if there are no general settings yet, add a navigation fallback
-    let globalSettings = await storageHelper.globalSettings();
+    let globalSettings = (await storageHelper.globalSettings()) || initialGlobalSettings;
 
     // if there are no list type settings yet, set the defaults as fallback
     const listTypesSettings = (await storageHelper.listTypesSettings()) || {
@@ -176,12 +180,12 @@ const MainAppWithApolloProvider = () => {
     }
 
     // if there are no locationSettings yet, set the defaults as fallback
-    const locationSettings = !globalSettings.settings.locationService
+    const locationSettings = !globalSettings?.settings?.locationService
       ? { locationService: false }
       : (await storageHelper.locationSettings()) || {};
 
     const defaultAlternativePosition =
-      globalSettings.settings.locationService?.defaultAlternativePosition;
+      globalSettings?.settings?.locationService?.defaultAlternativePosition;
 
     if (defaultAlternativePosition) {
       locationSettings.defaultAlternativePosition = latLngToLocationObject(

--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -54,7 +54,7 @@ const getRefreshInterval = (query) => {
 };
 
 const useRootRouteByCategory = (details, navigation) => {
-  const categoriesNews = useContext(SettingsContext)?.globalSettings?.sections?.categoriesNews;
+  const categoriesNews = useContext(SettingsContext).globalSettings?.sections?.categoriesNews;
   const id = details.categories?.[0]?.id;
 
   useEffect(() => {

--- a/src/screens/EncounterHomeScreen.tsx
+++ b/src/screens/EncounterHomeScreen.tsx
@@ -39,7 +39,7 @@ const a11yLabels = consts.a11yLabel;
 // eslint-disable-next-line complexity
 export const EncounterHomeScreen = ({ navigation, route }: any) => {
   // @ts-expect-error settings are not properly typed
-  const encounterCategoryId = useContext(SettingsContext).globalSettings.settings?.encounter
+  const encounterCategoryId = useContext(SettingsContext).globalSettings?.settings?.encounter
     ?.categoryId;
   const {
     loading: loadingQr,

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -27,7 +27,7 @@ export const HomeScreen = ({ navigation, route }) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
   const { globalSettings } = useContext(SettingsContext);
-  const { sections = {}, widgets: widgetConfigs } = globalSettings;
+  const { sections = {}, widgets: widgetConfigs = [] } = globalSettings;
   const {
     showNews = true,
     showPointsOfInterestAndTours = true,

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -69,7 +69,7 @@ export const SettingsScreen = () => {
 
   useEffect(() => {
     const updateSectionedData = async () => {
-      const { settings = { matomo: false } } = globalSettings;
+      const { settings = {} } = globalSettings;
 
       const additionalSectionedData = [];
 


### PR DESCRIPTION
- adjusted conditional chaining and initial empty objects everywhere to avoid errors while accessing settings objects
  - removed `matomo: false` fallback in settings screen as we now always can access the settings object and if there is no matomo it resolves to false
  - we cannot add fallback initial values for every possible settings
- added fallback to `initialGlobalSettings` on setting up the global settings to ensure a valid value also if there was nothing stored locally before or accessing failed somehow
- fixed error: `[Unhandled promise rejection: TypeError: null is not an object (evaluating 'globalSettings.settings')]`