### PR TITLE
feat: always show version number in drawer mode

### DIFF
--- a/src/components/screens/About.js
+++ b/src/components/screens/About.js
@@ -42,7 +42,7 @@ export const About = ({ navigation, withHomeRefresh, withSettings }) => {
       </LoadingContainer>
     );
 
-  if (!data?.length) return null;
+  if (!data?.length) return <VersionNumber />;
 
   const { sections = {} } = globalSettings;
   const { headlineAbout = texts.homeTitles.about } = sections;


### PR DESCRIPTION
- added rendering of version number if there is no data
  for "homeAbout", which resulted to a missing version number
  in latest version, as it was moved to section list footer, that
  was only rendered if there are list entries