### PR TITLE
feat: add filter for daily events on index screen

### DIFF
--- a/src/components/CategoryList.js
+++ b/src/components/CategoryList.js
@@ -1,14 +1,15 @@
+import _filter from 'lodash/filter';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { SectionList, View } from 'react-native';
-import _filter from 'lodash/filter';
+import { ActivityIndicator, SectionList, View } from 'react-native';
 
-import { device, consts, texts } from '../config';
+import { colors, consts, device, texts } from '../config';
 
+import { CategoryListItem } from './CategoryListItem';
+import { LoadingContainer } from './LoadingContainer';
 import { RegularText } from './Text';
 import { Title, TitleContainer, TitleShadow } from './Title';
 import { Wrapper } from './Wrapper';
-import { CategoryListItem } from './CategoryListItem';
 
 export class CategoryList extends React.PureComponent {
   keyExtractor = (item, index) => `index${index}-id${item.id}`;
@@ -30,6 +31,14 @@ export class CategoryList extends React.PureComponent {
 
   render() {
     const { data, navigation, noSubtitle, refreshControl, hasSectionHeader } = this.props;
+
+    if (!data?.length) {
+      return (
+        <LoadingContainer>
+          <ActivityIndicator color={colors.accent} />
+        </LoadingContainer>
+      );
+    }
 
     // Sorting data alphabetically
     data.sort((a, b) => a.title.localeCompare(b.title));
@@ -80,7 +89,7 @@ export class CategoryList extends React.PureComponent {
 
 CategoryList.propTypes = {
   navigation: PropTypes.object.isRequired,
-  data: PropTypes.array.isRequired,
+  data: PropTypes.array,
   noSubtitle: PropTypes.bool,
   refreshControl: PropTypes.object,
   hasSectionHeader: PropTypes.bool

--- a/src/components/DropdownHeader.js
+++ b/src/components/DropdownHeader.js
@@ -1,102 +1,161 @@
+import _isEmpty from 'lodash/isEmpty';
 import _uniqBy from 'lodash/uniqBy';
 import PropTypes from 'prop-types';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { texts } from '../config';
+import { colors, device, Icon, normalize, texts } from '../config';
 import { usePermanentFilter } from '../hooks';
+import { OrientationContext } from '../OrientationProvider';
 import { QUERY_TYPES } from '../queries';
 
 import { DropdownSelect } from './DropdownSelect';
-import { Wrapper } from './Wrapper';
+import { Label } from './Label';
+import { RegularText } from './Text';
+import { Wrapper, WrapperHorizontal, WrapperRow } from './Wrapper';
+
+const dropdownEntries = (query, queryVariables, data, excludedDataProviders) => {
+  // check if there is something set in the certain `queryVariables`
+  // if not, - Alle - will be selected in the `dropdownData`
+  const selected = {
+    [QUERY_TYPES.EVENT_RECORDS]: !queryVariables.categoryId,
+    [QUERY_TYPES.NEWS_ITEMS]: !queryVariables.dataProvider
+  }[query];
+
+  const blankEntry = {
+    id: '-1',
+    index: 0,
+    value: '- Alle -',
+    selected
+  };
+
+  let entries = [];
+
+  if (query === QUERY_TYPES.EVENT_RECORDS && data?.categories?.length) {
+    entries = _uniqBy(data.categories, 'name')
+      .filter((category) => !!category.upcomingEventRecordsCount)
+      .map((category, index) => ({
+        index: index + 1,
+        id: category.id,
+        value: category.name,
+        selected: category.id === queryVariables.categoryId
+      }));
+  } else if (query === QUERY_TYPES.NEWS_ITEMS) {
+    const filteredDataProviders = data?.dataProviders?.filter(
+      (dataProvider) => !excludedDataProviders.includes(dataProvider.id)
+    );
+
+    if (filteredDataProviders?.length) {
+      entries = _uniqBy(filteredDataProviders, 'name').map((dataProvider, index) => ({
+        index: index + 1,
+        id: dataProvider.id,
+        value: dataProvider.name,
+        selected: dataProvider.name === queryVariables.dataProvider
+      }));
+    }
+  }
+  return [blankEntry, ...entries];
+};
 
 export const DropdownHeader = ({ query, queryVariables, data, updateListData }) => {
+  const isEmptyData = _isEmpty(data);
+  const { orientation } = useContext(OrientationContext);
+  const { left: safeAreaLeft } = useSafeAreaInsets();
+
+  const marginHorizontal = normalize(14) + safeAreaLeft;
+
   const dropdownLabel = {
     [QUERY_TYPES.EVENT_RECORDS]: texts.categoryFilter.category,
     [QUERY_TYPES.NEWS_ITEMS]: texts.categoryFilter.dataProvider
   }[query];
 
-  const { state: excludedDataProviders } = usePermanentFilter();
-
-  const dropdownInitialData = useCallback(() => {
-    switch (query) {
-      case QUERY_TYPES.EVENT_RECORDS:
-        return data?.categories?.length
-          ? _uniqBy(data.categories, 'name')
-              .filter((category) => !!category.upcomingEventRecordsCount)
-              .map((category, index) => ({
-                index: index + 1,
-                id: category.id,
-                value: category.name,
-                selected: category.id === queryVariables.categoryId
-              }))
-          : [];
-      case QUERY_TYPES.NEWS_ITEMS: {
-        const filteredDataProviders = data?.dataProviders?.filter(
-          (dataProvider) => !excludedDataProviders.includes(dataProvider.id)
-        );
-
-        return filteredDataProviders?.length
-          ? _uniqBy(filteredDataProviders, 'name').map((dataProvider, index) => ({
-              index: index + 1,
-              value: dataProvider.name,
-              selected: dataProvider.name === queryVariables.dataProvider
-            }))
-          : [];
-      }
-      default:
-        return [];
-    }
-  }, [query, queryVariables, data, updateListData, excludedDataProviders]);
-
-  // check if there is something set in the certain `queryVariables`
-  // if not, - Alle - will be selected in the `dropdownData`
-  const selectedInitial = {
-    [QUERY_TYPES.EVENT_RECORDS]: !queryVariables.categoryId,
-    [QUERY_TYPES.NEWS_ITEMS]: !queryVariables.dataProvider
-  }[query];
   const selectedKey = {
     [QUERY_TYPES.EVENT_RECORDS]: 'id',
     [QUERY_TYPES.NEWS_ITEMS]: 'value'
   }[query];
 
-  const [dropdownData, setDropdownData] = useState([
-    {
-      index: 0,
-      value: '- Alle -',
-      selected: selectedInitial
-    }
-  ]);
+  const { state: excludedDataProviders } = usePermanentFilter();
+
+  const [dropdownData, setDropdownData] = useState(
+    dropdownEntries(query, queryVariables, data, excludedDataProviders)
+  );
 
   // https://medium.com/swlh/prevent-useeffects-callback-firing-during-initial-render-the-armchair-critic-f71bc0e03536
   const initialRender = useRef(true);
 
-  const selectedDropdownData = dropdownData?.find((entry) => entry.selected);
+  const selectedDropdownData = dropdownData?.find((entry) => entry.selected) || {};
 
   useEffect(() => {
-    setDropdownData((oldDropdownData) => [...oldDropdownData, ...dropdownInitialData()]);
-  }, [query]);
+    !isEmptyData &&
+      setDropdownData(dropdownEntries(query, queryVariables, data, excludedDataProviders));
+  }, [data]);
 
   // influence list data when changing selected dropdown value
-  // call update of the list with the selected data provider
+  // call update of the list with the selected key
   useEffect(() => {
     if (initialRender.current) {
       initialRender.current = false;
     } else {
-      // do not pass the value, if the index is 0, because we do not want to use "- Alle -"
+      // do not pass the value, if the index is 0, because we do not want to use "- Alle -" or "-1"
       // inside of updateListData
-      updateListData(!!selectedDropdownData.index && selectedDropdownData[selectedKey]);
+      !isEmptyData &&
+        updateListData(!!selectedDropdownData?.index && selectedDropdownData[selectedKey]);
     }
-  }, [selectedDropdownData?.value]);
+  }, [selectedDropdownData]);
 
-  // do not show a filter, if there is just one entry (Alle + Item = 2)
-  if (dropdownData.length <= 2) return null;
+  if (!isEmptyData && dropdownData.length <= 2) return null;
 
   return (
     <Wrapper>
-      <DropdownSelect data={dropdownData} setData={setDropdownData} label={dropdownLabel} />
+      {isEmptyData ? (
+        <View>
+          <WrapperHorizontal>
+            <Label>{dropdownLabel}</Label>
+          </WrapperHorizontal>
+          <View
+            style={[
+              styles.dropdownDropdown,
+              {
+                width:
+                  (orientation === 'portrait' ? device.width : device.height) - 2 * marginHorizontal
+              }
+            ]}
+          >
+            <WrapperRow style={styles.dropdownTextWrapper}>
+              <RegularText style={styles.selectedValueText}>
+                {selectedDropdownData?.value || '- Alle -'}
+              </RegularText>
+              <Icon.ArrowDown />
+            </WrapperRow>
+          </View>
+        </View>
+      ) : (
+        <DropdownSelect data={dropdownData} setData={setDropdownData} label={dropdownLabel} />
+      )}
     </Wrapper>
   );
 };
+
+const styles = StyleSheet.create({
+  dropdownTextWrapper: {
+    borderColor: colors.borderRgba,
+    borderWidth: StyleSheet.hairlineWidth,
+    justifyContent: 'space-between',
+    padding: normalize(14)
+  },
+  dropdownDropdown: {
+    borderColor: colors.borderRgba,
+    borderRadius: 0,
+    borderWidth: StyleSheet.hairlineWidth,
+    elevation: 2,
+    shadowColor: colors.shadow,
+    shadowOffset: { height: 5, width: 0 },
+    shadowOpacity: 0.5,
+    shadowRadius: 3
+  },
+  selectedValueText: { width: '90%' }
+});
 
 DropdownHeader.propTypes = {
   query: PropTypes.string.isRequired,

--- a/src/components/DropdownHeader.js
+++ b/src/components/DropdownHeader.js
@@ -1,10 +1,10 @@
-import PropTypes from 'prop-types';
-import React, { useEffect, useRef, useState } from 'react';
 import _uniqBy from 'lodash/uniqBy';
+import PropTypes from 'prop-types';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { texts } from '../config';
-import { QUERY_TYPES } from '../queries';
 import { usePermanentFilter } from '../hooks';
+import { QUERY_TYPES } from '../queries';
 
 import { DropdownSelect } from './DropdownSelect';
 import { Wrapper } from './Wrapper';
@@ -17,36 +17,36 @@ export const DropdownHeader = ({ query, queryVariables, data, updateListData }) 
 
   const { state: excludedDataProviders } = usePermanentFilter();
 
-  const dropdownInitialData = (query) => {
+  const dropdownInitialData = useCallback(() => {
     switch (query) {
       case QUERY_TYPES.EVENT_RECORDS:
-        return (
-          data?.categories?.length &&
-          _uniqBy(data.categories, 'name')
-            .filter((category) => !!category.upcomingEventRecordsCount)
-            .map((category, index) => ({
-              index: index + 1,
-              id: category.id,
-              value: category.name,
-              selected: category.id === queryVariables.categoryId
-            }))
-        );
+        return data?.categories?.length
+          ? _uniqBy(data.categories, 'name')
+              .filter((category) => !!category.upcomingEventRecordsCount)
+              .map((category, index) => ({
+                index: index + 1,
+                id: category.id,
+                value: category.name,
+                selected: category.id === queryVariables.categoryId
+              }))
+          : [];
       case QUERY_TYPES.NEWS_ITEMS: {
         const filteredDataProviders = data?.dataProviders?.filter(
           (dataProvider) => !excludedDataProviders.includes(dataProvider.id)
         );
 
-        return (
-          filteredDataProviders?.length &&
-          _uniqBy(filteredDataProviders, 'name').map((dataProvider, index) => ({
-            index: index + 1,
-            value: dataProvider.name,
-            selected: dataProvider.name === queryVariables.dataProvider
-          }))
-        );
+        return filteredDataProviders?.length
+          ? _uniqBy(filteredDataProviders, 'name').map((dataProvider, index) => ({
+              index: index + 1,
+              value: dataProvider.name,
+              selected: dataProvider.name === queryVariables.dataProvider
+            }))
+          : [];
       }
+      default:
+        return [];
     }
-  };
+  }, [query, queryVariables, data, updateListData, excludedDataProviders]);
 
   // check if there is something set in the certain `queryVariables`
   // if not, - Alle - will be selected in the `dropdownData`
@@ -64,14 +64,17 @@ export const DropdownHeader = ({ query, queryVariables, data, updateListData }) 
       index: 0,
       value: '- Alle -',
       selected: selectedInitial
-    },
-    ...(dropdownInitialData(query) || [])
+    }
   ]);
-
-  const selectedDropdownData = dropdownData.find((entry) => entry.selected);
 
   // https://medium.com/swlh/prevent-useeffects-callback-firing-during-initial-render-the-armchair-critic-f71bc0e03536
   const initialRender = useRef(true);
+
+  const selectedDropdownData = dropdownData?.find((entry) => entry.selected);
+
+  useEffect(() => {
+    setDropdownData((oldDropdownData) => [...oldDropdownData, ...dropdownInitialData()]);
+  }, [query]);
 
   // influence list data when changing selected dropdown value
   // call update of the list with the selected data provider
@@ -83,7 +86,7 @@ export const DropdownHeader = ({ query, queryVariables, data, updateListData }) 
       // inside of updateListData
       updateListData(!!selectedDropdownData.index && selectedDropdownData[selectedKey]);
     }
-  }, [selectedDropdownData.value]);
+  }, [selectedDropdownData?.value]);
 
   // do not show a filter, if there is just one entry (Alle + Item = 2)
   if (dropdownData.length <= 2) return null;

--- a/src/components/DropdownSelect.js
+++ b/src/components/DropdownSelect.js
@@ -39,14 +39,28 @@ export const DropdownSelect = ({
     [marginHorizontal]
   );
 
-  if (!data || !data.length) return null;
-
   const [arrow, setArrow] = useState('down');
-  const selectedData = data.find((entry) => entry.selected);
+  const selectedData = data?.find((entry) => entry.selected);
   const selectedValue = selectedData?.value;
-  const selectedMultipleData = data.filter((entry) => entry.selected);
+  const selectedIndex = selectedData?.index;
+  const selectedMultipleData = data?.filter((entry) => entry.selected);
   const selectedMultipleValues = selectedMultipleData?.map((entry) => entry.value).join(', ');
-  const selectedIndex = data.findIndex((entry) => entry.selected);
+
+  const renderRow = useCallback(
+    (rowData, rowID, highlighted) => {
+      if (multipleSelect) {
+        highlighted = selectedMultipleValues.includes(rowData);
+      }
+
+      return (
+        <Wrapper style={styles.dropdownRowWrapper}>
+          <RegularText primary={highlighted}>{rowData}</RegularText>
+        </Wrapper>
+      );
+    },
+    [data]
+  );
+
   const preselect = (index) => dropdownRef.current.select(index);
 
   useEffect(() => {
@@ -71,17 +85,7 @@ export const DropdownSelect = ({
         ]}
         dropdownTextStyle={styles.dropdownDropdownText}
         adjustFrame={adjustFrame}
-        renderRow={(rowData, rowID, highlighted) => {
-          if (multipleSelect) {
-            highlighted = selectedMultipleValues.includes(rowData);
-          }
-
-          return (
-            <Wrapper style={styles.dropdownRowWrapper}>
-              <RegularText primary={highlighted}>{rowData}</RegularText>
-            </Wrapper>
-          );
-        }}
+        renderRow={renderRow}
         renderSeparator={() => <View style={styles.dropdownSeparator} />}
         onDropdownWillShow={() => setArrow('up')}
         onDropdownWillHide={() => setArrow('down')}

--- a/src/components/EventList.js
+++ b/src/components/EventList.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-import { SectionList } from 'react-native';
+import { SectionList, StyleSheet } from 'react-native';
 
 import { momentFormat } from '../helpers';
 import { useRenderItem } from '../hooks';
@@ -75,9 +75,16 @@ export const EventList = ({
       )}
       sections={sectionedData}
       stickySectionHeadersEnabled
+      contentContainerStyle={styles.contentContainerStyle}
     />
   );
 };
+
+const styles = StyleSheet.create({
+  contentContainerStyle: {
+    flexGrow: 1
+  }
+});
 
 EventList.propTypes = {
   data: PropTypes.array,

--- a/src/components/VerticalList.js
+++ b/src/components/VerticalList.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useRef, useState } from 'react';
-import { ActivityIndicator, FlatList } from 'react-native';
+import { ActivityIndicator, FlatList, StyleSheet } from 'react-native';
 
 import { colors, normalize } from '../config';
 import { useRenderItem } from '../hooks';
@@ -78,9 +78,16 @@ export const VerticalList = ({
       onEndReached={onEndReached}
       refreshControl={refreshControl}
       keyboardShouldPersistTaps="handled"
+      contentContainerStyle={styles.contentContainerStyle}
     />
   );
 };
+
+const styles = StyleSheet.create({
+  contentContainerStyle: {
+    flexGrow: 1
+  }
+});
 
 VerticalList.propTypes = {
   data: PropTypes.array,

--- a/src/components/widgets/EventWidget.tsx
+++ b/src/components/widgets/EventWidget.tsx
@@ -12,6 +12,8 @@ import { WidgetProps } from '../../types';
 
 import { DefaultWidget } from './DefaultWidget';
 
+const currentDate = moment().format('YYYY-MM-DD');
+
 export const EventWidget = ({ text }: WidgetProps) => {
   const navigation = useNavigation();
   const refreshTime = useRefreshTime('event-widget', consts.REFRESH_INTERVALS.ONCE_A_DAY);
@@ -19,7 +21,6 @@ export const EventWidget = ({ text }: WidgetProps) => {
 
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp, refreshTime });
 
-  const currentDate = moment().format('YYYY-MM-DD');
   const queryVariables = {
     dateRange: [currentDate, currentDate],
     order: 'listDate_ASC'
@@ -36,7 +37,8 @@ export const EventWidget = ({ text }: WidgetProps) => {
       title: text ?? texts.homeTitles.events,
       query: QUERY_TYPES.EVENT_RECORDS,
       queryVariables,
-      rootRouteName: 'EventRecords'
+      rootRouteName: 'EventRecords',
+      filterByDailyEvents: true
     });
   }, [navigation, text, queryVariables]);
 

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -304,6 +304,7 @@ export const texts = {
   eventRecord: {
     appointments: 'Termine',
     description: 'Beschreibung',
+    filterByDailyEvents: 'Nur tagesaktuelle anzeigen',
     operatingCompany: 'Veranstalter',
     prices: 'Preise'
   },

--- a/src/queries/newsItems.js
+++ b/src/queries/newsItems.js
@@ -71,7 +71,7 @@ export const GET_NEWS_ITEMS_AND_DATA_PROVIDERS = gql`
     $dataProviderId: ID
     $excludeDataProviderIds: [ID]
     $categoryId: ID
-    $categoryIds: [ID]
+    $categoryIds: [ID!]
   ) {
     newsItems(
       limit: $limit
@@ -121,7 +121,7 @@ export const GET_NEWS_ITEMS_AND_DATA_PROVIDERS = gql`
         onlySummaryLinkText
       }
     }
-    dataProviders: newsItemsDataProviders(categoryId: $categoryId) {
+    dataProviders: newsItemsDataProviders(categoryId: $categoryId, categoryIds: $categoryIds) {
       id
       name
     }

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -218,6 +218,9 @@ export const IndexScreen = ({ navigation, route }) => {
       ...(route.params?.queryVariables ?? {}),
       ...getAdditionalQueryVariables(query, undefined, excludeDataProviderIds)
     });
+    // reset daily events filter as well when navigating from one index screen to a new events index
+    setFilterByDailyEvents(route.params?.filterByDailyEvents);
+    navigation.setParams({ filterByDailyEvents: false });
   }, [route.params?.queryVariables, query, excludeDataProviderIds]);
 
   useEffect(() => {

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -308,7 +308,7 @@ export const IndexScreen = ({ navigation, route }) => {
               <ListComponent
                 ListHeaderComponent={
                   <>
-                    {!!showFilter && (
+                    {!!showFilter && (query === QUERY_TYPES.EVENT_RECORDS || !loading) && (
                       <>
                         <DropdownHeader
                           {...{


### PR DESCRIPTION
- added a new switch on event index screens to toggle daily events which are default when coming from the event widget
- needed to make this `refetch` magic like we already did in `updateListData` to re-render the index screen
- re-organized imports in index screen and refactored `... ?... : null` to a shorter `&&` for the opening times filter

refactor(lists ): optimize behavior when filtering

- created a callback that handles the update of the switch state as well as the update of the query variables
  - this way we get rid of one re-rendering (first switch statte, second query variables state) which seems to affect the list rendering in a weird way
- refactored loading screen to refresh control to not have a full full white screen with the loading spinner when filtering but a loading spinner in the body of the list implemented per `ListEmptyComponent` using the `loading` flag
  - to position it vertically centered, lists needed a new `contentContainerStyle`
- refactored building of list items in a callback `buildListItems` to remove it from the render section and to benefit a bit from the memoization
- refactored line lengths of comments to be within 100 chars
- re-organized imports of touched files to be consistent in code base

HDVT-73

---

|22.07.2022 on|22.07.2022 off|
|---|---|
|![Simulator Screen Shot - iPhone 8 Plus - 2022-07-22 at 18 45 10](https://user-images.githubusercontent.com/1942953/180487733-31b0ca8c-d414-4c4e-be88-bf2da56ced42.png)|![Simulator Screen Shot - iPhone 8 Plus - 2022-07-22 at 18 45 17](https://user-images.githubusercontent.com/1942953/180487750-6240f725-8f88-4170-9db6-5dd8a5806726.png)|