### PR TITLE
fix: query variables without limit

### DIFF
--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -41,7 +41,8 @@ const INITIAL_TOP_FILTER = [
   { id: TOP_FILTER.MAP, title: texts.locationOverview.map, selected: false }
 ];
 
-const isMapSelected = (topFilter) =>
+const isMapSelected = (query, topFilter) =>
+  query === QUERY_TYPES.POINTS_OF_INTEREST &&
   topFilter.find((entry) => entry.selected).id === TOP_FILTER.MAP;
 
 const keyForSelectedValueByQuery = {
@@ -78,9 +79,9 @@ export const IndexScreen = ({ navigation, route }) => {
   const [filterByOpeningTimes, setFilterByOpeningTimes] = useState(false);
   const { state: excludeDataProviderIds } = usePermanentFilter();
 
-  const showMap = isMapSelected(topFilter);
-
   const query = route.params?.query ?? '';
+
+  const showMap = isMapSelected(query, topFilter);
 
   // we currently only require the position for POIs
   const sortByDistance = query === QUERY_TYPES.POINTS_OF_INTEREST;


### PR DESCRIPTION
added check for POI type when considering `showMap` to delete the `limit` param in `queryVariables` which could lead to requesting all news items when this is not intended