### PR TITLE
fix: solve empty section error

### DIFF
--- a/src/components/CrossData.tsx
+++ b/src/components/CrossData.tsx
@@ -98,6 +98,13 @@ const CrossDataSection = ({
     <DataListSection
       buttonTitle={texts.dataProvider.showAll}
       limit={3}
+      navigateButton={getNavigationFunction(
+        navigation,
+        dataProviderName,
+        query,
+        sectionTitle,
+        categoryId
+      )}
       navigate={getNavigationFunction(
         navigation,
         dataProviderName,

--- a/src/components/DataListSection.tsx
+++ b/src/components/DataListSection.tsx
@@ -58,9 +58,8 @@ export const DataListSection = ({
   if (loading) {
     return (
       <View>
-        {!!sectionTitle && (
-          <SectionHeader onPress={navigate} title={sectionTitle ?? getTitleForQuery(query)} />
-        )}
+        <SectionHeader onPress={navigate} title={sectionTitle ?? getTitleForQuery(query)} />
+
         <LoadingContainer>
           <ActivityIndicator color={colors.accent} />
         </LoadingContainer>
@@ -80,20 +79,14 @@ export const DataListSection = ({
   if (listData?.length) {
     return (
       <View>
-        {!!sectionTitle && (
-          <SectionHeader onPress={navigate} title={sectionTitle ?? getTitleForQuery(query)} />
-        )}
-        {!!limit &&
-          (listData?.length ? (
-            <ListComponent
-              data={isRandom ? _shuffle(listData).slice(0, limit) : listData.slice(0, limit)}
-              horizontal={horizontal}
-              navigation={navigation}
-              query={query}
-            />
-          ) : (
-            !!placeholder && placeholder
-          ))}
+        <SectionHeader onPress={navigate} title={sectionTitle ?? getTitleForQuery(query)} />
+
+        <ListComponent
+          data={isRandom ? _shuffle(listData).slice(0, limit) : listData.slice(0, limit)}
+          horizontal={horizontal}
+          navigation={navigation}
+          query={query}
+        />
         {!!linkTitle && !!navigateLink && showLink && (
           <Wrapper>
             <Touchable onPress={navigateLink}>

--- a/src/components/DataListSection.tsx
+++ b/src/components/DataListSection.tsx
@@ -77,36 +77,49 @@ export const DataListSection = ({
     skipLastDivider: true
   });
 
+  if (listData?.length) {
+    return (
+      <View>
+        {!!sectionTitle && (
+          <SectionHeader onPress={navigate} title={sectionTitle ?? getTitleForQuery(query)} />
+        )}
+        {!!limit &&
+          (listData?.length ? (
+            <ListComponent
+              data={isRandom ? _shuffle(listData).slice(0, limit) : listData.slice(0, limit)}
+              horizontal={horizontal}
+              navigation={navigation}
+              query={query}
+            />
+          ) : (
+            !!placeholder && placeholder
+          ))}
+        {!!linkTitle && !!navigateLink && showLink && (
+          <Wrapper>
+            <Touchable onPress={navigateLink}>
+              <BoldText center primary underline>
+                {linkTitle}
+              </BoldText>
+            </Touchable>
+          </Wrapper>
+        )}
+        {!!buttonTitle && !!navigateButton && showButton && (
+          <Wrapper>
+            <Button title={buttonTitle} onPress={navigateButton} />
+          </Wrapper>
+        )}
+      </View>
+    );
+  }
+
+  if (!placeholder) {
+    return null;
+  }
+
   return (
     <View>
-      {!!sectionTitle && (
-        <SectionHeader onPress={navigate} title={sectionTitle ?? getTitleForQuery(query)} />
-      )}
-      {!!limit &&
-        (listData?.length ? (
-          <ListComponent
-            data={isRandom ? _shuffle(listData).slice(0, limit) : listData.slice(0, limit)}
-            horizontal={horizontal}
-            navigation={navigation}
-            query={query}
-          />
-        ) : (
-          !!placeholder && placeholder
-        ))}
-      {!!linkTitle && !!navigateLink && showLink && (
-        <Wrapper>
-          <Touchable onPress={navigateLink}>
-            <BoldText center primary underline>
-              {linkTitle}
-            </BoldText>
-          </Touchable>
-        </Wrapper>
-      )}
-      {!!buttonTitle && !!navigateButton && showButton && (
-        <Wrapper>
-          <Button title={buttonTitle} onPress={navigateButton} />
-        </Wrapper>
-      )}
+      <SectionHeader onPress={navigate} title={sectionTitle ?? getTitleForQuery(query)} />
+      {placeholder}
     </View>
   );
 };


### PR DESCRIPTION
- fixed the error of displaying empty sections on
  `CrossData` page
- added `navigateButton` prop to `CrossData` to
  make `Alle anzeigen` button appear in sections
- added if to `DataListSection` to prevent rendering
  if `listData` is empty
- added to show placeholder render on screen if
  `listData` comes empty
- added null return if placeholder is empty

## How to test:
* [ ] Android portrait mode
* [x] iOS portrait mode
* [ ] Android landscape mode
* [ ] iOS landscape mode


## Screenshots:
|Before|After|
|--|--|
 ![IMG_0252](https://user-images.githubusercontent.com/11755668/179269570-3e6a9813-7789-4d4f-96dc-c929b4d5d47b.PNG)| ![IMG_089E275CD3FD-1](https://user-images.githubusercontent.com/11755668/179269567-7d796b5e-249e-4a34-a9eb-0f01b5c36e41.jpeg)

