### PR TITLE
refactor(ar): delete object move and rotate functions

### DIFF
--- a/src/screens/augmentedReality/ARShowScreen.js
+++ b/src/screens/augmentedReality/ARShowScreen.js
@@ -153,24 +153,7 @@ export const ARShowScreen = ({ navigation, route }) => {
 };
 
 const AugmentedRealityView = ({ sceneNavigator }) => {
-  const [rotation, setRotation] = useState([0, 0, 0]);
-  const [position, setPosition] = useState([0, -1, -5]);
-
   const { object, isStartAnimation, setIsObjectLoading } = sceneNavigator.viroAppProps;
-
-  const moveObject = (newPosition) => {
-    setPosition(newPosition);
-  };
-
-  const rotateObject = (rotateState, rotationFactor) => {
-    let newRotation = [rotation[0], rotation[1] - rotationFactor, rotation[2]];
-
-    if (rotateState === 2) {
-      setRotation(newRotation);
-
-      return;
-    }
-  };
 
   return (
     <ViroARScene dragType="FixedToWorld">
@@ -180,11 +163,9 @@ const AugmentedRealityView = ({ sceneNavigator }) => {
         source={{ uri: object.vrx }}
         resources={[{ uri: object.png }]}
         type="VRX"
-        position={position}
+        position={[0, -1, -5]}
         scale={[0.02, 0.02, 0.02]}
-        rotation={rotation}
-        onDrag={moveObject}
-        onRotate={rotateObject}
+        rotation={[0, 0, 0]}
         onLoadStart={() => setIsObjectLoading(true)}
         onLoadEnd={() => setIsObjectLoading(false)}
         onError={() => alert(texts.augmentedReality.arShowScreen.objectLoadErrorAlert)}

--- a/src/screens/augmentedReality/ARShowScreen.js
+++ b/src/screens/augmentedReality/ARShowScreen.js
@@ -155,6 +155,12 @@ export const ARShowScreen = ({ navigation, route }) => {
 const AugmentedRealityView = ({ sceneNavigator }) => {
   const { object, isStartAnimation, setIsObjectLoading } = sceneNavigator.viroAppProps;
 
+  // TODO: these data can be updated according to the data coming from the server when the
+  //       real 3D models arrive
+  const position = [0, -1, -5];
+  const rotation = [0, 0, 0];
+  const scale = [0.02, 0.02, 0.02];
+
   return (
     <ViroARScene dragType="FixedToWorld">
       <ViroAmbientLight color={'#fff'} />
@@ -163,9 +169,9 @@ const AugmentedRealityView = ({ sceneNavigator }) => {
         source={{ uri: object.vrx }}
         resources={[{ uri: object.png }]}
         type="VRX"
-        position={[0, -1, -5]}
-        scale={[0.02, 0.02, 0.02]}
-        rotation={[0, 0, 0]}
+        position={position}
+        rotation={rotation}
+        scale={scale}
         onLoadStart={() => setIsObjectLoading(true)}
         onLoadEnd={() => setIsObjectLoading(false)}
         onError={() => alert(texts.augmentedReality.arShowScreen.objectLoadErrorAlert)}


### PR DESCRIPTION
- deleted object `moveObject` and `rotateObject` functions
  as they are not necessary
- replace the `position` and `rotation` props with default
  data since the object  `moveObject` and `rotateObject`
  functions are deleted

SVA-633