### PR TITLE
feat(ar): recognise image and show model

### DIFF
--- a/src/components/augmentedReality/AugmentedReality.js
+++ b/src/components/augmentedReality/AugmentedReality.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
+import { isARSupportedOnDevice } from '@viro-community/react-viro';
 
 import { consts, device, texts } from '../../config';
 import { checkDownloadedData } from '../../helpers';
@@ -14,14 +15,27 @@ import { ARObjectList } from './ARObjectList';
 import { WhatIsARButton } from './WhatIsARButton';
 
 export const AugmentedReality = ({ navigation, onSettingsScreen, tourID }) => {
-  const { data: staticData, error, loading, refetch } = useStaticContent({
+  const {
+    data: staticData,
+    error,
+    loading,
+    refetch
+  } = useStaticContent({
     name: `arDownloadableDataList-${tourID}`,
     type: 'json'
   });
 
+  const [isARSupported, setIsARSupported] = useState(false);
   const [data, setData] = useState([]);
   const [isLoading, setIsLoading] = useState(loading);
   const [isModalVisible, setIsModalVisible] = useState(false);
+
+  useEffect(() => {
+    isARSupportedOnDevice(
+      () => null,
+      () => setIsARSupported(true)
+    );
+  }, []);
 
   useEffect(() => {
     setData(staticData);
@@ -37,7 +51,7 @@ export const AugmentedReality = ({ navigation, onSettingsScreen, tourID }) => {
     setIsLoading(false);
   };
 
-  if (error) return null;
+  if (error || !isARSupported) return null;
 
   if (isLoading || !staticData) return <LoadingSpinner loading />;
 

--- a/src/components/augmentedReality/AugmentedRealityView.js
+++ b/src/components/augmentedReality/AugmentedRealityView.js
@@ -1,0 +1,122 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {
+  Viro3DObject,
+  ViroAmbientLight,
+  ViroARImageMarker,
+  ViroARScene,
+  ViroARTrackingTargets,
+  ViroSound
+} from '@viro-community/react-viro';
+
+import { texts } from '../../config';
+
+export const AugmentedRealityView = ({ sceneNavigator }) => {
+  const {
+    isObjectLoading,
+    setIsObjectLoading,
+    isStartAnimationAndSound,
+    setIsStartAnimationAndSound,
+    object
+  } = sceneNavigator.viroAppProps;
+
+  // TODO: these data can be updated according to the data coming from the server when the
+  //       real 3D models arrive
+  const position = [0, 0, 0];
+  const rotation = [0, 0, 0];
+  const scale = [0.002, 0.002, 0.002];
+
+  ViroARTrackingTargets.createTargets({
+    targetImage: {
+      physicalWidth: 0.2, // real world width in meters
+      source: { uri: object.target },
+      type: 'image'
+    }
+  });
+
+  return (
+    <ViroARScene dragType="FixedToWorld">
+      <ViroAmbientLight color={'#fff'} />
+
+      {object.target ? (
+        <ViroARImageMarker
+          onAnchorFound={() => setIsStartAnimationAndSound(true)} // animation and sound file are started after the image is recognised
+          pauseUpdates // prevents the model from continuous jumping
+          target={'targetImage'}
+        >
+          <ViroSoundAnd3DObject
+            {...{
+              isObjectLoading,
+              isStartAnimationAndSound,
+              object,
+              position,
+              rotation,
+              scale,
+              setIsObjectLoading,
+              setIsStartAnimationAndSound
+            }}
+          />
+        </ViroARImageMarker>
+      ) : (
+        <ViroSoundAnd3DObject
+          {...{
+            isObjectLoading,
+            isStartAnimationAndSound,
+            object,
+            position,
+            rotation,
+            scale,
+            setIsObjectLoading,
+            setIsStartAnimationAndSound
+          }}
+        />
+      )}
+    </ViroARScene>
+  );
+};
+
+const ViroSoundAnd3DObject = (item) => {
+  const {
+    isObjectLoading,
+    isStartAnimationAndSound,
+    object,
+    position,
+    rotation,
+    scale,
+    setIsObjectLoading,
+    setIsStartAnimationAndSound
+  } = item;
+
+  return (
+    <>
+      {!!object.mp3 && !isObjectLoading && (
+        <ViroSound
+          source={{ uri: object.mp3 }}
+          paused={!isStartAnimationAndSound}
+          onFinish={() => setIsStartAnimationAndSound(false)}
+        />
+      )}
+
+      <Viro3DObject
+        source={{ uri: object.vrx }}
+        resources={[{ uri: object.png }]}
+        type="VRX"
+        position={position}
+        rotation={rotation}
+        scale={scale}
+        onLoadStart={() => setIsObjectLoading(true)}
+        onLoadEnd={() => setIsObjectLoading(false)}
+        onError={() => alert(texts.augmentedReality.arShowScreen.objectLoadErrorAlert)}
+        animation={{
+          loop: true,
+          name: object.animationName,
+          run: isStartAnimationAndSound
+        }}
+      />
+    </>
+  );
+};
+
+AugmentedRealityView.propTypes = {
+  sceneNavigator: PropTypes.object
+};

--- a/src/components/augmentedReality/AugmentedRealityView.js
+++ b/src/components/augmentedReality/AugmentedRealityView.js
@@ -53,8 +53,11 @@ export const AugmentedRealityView = ({ sceneNavigator }) => {
     />
   );
 
+  /* see `onAnchorFound` function to auto-start animation and sound file 
+     when showing a 3D model that is not `TARGET` in the future time */
+
   return (
-    <ViroARScene dragType="FixedToWorld">
+    <ViroARScene>
       <ViroAmbientLight color={colors.surface} />
 
       {object?.target ? (

--- a/src/components/augmentedReality/AugmentedRealityView.js
+++ b/src/components/augmentedReality/AugmentedRealityView.js
@@ -1,5 +1,3 @@
-import PropTypes from 'prop-types';
-import React from 'react';
 import {
   Viro3DObject,
   ViroAmbientLight,
@@ -8,8 +6,10 @@ import {
   ViroARTrackingTargets,
   ViroSound
 } from '@viro-community/react-viro';
+import PropTypes from 'prop-types';
+import React, { useEffect } from 'react';
 
-import { texts } from '../../config';
+import { colors, texts } from '../../config';
 
 export const AugmentedRealityView = ({ sceneNavigator }) => {
   const {
@@ -20,56 +20,53 @@ export const AugmentedRealityView = ({ sceneNavigator }) => {
     object
   } = sceneNavigator.viroAppProps;
 
+  const TARGET = 'targetImage';
+
   // TODO: these data can be updated according to the data coming from the server when the
   //       real 3D models arrive
   const position = [0, 0, 0];
   const rotation = [0, 0, 0];
   const scale = [0.002, 0.002, 0.002];
 
-  ViroARTrackingTargets.createTargets({
-    targetImage: {
-      physicalWidth: 0.2, // real world width in meters
-      source: { uri: object.target },
-      type: 'image'
-    }
-  });
+  useEffect(() => {
+    ViroARTrackingTargets.createTargets({
+      [TARGET]: {
+        physicalWidth: 0.2, // real world width in meters
+        source: { uri: object.target },
+        type: 'image'
+      }
+    });
+  }, [object?.target]);
+
+  const ViroContent = (
+    <ViroSoundAnd3DObject
+      {...{
+        isObjectLoading,
+        isStartAnimationAndSound,
+        object,
+        position,
+        rotation,
+        scale,
+        setIsObjectLoading,
+        setIsStartAnimationAndSound
+      }}
+    />
+  );
 
   return (
     <ViroARScene dragType="FixedToWorld">
-      <ViroAmbientLight color={'#fff'} />
+      <ViroAmbientLight color={colors.surface} />
 
-      {object.target ? (
+      {object?.target ? (
         <ViroARImageMarker
           onAnchorFound={() => setIsStartAnimationAndSound(true)} // animation and sound file are started after the image is recognised
           pauseUpdates // prevents the model from continuous jumping
-          target={'targetImage'}
+          target={TARGET}
         >
-          <ViroSoundAnd3DObject
-            {...{
-              isObjectLoading,
-              isStartAnimationAndSound,
-              object,
-              position,
-              rotation,
-              scale,
-              setIsObjectLoading,
-              setIsStartAnimationAndSound
-            }}
-          />
+          {ViroContent}
         </ViroARImageMarker>
       ) : (
-        <ViroSoundAnd3DObject
-          {...{
-            isObjectLoading,
-            isStartAnimationAndSound,
-            object,
-            position,
-            rotation,
-            scale,
-            setIsObjectLoading,
-            setIsStartAnimationAndSound
-          }}
-        />
+        ViroContent
       )}
     </ViroARScene>
   );

--- a/src/components/augmentedReality/index.js
+++ b/src/components/augmentedReality/index.js
@@ -1,6 +1,7 @@
 export * from './ARModal';
 export * from './ARObjectList';
 export * from './AugmentedReality';
+export * from './AugmentedRealityView';
 export * from './HiddenModalAlert';
 export * from './IconForDownloadType';
 export * from './WhatIsARButton';

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -33,6 +33,7 @@ export const texts = {
     },
     cancel: 'Abbrechen',
     hide: 'Ausblenden',
+    invalidModelError: 'Das 3D-Modell konnte nicht richtig geladen werden.',
     loadingArtworks: 'Kunstwerke laden',
     modalHiddenAlertMessage:
       'Das Herunterladen der Dateien ist noch im Gange. Bitte warten Sie, bis der Download komplett abgeschlossen ist, da ansonsten Probleme mit den heruntergeladenen Dateien auftreten können.',

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -1,3 +1,4 @@
+import { isARSupportedOnDevice } from '@viro-community/react-viro';
 import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
 import { ActivityIndicator, Alert, SectionList } from 'react-native';
@@ -58,8 +59,7 @@ const TOP_FILTER = {
 
 const INITIAL_FILTER = [
   { id: TOP_FILTER.GENERAL, title: texts.settingsTitles.tabs.general, selected: true },
-  { id: TOP_FILTER.LIST_TYPES, title: texts.settingsTitles.tabs.listTypes, selected: false },
-  { id: TOP_FILTER.AR_DOWNLOAD_LIST, title: texts.settingsTitles.tabs.arSettings, selected: false }
+  { id: TOP_FILTER.LIST_TYPES, title: texts.settingsTitles.tabs.listTypes, selected: false }
 ];
 
 export const SettingsScreen = () => {
@@ -195,6 +195,21 @@ export const SettingsScreen = () => {
     };
 
     updateSectionedData();
+  }, []);
+
+  useEffect(() => {
+    isARSupportedOnDevice(
+      () => null,
+      () =>
+        setFilter([
+          ...filter,
+          {
+            id: TOP_FILTER.AR_DOWNLOAD_LIST,
+            title: texts.settingsTitles.tabs.arSettings,
+            selected: false
+          }
+        ])
+    );
   }, []);
 
   if (!sectionedData.length) {


### PR DESCRIPTION
- added image recognition feature to show
  3D model
- wrapped augmented reality features with
  the `ViroARImageMarker` component to
  make the image recognition feature work
- added `targetImage` in `createTargets`
  object from `ViroARTrackingTargets` to
  add image information
- update the scale because the model looks
  too big
- added animation of the model and sound file
  when the image is recognised

SVA-633


## How to test:
* [ ] Android portrait mode
* [x] iOS portrait mode
* [ ] Android landscape mode
* [ ] iOS landscape mode

In order to test this feature, you must first delete any downloaded model data on your device. Then refresh the model list and download it again (54.9 MB). Because the target image must be added to the server for the image recognition feature.

After the download is complete, go to `ARShowScreen` and show the image shared below to the camera. 



![augmentedReality](https://user-images.githubusercontent.com/11755668/179988998-91bb56e7-c5da-4b1b-b192-46b3064c2a81.png)



