### PR TITLE
feat(ar): add map view to augmented reality

### DIFF
--- a/src/components/augmentedReality/AugmentedReality.js
+++ b/src/components/augmentedReality/AugmentedReality.js
@@ -1,6 +1,6 @@
+import { isARSupportedOnDevice } from '@viro-community/react-viro';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
-import { isARSupportedOnDevice } from '@viro-community/react-viro';
 
 import { colors, consts, device, texts } from '../../config';
 import { checkDownloadedData, navigationToArtworksDetailScreen } from '../../helpers';
@@ -165,13 +165,14 @@ export const AugmentedReality = ({ navigation, onSettingsScreen, tourID }) => {
   );
 };
 
-const mapToMapMarkers = (augmentedReality) => {
-  return augmentedReality
+const mapToMapMarkers = (augmentedReality) =>
+  augmentedReality
     ?.map((item) => {
-      const latitude = item.location.lat;
-      const longitude = item.location.lng;
+      const latitude = item.location?.lat;
+      const longitude = item.location?.lng;
 
       if (!latitude || !longitude) return undefined;
+
       return {
         icon: location(colors.primary),
         iconAnchor: locationIconAnchor,
@@ -183,7 +184,6 @@ const mapToMapMarkers = (augmentedReality) => {
       };
     })
     .filter((item) => item !== undefined);
-};
 
 AugmentedReality.propTypes = {
   navigation: PropTypes.object,

--- a/src/components/augmentedReality/AugmentedReality.js
+++ b/src/components/augmentedReality/AugmentedReality.js
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { isARSupportedOnDevice } from '@viro-community/react-viro';
 
 import { colors, consts, device, texts } from '../../config';
+import { checkDownloadedData, navigationToArtworksDetailScreen } from '../../helpers';
 import { useStaticContent } from '../../hooks';
 import { location, locationIconAnchor } from '../../icons';
 import { ScreenName } from '../../types';
@@ -52,6 +53,16 @@ export const AugmentedReality = ({ navigation, onSettingsScreen, tourID }) => {
       () => setIsARSupported(true)
     );
   }, []);
+
+  useEffect(() => {
+    navigationToArtworksDetailScreen({
+      data,
+      isNavigation: true,
+      modelId,
+      navigation,
+      refetch
+    });
+  }, [modelId]);
 
   useEffect(() => {
     setData(staticData);

--- a/src/components/augmentedReality/AugmentedReality.js
+++ b/src/components/augmentedReality/AugmentedReality.js
@@ -136,6 +136,18 @@ export const AugmentedReality = ({ navigation, onSettingsScreen, tourID }) => {
         <Map
           locations={mapMarkers}
           onMarkerPress={setModelId}
+          onMaximizeButtonPress={() =>
+            navigation.navigate(ScreenName.MapView, {
+              augmentedRealityData: {
+                data,
+                refetch
+              },
+              isAugmentedReality: true,
+              isMaximizeButtonVisible: false,
+              locations: mapMarkers
+            })
+          }
+          isMaximizeButtonVisible
         />
       )}
 

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -9,11 +9,13 @@ import { imageHeight, imageWidth } from '../../helpers';
 import { MapMarker } from '../../types';
 
 type Props = {
+  isMaximizeButtonVisible?: boolean;
   locations?: MapMarker[];
   mapCenterPosition?: { lat: number; lng: number };
   mapStyle?: StyleProp<ViewStyle>;
   onMapPress?: () => void;
   onMarkerPress?: (arg0?: string) => void;
+  onMaximizeButtonPress?: () => void;
   showsUserLocation?: boolean;
   style?: StyleProp<ViewStyle>;
   zoom?: number;
@@ -25,11 +27,13 @@ const LATITUDE_DELTA = 0.0922;
 const LONGITUDE_DELTA = LATITUDE_DELTA * (device.width / (device.height / 2));
 
 export const Map = ({
+  isMaximizeButtonVisible,
   locations,
   mapCenterPosition,
   mapStyle,
   onMapPress,
   onMarkerPress,
+  onMaximizeButtonPress,
   showsUserLocation = true,
   style,
   zoom
@@ -95,6 +99,11 @@ export const Map = ({
           </Marker>
         ))}
       </MapView>
+      {isMaximizeButtonVisible && (
+        <TouchableOpacity style={stylesForMap().maximizeMapButton} onPress={onMaximizeButtonPress}>
+          <Icon.NamedIcon name="expand" color={colors.primary} size={normalize(18)} />
+        </TouchableOpacity>
+      )}
     </View>
   );
 };
@@ -114,6 +123,19 @@ const stylesForMap = () => {
       backgroundColor: colors.lightestText,
       flex: 1,
       justifyContent: 'center'
+    },
+    maximizeMapButton: {
+      alignItems: 'center',
+      backgroundColor: colors.surface,
+      borderRadius: 50,
+      bottom: normalize(15),
+      height: normalize(48),
+      justifyContent: 'center',
+      opacity: 0.6,
+      position: 'absolute',
+      right: normalize(15),
+      width: normalize(48),
+      zIndex: 1
     },
     map: {
       alignSelf: 'center',

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -101,7 +101,7 @@ export const Map = ({
       </MapView>
       {isMaximizeButtonVisible && (
         <TouchableOpacity style={stylesForMap().maximizeMapButton} onPress={onMaximizeButtonPress}>
-          <Icon.NamedIcon name="expand" color={colors.primary} size={normalize(18)} />
+          <Icon.ExpandMap size={normalize(18)} />
         </TouchableOpacity>
       )}
     </View>

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -1,10 +1,10 @@
-import React, { useRef, useState } from 'react';
-import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
+import React, { useRef } from 'react';
+import { StyleProp, StyleSheet, TouchableOpacity, View, ViewStyle } from 'react-native';
 import { normalize } from 'react-native-elements';
 import MapView, { MAP_TYPES, Marker, UrlTile } from 'react-native-maps';
 import { SvgXml } from 'react-native-svg';
 
-import { colors, device } from '../../config';
+import { colors, device, Icon } from '../../config';
 import { imageHeight, imageWidth } from '../../helpers';
 import { MapMarker } from '../../types';
 
@@ -14,6 +14,7 @@ type Props = {
   mapStyle?: StyleProp<ViewStyle>;
   onMapPress?: () => void;
   onMarkerPress?: (arg0?: string) => void;
+  showsUserLocation?: boolean;
   style?: StyleProp<ViewStyle>;
   zoom?: number;
 };
@@ -26,14 +27,14 @@ const LONGITUDE_DELTA = LATITUDE_DELTA * (device.width / (device.height / 2));
 export const Map = ({
   locations,
   mapCenterPosition,
-  style,
   mapStyle,
-  onMarkerPress,
   onMapPress,
+  onMarkerPress,
+  showsUserLocation = true,
+  style,
   zoom
 }: Props) => {
   const refForMapView = useRef<MapView>(null);
-  const [showsUserLocation, setShowsUserLocation] = useState(true);
   const initialRegion = mapCenterPosition
     ? {
         latitude: mapCenterPosition.lat,

--- a/src/components/screens/Tour.js
+++ b/src/components/screens/Tour.js
@@ -1,3 +1,4 @@
+import _filter from 'lodash/filter';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { View } from 'react-native';
@@ -47,6 +48,11 @@ export const Tour = ({ data, navigation, route }) => {
   const logo = dataProvider && dataProvider.logo && dataProvider.logo.url;
   // the categories of a news item can be nested and we need the map of all names of all categories
   const categoryNames = categories && categories.map((category) => category.name).join(' / ');
+  // for tour addresses we just consider addresses that are kind of 'start' or 'end'
+  const tourAddresses = _filter(
+    addresses,
+    (address) => address.kind === 'start' || address.kind === 'end'
+  );
 
   // TODO: DEVELOP! - it will be deleted, it was only made to development!
   let augmentedReality = true;
@@ -82,7 +88,9 @@ export const Tour = ({ data, navigation, route }) => {
           <InfoCard category={category} addresses={addresses} contact={contact} webUrls={webUrls} />
         </Wrapper>
 
-        <TourCard lengthKm={lengthKm} addresses={addresses} />
+        {(!!tourAddresses.length || !!lengthKm) && (
+          <TourCard lengthKm={lengthKm} tourAddresses={tourAddresses} />
+        )}
 
         {!!description && (
           <View>

--- a/src/components/screens/TourCard.js
+++ b/src/components/screens/TourCard.js
@@ -1,4 +1,3 @@
-import _filter from 'lodash/filter';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
@@ -19,7 +18,7 @@ const addressOnPress = (address) => {
 
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
-export const TourCard = ({ addresses, lengthKm }) => (
+export const TourCard = ({ lengthKm, tourAddresses }) => (
   <View>
     <TitleContainer>
       <Title accessibilityLabel={`(${texts.tour.tour}) ${consts.a11yLabel.heading}`}>
@@ -35,38 +34,35 @@ export const TourCard = ({ addresses, lengthKm }) => (
         </InfoBox>
       )}
 
-      {!!addresses &&
-        _filter(addresses, (address) => address.kind === 'start' || address.kind === 'end').map(
-          (item, index) => {
-            const { city, street, zip, kind } = item;
-            let address = '';
+      {tourAddresses?.map((item, index) => {
+        const { city, street, zip, kind } = item;
+        let address = '';
 
-            if (!city && !street && !zip) return null;
+        if (!city && !street && !zip) return null;
 
-            // build the address in multiple steps to check every data before rendering
-            if (street) {
-              address += `${street},${'\n'}`;
-            }
-            if (zip) {
-              address += `${zip} `;
-            }
-            if (city) {
-              address += city;
-            }
+        // build the address in multiple steps to check every data before rendering
+        if (street) {
+          address += `${street},${'\n'}`;
+        }
+        if (zip) {
+          address += `${zip} `;
+        }
+        if (city) {
+          address += city;
+        }
 
-            return (
-              <InfoBox key={index}>
-                <Icon.Location style={styles.margin} />
-                <View>
-                  <RegularText>{kind === 'start' ? texts.tour.start : texts.tour.end}</RegularText>
-                  <TouchableOpacity onPress={() => addressOnPress(address)}>
-                    <RegularText primary>{address}</RegularText>
-                  </TouchableOpacity>
-                </View>
-              </InfoBox>
-            );
-          }
-        )}
+        return (
+          <InfoBox key={index}>
+            <Icon.Location style={styles.margin} />
+            <View>
+              <RegularText>{kind === 'start' ? texts.tour.start : texts.tour.end}</RegularText>
+              <TouchableOpacity onPress={() => addressOnPress(address)}>
+                <RegularText primary>{address}</RegularText>
+              </TouchableOpacity>
+            </View>
+          </InfoBox>
+        );
+      })}
     </Wrapper>
   </View>
 );
@@ -79,6 +75,6 @@ const styles = StyleSheet.create({
 });
 
 TourCard.propTypes = {
-  addresses: PropTypes.array,
-  lengthKm: PropTypes.number
+  lengthKm: PropTypes.number,
+  tourAddresses: PropTypes.array
 };

--- a/src/config/Icon.tsx
+++ b/src/config/Icon.tsx
@@ -116,6 +116,7 @@ export const Icon = {
   DrawerMenu: (props: IconProps) => <SvgIcon xml={drawerMenu} {...props} />,
   EditSetting: (props: IconProps) => <NamedIcon name="md-create" {...props} />,
   EmptySection: (props: IconProps) => <SvgIcon xml={emptySection} {...props} />,
+  ExpandMap: (props: IconProps) => <Icon.NamedIcon name="expand" {...props} />,
   Home: (props: IconProps) => <SvgIcon xml={home} {...props} />,
   NamedIcon,
   HeartEmpty: (props: IconProps) => <SvgIcon xml={heartEmpty} {...props} />,

--- a/src/config/navigation/defaultStackConfig.tsx
+++ b/src/config/navigation/defaultStackConfig.tsx
@@ -31,6 +31,7 @@ import {
   HtmlScreen,
   IndexScreen,
   LunchScreen,
+  MapViewScreen,
   MultiButtonScreen,
   NestedInfoScreen,
   OParlCalendarScreen,
@@ -249,6 +250,11 @@ export const defaultStackConfig = ({
     {
       routeName: ScreenName.Lunch,
       screenComponent: LunchScreen
+    },
+    {
+      routeName: ScreenName.MapView,
+      screenComponent: MapViewScreen,
+      screenOptions: { title: texts.screenTitles.mapView }
     },
     {
       routeName: ScreenName.MultiButton,

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -657,6 +657,7 @@ export const texts = {
     encounterHome: 'Mitfahrbank',
     feedback: 'Feedback',
     home: appJson.expo.name,
+    mapView: 'Kartenansicht',
     routePlanner: 'Routenplaner bbnavi',
     service: appJson.expo.name,
     settings: 'Einstellungen',

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -32,6 +32,10 @@ export const texts = {
       header: 'AR-Kunstwerk'
     },
     cancel: 'Abbrechen',
+    filter: {
+      mapView: 'Kartenansicht',
+      listView: 'Listenansicht'
+    },
     hide: 'Ausblenden',
     invalidModelError: 'Das 3D-Modell konnte nicht richtig geladen werden.',
     loadingArtworks: 'Kunstwerke laden',

--- a/src/helpers/augmentedReality/index.js
+++ b/src/helpers/augmentedReality/index.js
@@ -3,5 +3,6 @@ export * from './deleteObject';
 export * from './downloadAndDeleteAllData';
 export * from './downloadObject';
 export * from './downloadType';
+export * from './navigationToArtworkDetailScreen';
 export * from './progressSizeGenerator';
 export * from './storageNameCreator';

--- a/src/helpers/augmentedReality/navigationToArtworkDetailScreen.js
+++ b/src/helpers/augmentedReality/navigationToArtworkDetailScreen.js
@@ -1,0 +1,22 @@
+import { ScreenName } from '../../types';
+
+export const navigationToArtworksDetailScreen = ({
+  data,
+  isNavigation,
+  isShow,
+  modelId,
+  navigation,
+  refetch,
+  setModelData
+}) => {
+  for (let index = 0; index < data.length; index++) {
+    const { id } = data[index];
+    if (id.toString() === modelId) {
+      if (isNavigation) {
+        return navigation.navigate(ScreenName.ArtworkDetail, { data, index, refetch });
+      } else if (isShow) {
+        return setModelData(data[index]);
+      }
+    }
+  }
+};

--- a/src/screens/MapViewScreen.js
+++ b/src/screens/MapViewScreen.js
@@ -4,6 +4,7 @@ import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { Map, RegularText, Wrapper, WrapperRow, WrapperVertical } from '../components';
 import { colors, Icon, normalize } from '../config';
+import { navigationToArtworksDetailScreen } from '../helpers';
 
 export const MapViewScreen = ({ navigation, route }) => {
   const {
@@ -14,20 +15,65 @@ export const MapViewScreen = ({ navigation, route }) => {
     showsUserLocation
   } = route?.params;
 
+  /* the improvement in the next comment line has been added for augmented reality feature. */
+  const { data, refetch } = route?.params?.augmentedRealityData ?? [];
+
+  const [modelId, setModelId] = useState();
+  const [modelData, setModelData] = useState();
+
+  useEffect(() => {
+    navigationToArtworksDetailScreen({ data, isShow: true, modelId, setModelData });
+  }, [modelId]);
+  /* end of augmented reality feature */
 
   return (
+    <>
       <Map
         {...{
           isMaximizeButtonVisible,
           locations,
           mapStyle: styles.mapStyle,
+          onMarkerPress: isAugmentedReality ? setModelId : onMarkerPress,
           showsUserLocation
         }}
       />
+      {isAugmentedReality && modelData && (
+        <Wrapper>
+          <WrapperRow spaceBetween>
+            <View style={styles.augmentedRealityInfoContainer}>
+              <RegularText big>{modelData.title}</RegularText>
+              <RegularText small>{modelData.locationInfo}</RegularText>
+              <WrapperVertical>
+                <RegularText placeholder numberOfLines={2}>
+                  {modelData.description}
+                </RegularText>
+              </WrapperVertical>
+            </View>
+
+            <TouchableOpacity
+              onPress={() =>
+                navigationToArtworksDetailScreen({
+                  data,
+                  isNavigation: true,
+                  modelId,
+                  navigation,
+                  refetch
+                })
+              }
+            >
+              <Icon.ArrowRight size={normalize(30)} color={colors.primary} />
+            </TouchableOpacity>
+          </WrapperRow>
+        </Wrapper>
+      )}
+    </>
   );
 };
 
 const styles = StyleSheet.create({
+  augmentedRealityInfoContainer: {
+    width: '90%'
+  },
   mapStyle: {
     width: '100%',
     height: '100%'

--- a/src/screens/MapViewScreen.js
+++ b/src/screens/MapViewScreen.js
@@ -1,0 +1,40 @@
+import PropTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+
+import { Map, RegularText, Wrapper, WrapperRow, WrapperVertical } from '../components';
+import { colors, Icon, normalize } from '../config';
+
+export const MapViewScreen = ({ navigation, route }) => {
+  const {
+    isAugmentedReality,
+    isMaximizeButtonVisible,
+    locations,
+    onMarkerPress,
+    showsUserLocation
+  } = route?.params;
+
+
+  return (
+      <Map
+        {...{
+          isMaximizeButtonVisible,
+          locations,
+          mapStyle: styles.mapStyle,
+          showsUserLocation
+        }}
+      />
+  );
+};
+
+const styles = StyleSheet.create({
+  mapStyle: {
+    width: '100%',
+    height: '100%'
+  }
+});
+
+MapViewScreen.propTypes = {
+  navigation: PropTypes.object,
+  route: PropTypes.object
+};

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -21,6 +21,7 @@ export * from './HomeScreen';
 export * from './HtmlScreen';
 export * from './IndexScreen';
 export * from './LunchScreen';
+export * from './MapViewScreen';
 export * from './MultiButtonScreen';
 export * from './NestedInfoScreen';
 export * from './SettingsScreen';

--- a/src/types/Navigation.ts
+++ b/src/types/Navigation.ts
@@ -35,6 +35,7 @@ export enum ScreenName {
   Html = 'Html',
   Index = 'Index',
   Lunch = 'Lunch',
+  MapView = 'MapView',
   MultiButton = 'MultiButton',
   NestedInfo = 'NestedInfo',
   OParlCalendar = 'OParlCalendar',


### PR DESCRIPTION
- added `IndexFilterWrapperAndList` component to
  Augmented Reality section for map view and list view
- added `mapToMapMarkers` function to make the
  location data from the server suitable for the map
  component
- added new texts to `texts` file to show in filter section
- added redirection to `artworkDetailScreen` with
  markers on the map
- added `showUserLocation` as a prop and set true
  by default
- added full screen map view
- added a new button for full screen
  navigation at the bottom right of the
  small map view
- added `onMaximizeButtonPress` prop to
  `AugmentedReality` component to switch
  to large map view
- added new map navigation to
  `defaultStackConfig`
- added artwork information window shown below
  the map when clicking on the marker on the full
  page map
- used `navigationToArtworksDetailScreen` helper
  to navigate to `artworkDetailScreen` from the
  opened detail window

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [ ] Android landscape mode
* [ ] iOS landscape mode


## Screenshots:

|MapView on AR Section|ListView on AR Section|
|--|--|
![IMG_0029](https://user-images.githubusercontent.com/11755668/180781190-94197ea9-81e2-47c7-bb8d-d2fd87e239b8.PNG) | ![IMG_0030](https://user-images.githubusercontent.com/11755668/180781204-768ff714-2015-4559-a93b-ca46ede2650d.PNG)


|Full Screen Map|Full Screen Map with Art details|
|--|--|
![IMG_0031](https://user-images.githubusercontent.com/11755668/180781269-ed359f97-7ea0-499a-9c57-add3f7a7c22d.PNG) |  ![IMG_0032](https://user-images.githubusercontent.com/11755668/180781285-494e40bc-51a6-413d-a271-3d590f3be7dd.PNG)

