### PR TITLE
fix: react types version and versions listed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ For detailed documentation see the [docs](./docs/INDEX.md).
 
 Information about currently used packages and their versions:
 
-- Expo (43.0.1): https://github.com/expo/expo
-- React Native (0.64.3): https://github.com/facebook/react-native
-- React (17.0.1): https://github.com/facebook/react
+- Expo (45.0.6): https://github.com/expo/expo
+- React Native (0.68.2): https://github.com/facebook/react-native
+- React (17.0.2): https://github.com/facebook/react
 - React Navigation (5.16.1): https://github.com/react-navigation/react-navigation
-- React Native WebView (11.13.0): https://github.com/react-native-webview/react-native-webview
+- React Native WebView (11.18.1): https://github.com/react-native-webview/react-native-webview
 - React Native Elements (1.2.7): https://github.com/react-native-training/react-native-elements
-- React Native Calendars (1.1276.0): https://github.com/wix/react-native-calendars
+- React Native Calendars (1.1285.0): https://github.com/wix/react-native-calendars
 - Apollo Client (2.6.10): https://github.com/apollographql/apollo-client
 - GraphQL (14.7.0): https://github.com/graphql/graphql-js
 - styled-components (4.4.1): https://github.com/styled-components/styled-components
-- Jest (25.5.4): https://github.com/facebook/jest
+- Jest (26.6.3): https://github.com/facebook/jest
 
 ## Changelog
 

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "typescript": "~4.3.5"
   },
   "resolutions": {
+    "@types/react": "~17.0.21",
     "markdown-it": "^12.3.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2554,16 +2554,7 @@
   dependencies:
     "@types/react" "^17"
 
-"@types/react@*":
-  version "18.0.15"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.15.tgz#d355644c26832dc27f3e6cbf0c4f4603fc4ab7fe"
-  integrity sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17", "@types/react@~17.0.21":
+"@types/react@*", "@types/react@^17", "@types/react@~17.0.21":
   version "17.0.47"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.47.tgz#4ee71aaf4c5a9e290e03aa4d0d313c5d666b3b78"
   integrity sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==


### PR DESCRIPTION
- there could be problems with different versions of react types so we fixed it to 17.x per resolutions
  - https://stackoverflow.com/a/72714740/9956365
- updated versions of packages used in README