### PR TITLE
feat(map): add on settings screen new map

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -5,16 +5,17 @@ import MapView, { MAP_TYPES, Marker, UrlTile } from 'react-native-maps';
 import { SvgXml } from 'react-native-svg';
 
 import { colors, device } from '../../config';
+import { imageHeight, imageWidth } from '../../helpers';
 import { MapMarker } from '../../types';
 
 type Props = {
   locations?: MapMarker[];
-  mapCenterPosition?: {
-    lat: number;
-    lng: number;
-  };
-  style?: StyleProp<ViewStyle>;
+  mapCenterPosition?: { lat: number; lng: number };
+  mapStyle?: StyleProp<ViewStyle>;
+  onMapPress?: () => void;
   onMarkerPress: (arg0?: string) => void;
+  style?: StyleProp<ViewStyle>;
+  zoom?: number;
 };
 
 const MARKER_ICON_SIZE = normalize(40);
@@ -22,7 +23,15 @@ const LATITUDE_DELTA = 0.0922;
 // example for longitude delta: https://github.com/react-native-maps/react-native-maps/blob/master/example/examples/DisplayLatLng.js#L18
 const LONGITUDE_DELTA = LATITUDE_DELTA * (device.width / (device.height / 2));
 
-export const Map = ({ locations, mapCenterPosition, style, onMarkerPress }: Props) => {
+export const Map = ({
+  locations,
+  mapCenterPosition,
+  style,
+  mapStyle,
+  onMarkerPress,
+  onMapPress,
+  zoom
+}: Props) => {
   const refForMapView = useRef<MapView>(null);
   const [showsUserLocation, setShowsUserLocation] = useState(true);
   const initialRegion = mapCenterPosition
@@ -42,15 +51,17 @@ export const Map = ({ locations, mapCenterPosition, style, onMarkerPress }: Prop
     : undefined;
 
   return (
-    <View style={[style, styles.container]}>
+    <View style={[stylesForMap().container, style]}>
       <MapView
-        ref={refForMapView}
-        style={styles.map}
-        mapType={device.platform === 'android' ? MAP_TYPES.NONE : MAP_TYPES.STANDARD}
         initialRegion={initialRegion}
-        showsUserLocation={showsUserLocation}
-        userLocationPriority="balanced"
+        mapType={device.platform === 'android' ? MAP_TYPES.NONE : MAP_TYPES.STANDARD}
+        maxZoomLevel={zoom}
+        onPress={onMapPress}
+        ref={refForMapView}
         rotateEnabled={false}
+        showsUserLocation={showsUserLocation}
+        style={[stylesForMap().map, mapStyle]}
+        userLocationPriority="balanced"
         mapPadding={{
           top: 0,
           right: 0,
@@ -83,15 +94,27 @@ export const Map = ({ locations, mapCenterPosition, style, onMarkerPress }: Prop
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    alignItems: 'center',
-    backgroundColor: colors.lightestText,
-    flex: 1,
-    justifyContent: 'center'
-  },
-  map: {
-    height: device.height / 2,
-    width: device.width
-  }
-});
+/* eslint-disable react-native/no-unused-styles */
+/* this works properly, we do not want that eslint warning */
+// the map should have the same aspect ratio as images.
+// we need to call the default styles in a method to ensure correct defaults for image aspect ratio,
+// which could be overwritten bei server global settings. otherwise (as default prop) the style
+// would be set before the overwriting occurred.
+const stylesForMap = () => {
+  const width = imageWidth();
+
+  return StyleSheet.create({
+    container: {
+      alignItems: 'center',
+      backgroundColor: colors.lightestText,
+      flex: 1,
+      justifyContent: 'center'
+    },
+    map: {
+      alignSelf: 'center',
+      height: imageHeight(width),
+      width
+    }
+  });
+};
+/* eslint-enable react-native/no-unused-styles */

--- a/src/components/settings/LocationSettings.js
+++ b/src/components/settings/LocationSettings.js
@@ -119,11 +119,10 @@ export const LocationSettings = () => {
             locations={locations}
             mapCenterPosition={{ lat: 51.1657, lng: 10.4515 }} // center of germany
             onMapPress={({ nativeEvent }) => {
-              const coordinate = {
+              setSelectedPosition({
                 lat: nativeEvent.coordinate.latitude,
                 lng: nativeEvent.coordinate.longitude
-              };
-              setSelectedPosition(coordinate);
+              });
             }}
             zoom={4} // this sets the zoom to show all of germany
           />

--- a/src/components/settings/LocationSettings.js
+++ b/src/components/settings/LocationSettings.js
@@ -5,7 +5,7 @@ import Collapsible from 'react-native-collapsible';
 
 import { colors, texts } from '../../config';
 import { useLocationSettings } from '../../hooks';
-import { WebViewMap } from '../map';
+import { Map } from '../map';
 import { Button } from '../Button';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { RegularText } from '../Text';
@@ -115,13 +115,25 @@ export const LocationSettings = () => {
           </RegularText>
         </Wrapper>
         <Collapsible collapsed={!showMap}>
-          <WebViewMap
+          {/* <WebViewMap
             mapCenterPosition={{ lat: 51.1657, lng: 10.4515 }} // center of germany
             locations={locations}
             onMessageReceived={(msg) => {
               if (msg.event === 'onMapClicked') {
                 setSelectedPosition(msg.payload.touchLatLng);
               }
+            }}
+            zoom={4} // this sets the zoom to show all of germany
+          /> */}
+          <Map
+            locations={locations}
+            mapCenterPosition={{ lat: 51.1657, lng: 10.4515 }} // center of germany
+            onMapPress={({ nativeEvent }) => {
+              const coordinate = {
+                lat: nativeEvent.coordinate.latitude,
+                lng: nativeEvent.coordinate.longitude
+              };
+              setSelectedPosition(coordinate);
             }}
             zoom={4} // this sets the zoom to show all of germany
           />

--- a/src/components/settings/LocationSettings.js
+++ b/src/components/settings/LocationSettings.js
@@ -115,16 +115,6 @@ export const LocationSettings = () => {
           </RegularText>
         </Wrapper>
         <Collapsible collapsed={!showMap}>
-          {/* <WebViewMap
-            mapCenterPosition={{ lat: 51.1657, lng: 10.4515 }} // center of germany
-            locations={locations}
-            onMessageReceived={(msg) => {
-              if (msg.event === 'onMapClicked') {
-                setSelectedPosition(msg.payload.touchLatLng);
-              }
-            }}
-            zoom={4} // this sets the zoom to show all of germany
-          /> */}
           <Map
             locations={locations}
             mapCenterPosition={{ lat: 51.1657, lng: 10.4515 }} // center of germany


### PR DESCRIPTION
- updated `WebViewMap` in settings page
  with new map
- added `onMapPress` prop to `Map`
  component for user to change location
- added `mapStyle` prop to `Map` component
  because we may need different map styles on
  different pages
- added `maxZoomLevel` prop to `MapView`
  component because zoom value may vary on
  different pages
- integrated the style used in `WebViewMap`
  into the new `Map` component to achieve the
  same look and feel
- added alphabetical order to the `Map`
  component's props to make it more understandable

SVA-634


## How to test:
* [ ] Android portrait mode
* [x] iOS portrait mode
* [ ] Android landscape mode
* [ ] iOS landscape mode

## Screenshots:

|Old Map|New Map|
|--|--|
![IMG_6C8ED6DC278E-1](https://user-images.githubusercontent.com/11755668/180491855-d54c3e38-f7ef-4390-9af1-941d485ccd90.jpeg) |  ![IMG_DFDD4551024D-1](https://user-images.githubusercontent.com/11755668/180491857-f367bc8d-03dd-428f-919a-44c8ceb1ccb8.jpeg)

