### PR TITLE
feat(ar): handle error for screen record

### DIFF
--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -16,8 +16,14 @@ export const texts = {
         'Bitte beende die Videoaufzeichnung, bevor Sie zurückkehren.',
       objectLoadErrorAlert:
         'Beim Laden des 3D-Objekts ist ein Problem aufgetreten. Bitte versuchen Sie es erneut.',
+      screenRecordAlreadyRecordingError: 'Ihr System zeichnet bereits auf.',
+      screenRecordAlreadyStoppedError: 'Ihr System kann derzeit nicht aufzeichnen.',
       screenRecordingCompleted: 'Die Aufnahme wurde erfolgreich in Ihrer Galerie gespeichert.',
-      screenRecordingError: 'Bei der Bildschirmaufzeichnung ist ein Fehler aufgetreten.'
+      screenRecordingError: 'Bei der Bildschirmaufzeichnung ist ein Fehler aufgetreten.',
+      screenRecordInitializationError:
+        'Bei der Initialisierung der Bildschirmaufzeichnung ist ein Fehler aufgetreten.',
+      screenRecordNoPermissionError: 'Bitte erlauben Sie die Aufnahme von Videos/Screenshots.',
+      screenRecordWriteToFileError: 'Beim Schreiben in die Datei ist ein Fehler aufgetreten.'
     },
     artworkDetailScreen: {
       downloadAndLookAtArt: 'Downloaden & AR Kunst gucken',
@@ -320,8 +326,7 @@ export const texts = {
       'Schade, es wurden keine passenden Einträge in dieser Kategorie gefunden. Bitte eine Unterkategorie wählen oder zu einem späteren Zeitpunkt erneut versuchen.',
     content:
       'Schade, es wurde kein passender Inhalt gefunden, bitte zu einem späteren Zeitpunkt erneut versuchen.',
-    list:
-      'Schade, es wurden keine passenden Einträge gefunden, bitte zu einem späteren Zeitpunkt erneut versuchen.'
+    list: 'Schade, es wurden keine passenden Einträge gefunden, bitte zu einem späteren Zeitpunkt erneut versuchen.'
   },
   errors: {
     image: {
@@ -751,8 +756,7 @@ export const texts = {
     },
     commentSubmissionAlert: {
       de: 'Ihr Kommentar wird nun redaktionell geprüft und schnellstmöglich veröffentlicht.',
-      pl:
-        'Twój komentarz zostanie teraz sprawdzony redakcyjnie i opublikowany tak szybko, jak to możliwe.'
+      pl: 'Twój komentarz zostanie teraz sprawdzony redakcyjnie i opublikowany tak szybko, jak to możliwe.'
     },
     commentSubmissionAlertTitle: 'Ihr Kommentar wird nun redaktionell geprüft',
     dateEnd: {
@@ -769,10 +773,8 @@ export const texts = {
       submissionTitle: 'Fehler'
     },
     hint: {
-      de:
-        'Die Umfrageergebnisse werden erst angezeigt, wenn Sie Ihre Stimme abgegeben haben oder die Umfrage beendet wurde.',
-      pl:
-        'Wyniki ankiety nie będą wyświetlane, dopóki nie oddasz głosu lub ankieta nie zostanie zakończona.'
+      de: 'Die Umfrageergebnisse werden erst angezeigt, wenn Sie Ihre Stimme abgegeben haben oder die Umfrage beendet wurde.',
+      pl: 'Wyniki ankiety nie będą wyświetlane, dopóki nie oddasz głosu lub ankieta nie zostanie zakończona.'
     },
     multiSelectPossible: {
       de: 'Mehrfachantwort möglich.',

--- a/src/screens/augmentedReality/ARShowScreen.js
+++ b/src/screens/augmentedReality/ARShowScreen.js
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types';
-import React, { useCallback, useEffect, useState, useRef } from 'react';
-import { Alert, Animated, View, StyleSheet, TouchableOpacity } from 'react-native';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Alert, Animated, StyleSheet, TouchableOpacity, View } from 'react-native';
 import {
   Viro3DObject,
   ViroAmbientLight,
   ViroARScene,
   ViroARSceneNavigator,
+  ViroRecordingErrorConstants,
   ViroSound
 } from '@viro-community/react-viro';
 
@@ -31,9 +32,13 @@ export const ARShowScreen = ({ navigation, route }) => {
     const fileName = 'AugmentedReality_' + Date.now().toString();
 
     try {
-      await arSceneRef.current._takeScreenshot(fileName, true);
+      const { success, errorCode } = await arSceneRef.current._takeScreenshot(fileName, true);
 
-      screenshotFlashEffect({ screenshotEffectOpacityRef });
+      if (success) {
+        screenshotFlashEffect({ screenshotEffectOpacityRef });
+      } else {
+        errorHandler(errorCode);
+      }
     } catch (error) {
       console.error(error.message);
     }
@@ -47,7 +52,7 @@ export const ARShowScreen = ({ navigation, route }) => {
     if (!isVideoRecording) {
       arSceneRef.current._startVideoRecording(fileName, true, (error) => alert(error));
     } else {
-      const { success } = await arSceneRef.current._stopVideoRecording();
+      const { success, errorCode } = await arSceneRef.current._stopVideoRecording();
 
       if (success) {
         Alert.alert(
@@ -55,15 +60,12 @@ export const ARShowScreen = ({ navigation, route }) => {
           texts.augmentedReality.arShowScreen.screenRecordingCompleted
         );
       } else {
-        Alert.alert(
-          texts.augmentedReality.modalHiddenAlertTitle,
-          texts.augmentedReality.arShowScreen.screenRecordingError
-        );
+        errorHandler(errorCode);
       }
     }
   };
 
-  if (isLoading || !object || !object.vrx) return <LoadingSpinner loading />;
+  if (isLoading || !object) return <LoadingSpinner loading />;
 
   return (
     <>
@@ -209,7 +211,7 @@ const AugmentedRealityView = ({ sceneNavigator }) => {
   );
 };
 
-const objectParser = async ({ item, setObject, setIsLoading, onPress }) => {
+const objectParser = async ({ item, setObject, setIsLoading }) => {
   let parsedObject = {};
 
   if (item.animationName) {
@@ -220,22 +222,55 @@ const objectParser = async ({ item, setObject, setIsLoading, onPress }) => {
     parsedObject[item.type] = item.uri;
   });
 
-  // TODO: Just for the test
-  if (!parsedObject.vrx) {
-    return Alert.alert(
-      'Hinweis',
-      'Bitte laden Sie ein echtes AR-Objekt herunter. Die Dateien im Gerät sind nur zu Testzwecken vorbereitet. Sie können ein Beispielobjekt sehen, indem Sie die Datei Diffuse Texture aus der Objektliste herunterladen.',
-      [
-        {
-          text: 'OK',
-          onPress
-        }
-      ]
-    );
-  }
-
   setObject(parsedObject);
   setIsLoading(false);
+};
+
+const errorHandler = (errorCode) => {
+  switch (errorCode) {
+    case ViroRecordingErrorConstants.RECORD_ERROR_UNKNOWN:
+      Alert.alert(
+        texts.augmentedReality.modalHiddenAlertTitle,
+        texts.augmentedReality.arShowScreen.screenRecordingError
+      );
+      break;
+    case ViroRecordingErrorConstants.RECORD_ERROR_NO_PERMISSION:
+      Alert.alert(
+        texts.augmentedReality.modalHiddenAlertTitle,
+        texts.augmentedReality.arShowScreen.screenRecordNoPermissionError
+      );
+      break;
+    case ViroRecordingErrorConstants.RECORD_ERROR_INITIALIZATION:
+      Alert.alert(
+        texts.augmentedReality.modalHiddenAlertTitle,
+        texts.augmentedReality.arShowScreen.screenRecordInitializationError
+      );
+      break;
+    case ViroRecordingErrorConstants.RECORD_ERROR_WRITE_TO_FILE:
+      Alert.alert(
+        texts.augmentedReality.modalHiddenAlertTitle,
+        texts.augmentedReality.arShowScreen.screenRecordWriteToFileError
+      );
+      break;
+    case ViroRecordingErrorConstants.RECORD_ERROR_ALREADY_RUNNING:
+      Alert.alert(
+        texts.augmentedReality.modalHiddenAlertTitle,
+        texts.augmentedReality.arShowScreen.screenRecordAlreadyRecordingError
+      );
+      break;
+    case ViroRecordingErrorConstants.RECORD_ERROR_ALREADY_STOPPED:
+      Alert.alert(
+        texts.augmentedReality.modalHiddenAlertTitle,
+        texts.augmentedReality.arShowScreen.screenRecordAlreadyStoppedError
+      );
+      break;
+    default:
+      Alert.alert(
+        texts.augmentedReality.modalHiddenAlertTitle,
+        texts.augmentedReality.arShowScreen.screenRecordingError
+      );
+      break;
+  }
 };
 
 const screenshotFlashEffect = ({ screenshotEffectOpacityRef }) => {


### PR DESCRIPTION
- added alerts to explain the different errors
  encountered when screen recording and
  screenshotting
- removed alert in `objectParser` used for
  testing
- added `ViroRecordingErrorConstants` to
  understand which error was returned in
  response to `errorCode`
- added error messages to `texts` file

SVA-633

## How to test:
* [ ] Android portrait mode
* [x] iOS portrait mode
* [ ] Android landscape mode
* [ ] iOS landscape mode

