### PR TITLE
refactor: unify mail icon

### DIFF
--- a/src/components/consul/detail/ConsulCommentListItem.js
+++ b/src/components/consul/detail/ConsulCommentListItem.js
@@ -231,7 +231,7 @@ export const ConsulCommentListItem = ({ commentItem, refetch, replyList, navigat
             style={styles.button}
             disabled={isLoading}
           >
-            <Icon.Send color={colors.primary} size={normalize(16)} />
+            <Icon.Mail color={colors.primary} />
           </TouchableOpacity>
         </WrapperRow>
       ) : null}

--- a/src/components/screens/consul/Debates/DebateDetail.js
+++ b/src/components/screens/consul/Debates/DebateDetail.js
@@ -166,7 +166,7 @@ export const DebateDetail = ({ data, refetch, route, navigation }) => {
             style={styles.button}
             disabled={isLoading}
           >
-            <Icon.Send color={colors.primary} size={normalize(16)} />
+            <Icon.Mail color={colors.primary} />
           </TouchableOpacity>
         </WrapperRow>
       </Wrapper>

--- a/src/components/screens/consul/Polls/PollDetail.js
+++ b/src/components/screens/consul/Polls/PollDetail.js
@@ -131,7 +131,7 @@ export const PollDetail = ({ data, refetch, route, navigation }) => {
             style={styles.button}
             disabled={isLoading}
           >
-            <Icon.Send color={colors.primary} size={normalize(16)} />
+            <Icon.Mail color={colors.primary} />
           </TouchableOpacity>
         </WrapperRow>
       </Wrapper>

--- a/src/components/screens/consul/Proposals/ProposalDetail.js
+++ b/src/components/screens/consul/Proposals/ProposalDetail.js
@@ -239,7 +239,7 @@ export const ProposalDetail = ({ data, refetch, route, navigation }) => {
             style={styles.button}
             disabled={isLoading}
           >
-            <Icon.Send color={colors.primary} size={normalize(16)} />
+            <Icon.Mail color={colors.primary} />
           </TouchableOpacity>
         </WrapperRow>
       </Wrapper>

--- a/src/config/Icon.tsx
+++ b/src/config/Icon.tsx
@@ -146,7 +146,6 @@ export const Icon = {
   Settings: (props: IconProps) => (
     <NamedIcon name={device.platform === 'ios' ? 'ios-settings' : 'md-settings'} {...props} />
   ),
-  Send: (props: IconProps) => <NamedIcon name="send" {...props} />,
   Share: (props: IconProps) =>
     device.platform === 'ios' ? (
       <NamedIcon name="ios-share" {...props} />


### PR DESCRIPTION
- removed `Send` icon as we used `Mail` in other places
  and want to have the same icon everywhere
  - also `Mail` is svg and does not depend on a font icon set
    so there are no changes necessary across different cities