### PR TITLE
feat(news): index with multiple category ids

### DIFF
--- a/src/hooks/NewsCategories.ts
+++ b/src/hooks/NewsCategories.ts
@@ -21,5 +21,6 @@ export const useNewsCategories = () => {
     categoryTitleDetail?: string;
     categoryButton?: string;
     categoryId?: string;
+    indexCategoryIds?: string[];
   }>;
 };

--- a/src/queries/newsItems.js
+++ b/src/queries/newsItems.js
@@ -9,6 +9,7 @@ export const GET_NEWS_ITEMS = gql`
     $dataProviderId: ID
     $excludeDataProviderIds: [ID]
     $categoryId: ID
+    $categoryIds: [ID]
   ) {
     newsItems(
       ids: $ids
@@ -18,6 +19,7 @@ export const GET_NEWS_ITEMS = gql`
       dataProviderId: $dataProviderId
       excludeDataProviderIds: $excludeDataProviderIds
       categoryId: $categoryId
+      categoryIds: $categoryIds
     ) {
       id
       mainTitle: title
@@ -69,6 +71,7 @@ export const GET_NEWS_ITEMS_AND_DATA_PROVIDERS = gql`
     $dataProviderId: ID
     $excludeDataProviderIds: [ID]
     $categoryId: ID
+    $categoryIds: [ID]
   ) {
     newsItems(
       limit: $limit
@@ -77,6 +80,7 @@ export const GET_NEWS_ITEMS_AND_DATA_PROVIDERS = gql`
       dataProviderId: $dataProviderId
       excludeDataProviderIds: $excludeDataProviderIds
       categoryId: $categoryId
+      categoryIds: $categoryIds
     ) {
       id
       mainTitle: title

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -116,16 +116,32 @@ export const HomeScreen = ({ navigation, route }) => {
         rootRouteName: ROOT_ROUTE_NAMES.EVENT_RECORDS
       }
     },
-    NEWS_ITEMS_INDEX: ({ categoryId, categoryTitle, categoryTitleDetail, rootRouteName }) => ({
-      name: 'Index',
-      params: {
-        title: categoryTitle,
-        titleDetail: categoryTitleDetail,
-        query: QUERY_TYPES.NEWS_ITEMS,
-        queryVariables: { limit: 15, ...{ categoryId } },
-        rootRouteName: rootRouteName || ROOT_ROUTE_NAMES.NEWS_ITEMS
+    NEWS_ITEMS_INDEX: ({
+      categoryId,
+      categoryTitle,
+      categoryTitleDetail,
+      indexCategoryIds,
+      rootRouteName
+    }) => {
+      const queryVariables = { limit: 15 };
+
+      if (indexCategoryIds?.length) {
+        queryVariables.categoryIds = indexCategoryIds;
+      } else {
+        queryVariables.categoryId = categoryId;
       }
-    })
+
+      return {
+        name: 'Index',
+        params: {
+          title: categoryTitle,
+          titleDetail: categoryTitleDetail,
+          query: QUERY_TYPES.NEWS_ITEMS,
+          queryVariables,
+          rootRouteName: rootRouteName || ROOT_ROUTE_NAMES.NEWS_ITEMS
+        }
+      };
+    }
   };
 
   return (
@@ -152,7 +168,14 @@ export const HomeScreen = ({ navigation, route }) => {
         {showNews &&
           categoriesNews.map(
             (
-              { categoryButton, categoryId, categoryTitle, categoryTitleDetail, rootRouteName },
+              {
+                categoryButton,
+                categoryId,
+                categoryTitle,
+                categoryTitleDetail,
+                indexCategoryIds,
+                rootRouteName
+              },
               index
             ) => (
               <HomeSection
@@ -168,6 +191,7 @@ export const HomeScreen = ({ navigation, route }) => {
                       categoryId,
                       categoryTitle,
                       categoryTitleDetail,
+                      indexCategoryIds,
                       rootRouteName
                     })
                   )


### PR DESCRIPTION
Added an option to request multiple category ids on the index screen if passed with `indexCategoryIds`. If not it uses the `categoryId` like before. The main-server is prepared to accept `categoryId` or `categoryIds`.

SVA-660

---

For global settings here is an example to request category with id 1 on the home screen and when navigating to the index screen there should be requested category ids 1 and 78:

<img width="433" alt="Bildschirmfoto 2022-07-21 um 17 17 18" src="https://user-images.githubusercontent.com/1942953/180261823-c36c2016-68b6-4a31-8e11-8400b511bccc.png">

