### PR TITLE
fix(linking): error android linking not opening

### DIFF
--- a/src/helpers/linkHelper.js
+++ b/src/helpers/linkHelper.js
@@ -38,17 +38,9 @@ function isWeb(linkWithProtocol) {
 export function openLink(link, openWebScreen) {
   const linkWithProtocol = ensureProtocol(link);
 
-  Linking.canOpenURL(linkWithProtocol)
-    .then((canOpen) => {
-      if (!canOpen) {
-        alert(`Can't handle: ${linkWithProtocol}`);
-      } else {
-        if (isWeb(linkWithProtocol) && openWebScreen) {
-          return openWebScreen(linkWithProtocol);
-        }
+  if (isWeb(linkWithProtocol) && openWebScreen) {
+    return openWebScreen(linkWithProtocol);
+  }
 
-        return Linking.openURL(linkWithProtocol);
-      }
-    })
-    .catch((err) => console.warn('An error occurred', err));
+  return Linking.openURL(linkWithProtocol);
 }


### PR DESCRIPTION
- fixed `canOpenURL` bug that prevented links
  from opening on android

SVA-689


## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode
