### PR TITLE
fix(ar): solve android crash for recognise image

### DIFF
--- a/src/components/augmentedReality/AugmentedRealityView.js
+++ b/src/components/augmentedReality/AugmentedRealityView.js
@@ -31,6 +31,7 @@ export const AugmentedRealityView = ({ sceneNavigator }) => {
   useEffect(() => {
     ViroARTrackingTargets.createTargets({
       [TARGET]: {
+        orientation: 'Up',
         physicalWidth: 0.2, // real world width in meters
         source: { uri: object.target },
         type: 'image'


### PR DESCRIPTION
- added `orientation` prop to `createTargets`
  because image recognition feature is crash
  in android
  -  orientation prop: determines the orientation
      of the source image

[viro document for orientation](https://viro-community.readme.io/docs/viroartrackingtargets#orientation)

SVA-633