### PR TITLE
refactor(colors): adjust and cleanup

### DIFF
--- a/__tests__/components/__snapshots__/Link.test.js.snap
+++ b/__tests__/components/__snapshots__/Link.test.js.snap
@@ -73,7 +73,7 @@ exports[`Link renders a Link that opens a WebScreen 1`] = `
   <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
   <svg width=\\"24px\\" height=\\"24px\\" viewBox=\\"0 0 24 24\\" version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\">
     <g stroke=\\"none\\" stroke-width=\\"1\\" fill=\\"none\\" fill-rule=\\"evenodd\\">
-      <g transform=\\"translate(3.000000, 3.000000)\\" fill=\\"rgb(9, 72, 60)\\">
+      <g transform=\\"translate(3.000000, 3.000000)\\" fill=\\"#107821\\">
         <path d=\\"M10.7496,1.3135 L18.5286,0.6065 L17.8206,8.3845 L16.6426,7.2065 L17.1136,2.0205
           L11.9286,2.4925 L10.7496,1.3135 Z M0,3.3214 L5.75,3.3214 L5.75,4.8204 L1.5,4.8204
           L1.5,17.3204 L15,17.3204 L15,13.4044 L16.5,13.4044 L16.5,18.8214 L0,18.8214 L0,3.3214 Z
@@ -101,7 +101,7 @@ exports[`Link renders a Link that opens a WebScreen 1`] = `
             strokeWidth={1}
           >
             <RNSVGGroup
-              fill={4278798396}
+              fill={4279269409}
               matrix={
                 Array [
                   1,
@@ -222,7 +222,7 @@ exports[`Link renders a default Link 1`] = `
   <?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
   <svg width=\\"24px\\" height=\\"24px\\" viewBox=\\"0 0 24 24\\" version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\">
     <g stroke=\\"none\\" stroke-width=\\"1\\" fill=\\"none\\" fill-rule=\\"evenodd\\">
-      <g transform=\\"translate(3.000000, 3.000000)\\" fill=\\"rgb(9, 72, 60)\\">
+      <g transform=\\"translate(3.000000, 3.000000)\\" fill=\\"#107821\\">
         <path d=\\"M10.7496,1.3135 L18.5286,0.6065 L17.8206,8.3845 L16.6426,7.2065 L17.1136,2.0205
           L11.9286,2.4925 L10.7496,1.3135 Z M0,3.3214 L5.75,3.3214 L5.75,4.8204 L1.5,4.8204
           L1.5,17.3204 L15,17.3204 L15,13.4044 L16.5,13.4044 L16.5,18.8214 L0,18.8214 L0,3.3214 Z
@@ -250,7 +250,7 @@ exports[`Link renders a default Link 1`] = `
             strokeWidth={1}
           >
             <RNSVGGroup
-              fill={4278798396}
+              fill={4279269409}
               matrix={
                 Array [
                   1,

--- a/__tests__/config/colors.test.js
+++ b/__tests__/config/colors.test.js
@@ -1,6 +1,10 @@
 import { colors } from '../../src/config';
 
 describe('color', () => {
+  it('lighterPrimary is defined', () => {
+    expect(colors.lighterPrimary).toBeTruthy();
+  });
+
   it('primary is defined', () => {
     expect(colors.primary).toBeTruthy();
   });
@@ -9,19 +13,71 @@ describe('color', () => {
     expect(colors.darkerPrimary).toBeTruthy();
   });
 
+  it('darkerPrimaryRgba is defined', () => {
+    expect(colors.darkerPrimaryRgba).toBeTruthy();
+  });
+
   it('secondary is defined', () => {
     expect(colors.secondary).toBeTruthy();
+  });
+
+  it('accent is defined', () => {
+    expect(colors.accent).toBeTruthy();
+  });
+
+  it('error is defined', () => {
+    expect(colors.error).toBeTruthy();
   });
 
   it('darkText is defined', () => {
     expect(colors.darkText).toBeTruthy();
   });
 
-  it('lighterText is defined', () => {
-    expect(colors.lighterText).toBeTruthy();
-  });
-
   it('lightestText is defined', () => {
     expect(colors.lightestText).toBeTruthy();
+  });
+
+  it('shadow is defined', () => {
+    expect(colors.shadow).toBeTruthy();
+  });
+
+  it('shadowRgba is defined', () => {
+    expect(colors.shadowRgba).toBeTruthy();
+  });
+
+  it('placeholder is defined', () => {
+    expect(colors.placeholder).toBeTruthy();
+  });
+
+  it('backgroundRgba is defined', () => {
+    expect(colors.backgroundRgba).toBeTruthy();
+  });
+
+  it('borderRgba is defined', () => {
+    expect(colors.borderRgba).toBeTruthy();
+  });
+
+  it('overlayRgba is defined', () => {
+    expect(colors.overlayRgba).toBeTruthy();
+  });
+
+  it('surface is defined', () => {
+    expect(colors.surface).toBeTruthy();
+  });
+
+  it('transparent is defined', () => {
+    expect(colors.transparent).toBeTruthy();
+  });
+
+  it('gray20 is defined', () => {
+    expect(colors.gray20).toBeTruthy();
+  });
+
+  it('gray40 is defined', () => {
+    expect(colors.gray40).toBeTruthy();
+  });
+
+  it('gray60 is defined', () => {
+    expect(colors.gray40).toBeTruthy();
   });
 });

--- a/src/components/BB-BUS/IndexFilter.js
+++ b/src/components/BB-BUS/IndexFilter.js
@@ -201,7 +201,7 @@ export const IndexFilter = ({
 
 const styles = StyleSheet.create({
   divider: {
-    backgroundColor: colors.lightestText,
+    backgroundColor: colors.surface,
     height: normalize(18),
     opacity: 0
   },

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -59,7 +59,7 @@ export const Checkbox = ({
 
 const styles = StyleSheet.create({
   containerStyle: {
-    backgroundColor: colors.lightestText,
+    backgroundColor: colors.surface,
     borderWidth: 0,
     marginLeft: 0,
     marginRight: 0

--- a/src/components/DropdownSelect.js
+++ b/src/components/DropdownSelect.js
@@ -144,7 +144,7 @@ const styles = StyleSheet.create({
   },
   dropdownDropdownText: baseFontStyle,
   dropdownRowWrapper: {
-    backgroundColor: colors.lightestText
+    backgroundColor: colors.surface
   },
   dropdownSeparator: {
     backgroundColor: colors.borderRgba,

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -14,7 +14,7 @@ export const Link = ({ url, description, openWebScreen }) => (
     accessibilityLabel={`(${description}) ${consts.a11yLabel.link}`}
   >
     <WrapperRow>
-      <Icon.Link color={colors.secondary} style={styles.icon} />
+      <Icon.Link color={colors.primary} style={styles.icon} />
       <RegularText primary>{description}</RegularText>
     </WrapperRow>
   </TouchableOpacity>

--- a/src/components/Radiobutton.js
+++ b/src/components/Radiobutton.js
@@ -31,7 +31,7 @@ export const Radiobutton = ({ title, disabled, selected, onPress, containerStyle
 
 const styles = StyleSheet.create({
   containerStyle: {
-    backgroundColor: colors.lightestText,
+    backgroundColor: colors.surface,
     borderColor: colors.lightestText,
     borderRadius: 0,
     borderWidth: 0,

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -92,8 +92,8 @@ export const RegularText = styled(Text)`
   ${(props) =>
     props.lighter &&
     css`
-      color: ${colors.lighterText};
-      text-decoration-color: ${colors.lighterText};
+      color: ${colors.gray60};
+      text-decoration-color: ${colors.gray60};
     `};
 
   ${(props) =>

--- a/src/components/Title.js
+++ b/src/components/Title.js
@@ -29,7 +29,7 @@ export const Title = styled(Text)`
 // need to set a background color for shadow applying to the View instead of Text inside it
 // thx to https://github.com/styled-components/styled-components/issues/709#issuecomment-377968412
 export const TitleContainer = styled.View`
-  background-color: ${colors.lightestText};
+  background-color: ${colors.surface};
   padding: ${normalize(7)}px ${normalize(14)}px;
 
   ${() =>
@@ -50,7 +50,7 @@ export const TitleContainer = styled.View`
 
 // dummy bottom shadow container for iOS
 export const TitleShadow = styled.View`
-  background-color: ${colors.lightestText};
+  background-color: ${colors.surface};
   shadow-color: ${colors.shadow};
   shadow-offset: 0px 1px;
   shadow-opacity: 0.7;

--- a/src/components/consul/detail/ConsulDocumentListItem.js
+++ b/src/components/consul/detail/ConsulDocumentListItem.js
@@ -78,7 +78,7 @@ const styles = StyleSheet.create({
   },
   modalView: {
     alignItems: 'center',
-    backgroundColor: colors.lightestText,
+    backgroundColor: colors.surface,
     borderRadius: 20,
     height: Dimensions.get('screen').height - 120,
     paddingTop: 75

--- a/src/components/form/Input.tsx
+++ b/src/components/form/Input.tsx
@@ -105,7 +105,12 @@ export const Input = ({
         !isValid && !!errorMessage && styles.inputContainerError
       ]}
       rightIconContainerStyle={styles.rightIconContainer}
-      inputStyle={[styles.input, multiline && device.platform === 'ios' && styles.multiline]}
+      inputStyle={[
+        styles.input,
+        multiline && device.platform === 'ios' && styles.multiline,
+        !isValid && !!errorMessage && styles.inputError
+      ]}
+      errorStyle={styles.inputError}
       placeholderTextColor={colors.placeholder}
       disabledInputStyle={styles.inputDisabled}
       accessibilityLabel={`${a11yLabel[name]} ${a11yLabel.textInput}: ${field.value}`}
@@ -130,7 +135,7 @@ const styles = StyleSheet.create({
   },
   inputContainerDisabled: {
     backgroundColor: colors.gray20,
-    borderColor: colors.lighterText
+    borderColor: colors.gray60
   },
   inputContainerHidden: {
     borderBottomWidth: 0,
@@ -151,6 +156,7 @@ const styles = StyleSheet.create({
     paddingRight: normalize(12)
   },
   input: {
+    color: colors.darkText,
     paddingLeft: normalize(12),
     paddingRight: normalize(6),
     paddingVertical: device.platform === 'ios' ? normalize(10) : normalize(8),
@@ -158,6 +164,9 @@ const styles = StyleSheet.create({
   },
   multiline: {
     paddingTop: normalize(12)
+  },
+  inputError: {
+    color: colors.error
   },
   inputDisabled: {
     color: colors.placeholder

--- a/src/components/screens/consul/Debates/DebateDetail.js
+++ b/src/components/screens/consul/Debates/DebateDetail.js
@@ -186,7 +186,7 @@ const styles = StyleSheet.create({
     shadowColor: colors.shadow,
     shadowOpacity: 0.7,
     shadowRadius: 3,
-    backgroundColor: colors.lightestText
+    backgroundColor: colors.surface
   }
 });
 

--- a/src/components/screens/consul/Polls/PollDetail.js
+++ b/src/components/screens/consul/Polls/PollDetail.js
@@ -151,7 +151,7 @@ const styles = StyleSheet.create({
     shadowColor: colors.shadow,
     shadowOpacity: 0.7,
     shadowRadius: 3,
-    backgroundColor: colors.lightestText
+    backgroundColor: colors.surface
   }
 });
 

--- a/src/components/screens/consul/Proposals/NewProposal.js
+++ b/src/components/screens/consul/Proposals/NewProposal.js
@@ -268,14 +268,7 @@ export const NewProposal = ({ navigation, data, query }) => {
                   <TouchableOpacity
                     key={indexs}
                     activeOpacity={1}
-                    style={[
-                      styles.tagContainer,
-                      {
-                        backgroundColor: items.selected
-                          ? colors.lighterPrimary
-                          : colors.placeholder + '60'
-                      }
-                    ]}
+                    style={[styles.tagContainer, !!items.selected && styles.tagContainerSelected]}
                     onPress={() => {
                       if (items.selected) {
                         items.selected = false;
@@ -354,6 +347,9 @@ const styles = StyleSheet.create({
     backgroundColor: colors.borderRgba,
     margin: 5,
     borderRadius: 5
+  },
+  tagContainerSelected: {
+    backgroundColor: colors.primary
   },
   tagText: {
     padding: 10

--- a/src/components/screens/consul/Proposals/ProposalDetail.js
+++ b/src/components/screens/consul/Proposals/ProposalDetail.js
@@ -262,7 +262,7 @@ const styles = StyleSheet.create({
     shadowColor: colors.shadow,
     shadowOpacity: 0.7,
     shadowRadius: 3,
-    backgroundColor: colors.lightestText
+    backgroundColor: colors.surface
   }
 });
 

--- a/src/components/volunteer/VolunteerAvatar.tsx
+++ b/src/components/volunteer/VolunteerAvatar.tsx
@@ -72,10 +72,10 @@ const styles = StyleSheet.create({
     marginLeft: normalize(-12)
   },
   overlayContainerStyle: {
-    backgroundColor: colors.lightestText
+    backgroundColor: colors.surface
   },
   placeholderStyle: {
-    backgroundColor: colors.lightestText
+    backgroundColor: colors.surface
   },
   titleStyle: {
     color: colors.darkText,

--- a/src/components/volunteer/VolunteerFormCalendar.tsx
+++ b/src/components/volunteer/VolunteerFormCalendar.tsx
@@ -334,7 +334,7 @@ const styles = StyleSheet.create({
     paddingTop: 0
   },
   checkboxContainerStyle: {
-    backgroundColor: colors.lightestText,
+    backgroundColor: colors.surface,
     borderWidth: 0,
     marginLeft: 0,
     marginRight: 0

--- a/src/components/volunteer/VolunteerFormGroup.tsx
+++ b/src/components/volunteer/VolunteerFormGroup.tsx
@@ -167,7 +167,7 @@ const styles = StyleSheet.create({
     paddingTop: 0
   },
   checkboxContainerStyle: {
-    backgroundColor: colors.lightestText,
+    backgroundColor: colors.surface,
     borderWidth: 0,
     marginLeft: 0,
     marginRight: 0

--- a/src/components/volunteer/VolunteerMessage.tsx
+++ b/src/components/volunteer/VolunteerMessage.tsx
@@ -134,10 +134,10 @@ const styles = StyleSheet.create({
     marginBottom: normalize(10)
   },
   overlayContainerStyle: {
-    backgroundColor: colors.lightestText
+    backgroundColor: colors.surface
   },
   placeholderStyle: {
-    backgroundColor: colors.lightestText
+    backgroundColor: colors.surface
   },
   titleStyle: {
     color: colors.darkText,

--- a/src/config/colors.js
+++ b/src/config/colors.js
@@ -1,32 +1,33 @@
-const gray40 = '#DBDBE6';
-const gray20 = '#EAEAEA';
 const white = '#FFFFFF';
+const black = '#141414';
+const gray20 = '#EAEAEA';
+const gray40 = '#DBDBE6';
+const gray60 = '#BCBBC1';
+const gray80 = '#A2A2A2';
 
 export const colors = {
   lighterPrimary: '#5EC66F',
   primary: '#107821',
   darkerPrimary: 'rgb(15, 70, 24)',
-  darkerPrimaryRgba: 'rgba(15, 70, 24, 0.6)',
+  darkerPrimaryRgba: 'rgba(15, 70, 24, 0.6)', // darkerPrimary with 0.6 alpha
   secondary: 'rgb(9, 72, 60)',
   accent: 'rgb(15, 70, 24)',
 
   error: 'rgb(174, 0, 29)',
 
-  darkText: '#000000',
-  lighterText: 'rgba(221, 242, 243, 0.6)',
+  darkText: black,
   lightestText: white,
 
-  shadow: '#BCBBC1',
-  shadowRgba: 'rgba(188, 187, 193, 0.4)',
-
-  backgroundRgba: 'rgba(162, 162, 162, 0.08)',
-  borderRgba: 'rgba(162, 162, 162, 0.75)',
-  placeholder: '#A2A2A2',
-  overlayRgba: 'rgba(20, 20, 20, 0.7)',
+  shadow: gray60,
+  shadowRgba: 'rgba(188, 187, 193, 0.4)', // gray60 with 0.4 alpha
+  placeholder: gray80,
+  backgroundRgba: 'rgba(162, 162, 162, 0.08)', // gray80 with 0.08 alpha
+  borderRgba: 'rgba(162, 162, 162, 0.75)', // gray80 with 0.75 alpha
+  overlayRgba: 'rgba(20, 20, 20, 0.7)', // black with 0.7 alpha
 
   surface: white,
-
   transparent: 'transparent',
   gray20,
-  gray40
+  gray40,
+  gray60
 };

--- a/src/navigation/DrawerNavigatorItem.js
+++ b/src/navigation/DrawerNavigatorItem.js
@@ -51,7 +51,7 @@ const styles = StyleSheet.create({
     paddingVertical: normalize(12)
   },
   divider: {
-    backgroundColor: colors.lightestText,
+    backgroundColor: colors.surface,
     height: StyleSheet.hairlineWidth,
     opacity: 0.3
   }

--- a/src/screens/EncounterHomeScreen.tsx
+++ b/src/screens/EncounterHomeScreen.tsx
@@ -202,7 +202,7 @@ const styles = StyleSheet.create({
   container: {
     alignItems: 'center'
   },
-  divider: { backgroundColor: colors.lightestText },
+  divider: { backgroundColor: colors.surface },
   gradient: {
     justifyContent: 'center',
     paddingVertical: normalize(24)

--- a/src/screens/FeedbackScreen.js
+++ b/src/screens/FeedbackScreen.js
@@ -158,7 +158,7 @@ const styles = StyleSheet.create({
     padding: normalize(10)
   },
   checkboxContainerStyle: {
-    backgroundColor: colors.lightestText,
+    backgroundColor: colors.surface,
     borderWidth: 0,
     marginBottom: normalize(10),
     marginLeft: 0,


### PR DESCRIPTION
- changed `lightestText` to `surface` where it was used for background, as both are white, but one for texts and the other for surfaces
- removed `lighterText` as it was rarely used and gray, so `gray60` could be used
- changed `secondary` to `primary` for bus bb link icons to always have the same color for the icon and the text
- properly set error color for form validations of inputs
- updated jest snapshots with missing colors

SVA-646