### PR TITLE
feat(ar): start animation

### DIFF
--- a/src/screens/augmentedReality/ARShowScreen.js
+++ b/src/screens/augmentedReality/ARShowScreen.js
@@ -12,6 +12,7 @@ import { LoadingSpinner } from '../../components';
 import { colors, Icon, normalize } from '../../config';
 
 export const ARShowScreen = ({ navigation, route }) => {
+  const [startAnimation, setStartAnimation] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isVideoRecording, setIsVideoRecording] = useState(false);
   const data = route?.params?.data ?? [];
@@ -69,7 +70,7 @@ export const ARShowScreen = ({ navigation, route }) => {
         initialScene={{
           scene: AugmentedRealityView
         }}
-        viroAppProps={{ object }}
+        viroAppProps={{ object, startAnimation }}
         style={styles.arSceneNavigator}
       />
 
@@ -105,6 +106,16 @@ export const ARShowScreen = ({ navigation, route }) => {
         <Icon.NamedIcon name="camera" color={colors.darkText} size={normalize(30)} />
       </TouchableOpacity>
 
+      <TouchableOpacity
+        style={[styles.animationButton, styles.generalButtonStyle]}
+        onPress={() => setStartAnimation(!startAnimation)}
+      >
+        {startAnimation ? (
+          <Icon.NamedIcon name="stop" color={colors.primary} size={normalize(40)} />
+        ) : (
+          <Icon.NamedIcon name="play" color={colors.primary} size={normalize(40)} />
+        )}
+      </TouchableOpacity>
     </>
   );
 };
@@ -113,7 +124,8 @@ const AugmentedRealityView = ({ sceneNavigator }) => {
   const [rotation, setRotation] = useState([0, 0, 0]);
   const [position, setPosition] = useState([0, -1, -5]);
 
-  const { object } = sceneNavigator.viroAppProps;
+  const { object, startAnimation } = sceneNavigator.viroAppProps;
+
 
   const moveObject = (newPosition) => {
     setPosition(newPosition);
@@ -155,6 +167,11 @@ const AugmentedRealityView = ({ sceneNavigator }) => {
         onLoadStart={handleLoadStart}
         onLoadEnd={handleLoadEnd}
         onError={(event) => handleError(event)}
+        animation={{
+          loop: true,
+          name: object.animationName,
+          run: startAnimation
+        }}
       />
     </ViroARScene>
   );
@@ -162,6 +179,10 @@ const AugmentedRealityView = ({ sceneNavigator }) => {
 
 const objectParser = async ({ item, setObject, onPress }) => {
   let parsedObject = {};
+
+  if (item.animationName) {
+    parsedObject.animationName = item.animationName;
+  }
 
   item.localUris?.find((item) => {
     if (item.type === 'vrx') {
@@ -193,6 +214,11 @@ const objectParser = async ({ item, setObject, onPress }) => {
 };
 
 var styles = StyleSheet.create({
+  animationButton: {
+    alignSelf: 'center',
+    bottom: 100,
+    padding: 12
+  },
   arSceneNavigator: {
     flex: 1
   },

--- a/src/screens/augmentedReality/ARShowScreen.js
+++ b/src/screens/augmentedReality/ARShowScreen.js
@@ -12,7 +12,7 @@ import { LoadingSpinner } from '../../components';
 import { colors, Icon, normalize } from '../../config';
 
 export const ARShowScreen = ({ navigation, route }) => {
-  const [startAnimation, setStartAnimation] = useState(false);
+  const [isStartAnimation, setIsStartAnimation] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
   const [isVideoRecording, setIsVideoRecording] = useState(false);
   const data = route?.params?.data ?? [];
@@ -70,7 +70,7 @@ export const ARShowScreen = ({ navigation, route }) => {
         initialScene={{
           scene: AugmentedRealityView
         }}
-        viroAppProps={{ object, startAnimation }}
+        viroAppProps={{ object, isStartAnimation }}
         style={styles.arSceneNavigator}
       />
 
@@ -108,12 +108,12 @@ export const ARShowScreen = ({ navigation, route }) => {
 
       <TouchableOpacity
         style={[styles.animationButton, styles.generalButtonStyle]}
-        onPress={() => setStartAnimation(!startAnimation)}
+        onPress={() => setIsStartAnimation(!isStartAnimation)}
       >
-        {startAnimation ? (
-          <Icon.NamedIcon name="stop" color={colors.primary} size={normalize(40)} />
+        {isStartAnimation ? (
+          <Icon.NamedIcon name="pause" color={colors.primary} size={normalize(30)} />
         ) : (
-          <Icon.NamedIcon name="play" color={colors.primary} size={normalize(40)} />
+          <Icon.NamedIcon name="play" color={colors.primary} size={normalize(30)} />
         )}
       </TouchableOpacity>
     </>
@@ -124,8 +124,7 @@ const AugmentedRealityView = ({ sceneNavigator }) => {
   const [rotation, setRotation] = useState([0, 0, 0]);
   const [position, setPosition] = useState([0, -1, -5]);
 
-  const { object, startAnimation } = sceneNavigator.viroAppProps;
-
+  const { object, isStartAnimation } = sceneNavigator.viroAppProps;
 
   const moveObject = (newPosition) => {
     setPosition(newPosition);
@@ -170,7 +169,7 @@ const AugmentedRealityView = ({ sceneNavigator }) => {
         animation={{
           loop: true,
           name: object.animationName,
-          run: startAnimation
+          run: isStartAnimation
         }}
       />
     </ViroARScene>
@@ -216,8 +215,8 @@ const objectParser = async ({ item, setObject, onPress }) => {
 var styles = StyleSheet.create({
   animationButton: {
     alignSelf: 'center',
-    bottom: 100,
-    padding: 12
+    bottom: normalize(40),
+    padding: normalize(15)
   },
   arSceneNavigator: {
     flex: 1


### PR DESCRIPTION
- added the ability to start and stop
  animation to 3D object
- added a new if to the parser to
  distinguish if there is an animated
  3D object
- added animation prop to `Viro3DObject`
  to start and stop animation

SVA-633

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [ ] Android landscape mode
* [ ] iOS landscape mode


## Screenshots:

|Animation Start Button|
|--|
![IMG_0201 3](https://user-images.githubusercontent.com/11755668/178554769-2da1103a-0fff-4eea-b906-969897d368d9.jpg)

