### PR TITLE
feat(ar): show buttons after loading the 3D object

### DIFF
--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -17,7 +17,14 @@ export const texts = {
       objectLoadErrorAlert:
         'Beim Laden des 3D-Objekts ist ein Problem aufgetreten. Bitte versuchen Sie es erneut.',
       screenRecordingCompleted: 'Die Aufnahme wurde erfolgreich in Ihrer Galerie gespeichert.',
-      screenRecordingError: 'Bei der Bildschirmaufzeichnung ist ein Fehler aufgetreten.'
+      viroRecordingError: {
+        0: 'Bei der Bildschirmaufzeichnung ist ein Fehler aufgetreten.',
+        1: 'Bitte erlauben Sie die Aufnahme von Videos/Screenshots.',
+        2: 'Bei der Initialisierung der Bildschirmaufzeichnung ist ein Fehler aufgetreten.',
+        3: 'Beim Speichern der Datei ist ein Fehler aufgetreten.',
+        4: 'Ihr System zeichnet bereits auf.',
+        5: 'Ihr System kann derzeit nicht aufzeichnen.'
+      }
     },
     artworkDetailScreen: {
       downloadAndLookAtArt: 'Downloaden & AR Kunst gucken',
@@ -320,8 +327,7 @@ export const texts = {
       'Schade, es wurden keine passenden Einträge in dieser Kategorie gefunden. Bitte eine Unterkategorie wählen oder zu einem späteren Zeitpunkt erneut versuchen.',
     content:
       'Schade, es wurde kein passender Inhalt gefunden, bitte zu einem späteren Zeitpunkt erneut versuchen.',
-    list:
-      'Schade, es wurden keine passenden Einträge gefunden, bitte zu einem späteren Zeitpunkt erneut versuchen.'
+    list: 'Schade, es wurden keine passenden Einträge gefunden, bitte zu einem späteren Zeitpunkt erneut versuchen.'
   },
   errors: {
     image: {
@@ -751,8 +757,7 @@ export const texts = {
     },
     commentSubmissionAlert: {
       de: 'Ihr Kommentar wird nun redaktionell geprüft und schnellstmöglich veröffentlicht.',
-      pl:
-        'Twój komentarz zostanie teraz sprawdzony redakcyjnie i opublikowany tak szybko, jak to możliwe.'
+      pl: 'Twój komentarz zostanie teraz sprawdzony redakcyjnie i opublikowany tak szybko, jak to możliwe.'
     },
     commentSubmissionAlertTitle: 'Ihr Kommentar wird nun redaktionell geprüft',
     dateEnd: {
@@ -769,10 +774,8 @@ export const texts = {
       submissionTitle: 'Fehler'
     },
     hint: {
-      de:
-        'Die Umfrageergebnisse werden erst angezeigt, wenn Sie Ihre Stimme abgegeben haben oder die Umfrage beendet wurde.',
-      pl:
-        'Wyniki ankiety nie będą wyświetlane, dopóki nie oddasz głosu lub ankieta nie zostanie zakończona.'
+      de: 'Die Umfrageergebnisse werden erst angezeigt, wenn Sie Ihre Stimme abgegeben haben oder die Umfrage beendet wurde.',
+      pl: 'Wyniki ankiety nie będą wyświetlane, dopóki nie oddasz głosu lub ankieta nie zostanie zakończona.'
     },
     multiSelectPossible: {
       de: 'Mehrfachantwort möglich.',

--- a/src/screens/augmentedReality/ARShowScreen.js
+++ b/src/screens/augmentedReality/ARShowScreen.js
@@ -284,8 +284,7 @@ var styles = StyleSheet.create({
   objectLoadingIndicatorComponent: {
     height: '100%',
     position: 'absolute',
-    width: '100%',
-    zIndex: 1
+    width: '100%'
   },
   opacity: {
     opacity: 0.6

--- a/src/screens/augmentedReality/ARShowScreen.js
+++ b/src/screens/augmentedReality/ARShowScreen.js
@@ -103,54 +103,57 @@ export const ARShowScreen = ({ navigation, route }) => {
         <Icon.Close color={colors.surface} />
       </TouchableOpacity>
 
-      {isObjectLoading && (
+      {isObjectLoading ? (
         <View style={styles.objectLoadingIndicatorComponent}>
           <LoadingSpinner loading />
         </View>
+      ) : (
+        <>
+          <TouchableOpacity
+            style={[styles.generalButtonStyle, styles.screenRecording, styles.opacity]}
+            onPress={screenVideoRecording}
+          >
+            {isVideoRecording ? (
+              <Icon.NamedIcon
+                name="stop"
+                color={colors.error}
+                size={normalize(30)}
+                style={styles.opacity}
+              />
+            ) : (
+              <Icon.NamedIcon
+                name="videocam"
+                color={colors.error}
+                size={normalize(30)}
+                style={styles.opacity}
+              />
+            )}
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[styles.generalButtonStyle, styles.screenShotButton, styles.opacity]}
+            onPress={takeScreenshot}
+          >
+            <Icon.NamedIcon
+              name="camera"
+              color={colors.darkText}
+              size={normalize(30)}
+              style={styles.opacity}
+            />
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[styles.animationButton, styles.generalButtonStyle]}
+            onPress={() => setIsStartAnimationAndSound(!isStartAnimationAndSound)}
+          >
+            {isStartAnimationAndSound ? (
+              <Icon.NamedIcon name="pause" color={colors.primary} size={normalize(30)} />
+            ) : (
+              <Icon.NamedIcon name="play" color={colors.primary} size={normalize(30)} />
+            )}
+          </TouchableOpacity>
+        </>
       )}
-      <TouchableOpacity
-        style={[styles.generalButtonStyle, styles.screenRecording, styles.opacity]}
-        onPress={screenVideoRecording}
-      >
-        {isVideoRecording ? (
-          <Icon.NamedIcon
-            name="stop"
-            color={colors.error}
-            size={normalize(30)}
-            style={styles.opacity}
-          />
-        ) : (
-          <Icon.NamedIcon
-            name="videocam"
-            color={colors.error}
-            size={normalize(30)}
-            style={styles.opacity}
-          />
-        )}
-      </TouchableOpacity>
-
-      <TouchableOpacity
-        style={[styles.generalButtonStyle, styles.screenShotButton, styles.opacity]}
-        onPress={takeScreenshot}
-      >
-        <Icon.NamedIcon
-          name="camera"
-          color={colors.darkText}
-          size={normalize(30)}
-          style={styles.opacity}
-        />
-      </TouchableOpacity>
-
-      <TouchableOpacity
-        style={[styles.animationButton, styles.generalButtonStyle]}
-        onPress={() => setIsStartAnimationAndSound(!isStartAnimationAndSound)}
-      >
-        {isStartAnimationAndSound ? (
-          <Icon.NamedIcon name="pause" color={colors.primary} size={normalize(30)} />
-        ) : (
-          <Icon.NamedIcon name="play" color={colors.primary} size={normalize(30)} />
-        )}
-      </TouchableOpacity>
 
       <Animated.View
         style={[styles.flashEffectContainer, { opacity: screenshotEffectOpacityRef }]}


### PR DESCRIPTION
- updated the screen recording button, screenshot
  button and animation button to be shown after the
  model is loaded because the buttons are not
  functional without loading the 3D object

SVA-633


## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [ ] Android landscape mode
* [ ] iOS landscape mode