### PR TITLE
refactor/fix: && chained check in addition to conditional chaining

### DIFF
--- a/src/screens/volunteer/VolunteerMeScreen.tsx
+++ b/src/screens/volunteer/VolunteerMeScreen.tsx
@@ -34,7 +34,7 @@ export const VolunteerMeScreen = ({ navigation, route }: StackScreenProps<any>) 
     return <LoadingSpinner loading />;
   }
 
-  if (isError || (isSuccess && data?.status !== 200)) {
+  if (isError || (isSuccess && data?.status && data?.status !== 200)) {
     return (
       <SafeAreaViewFlex>
         <Wrapper>

--- a/src/screens/volunteer/VolunteerSignupScreen.tsx
+++ b/src/screens/volunteer/VolunteerSignupScreen.tsx
@@ -79,7 +79,7 @@ export const VolunteerSignupScreen = ({ navigation, route }: StackScreenProps<an
     isError ||
     isErrorMe ||
     (isSuccess && data?.code !== 200) ||
-    (isSuccessMe && dataMe?.status !== 200)
+    (isSuccessMe && dataMe?.status && dataMe?.status !== 200)
   ) {
     showSignupFailAlert();
     reset();


### PR DESCRIPTION
- there could be no `status` at all in an successful response
  so we need to check for existing `.status` explicitly, conditional
  chaining cannot achieve that

---

follow up for #561 