### PR TITLE
feat(ar): add `tourStops` query

### DIFF
--- a/src/components/augmentedReality/ARModal.js
+++ b/src/components/augmentedReality/ARModal.js
@@ -21,18 +21,21 @@ export const ARModal = ({
   isModalVisible,
   setIsModalVisible,
   onModalVisible,
-  refetch,
   showTitle
 }) => {
   // this modal is called for file package lists and for single file packages, where we need the
   // explicit object at the given `index`. the `index` is only given if we do not have a
   // truthy `isListView`, thats why we need to "secure" the destructing with `{}`.
-  const { DOWNLOAD_TYPE: itemDownloadType, progress, progressSize, title, totalSize } =
-    data?.[index] || {};
+  const { downloadType: itemDownloadType, progress, progressSize, totalSize } =
+    data?.[index]?.payload || {};
+
+  const { title } = data?.[index] || {};
 
   // if a download is running, we want to show the users an additional alert to inform about
   // difficulties with hiding the modal.
-  const showHiddenAlert = data?.some((item) => item.DOWNLOAD_TYPE === DOWNLOAD_TYPE.DOWNLOADING);
+  const showHiddenAlert = data?.some(
+    (item) => item?.payload?.downloadType === DOWNLOAD_TYPE.DOWNLOADING
+  );
 
   // in modals for single files we can have two states of the modal button and not only "hide",
   // because we want to navigate directly in case the file package is downloaded instead of hiding
@@ -66,7 +69,6 @@ export const ARModal = ({
           data={data}
           setData={setData}
           isLoading={isLoading}
-          refetch={refetch}
           showDeleteAllButton
           showDownloadAllButton
           showFreeSpace
@@ -122,6 +124,5 @@ ARModal.propTypes = {
   isModalVisible: PropTypes.bool.isRequired,
   setIsModalVisible: PropTypes.func,
   onModalVisible: PropTypes.func,
-  refetch: PropTypes.func,
   showTitle: PropTypes.bool
 };

--- a/src/components/augmentedReality/ARModal.js
+++ b/src/components/augmentedReality/ARModal.js
@@ -26,8 +26,7 @@ export const ARModal = ({
   // this modal is called for file package lists and for single file packages, where we need the
   // explicit object at the given `index`. the `index` is only given if we do not have a
   // truthy `isListView`, thats why we need to "secure" the destructing with `{}`.
-  const { downloadType: itemDownloadType, progress, progressSize, totalSize } =
-    data?.[index]?.payload || {};
+  const { downloadType, progress, progressSize, totalSize } = data?.[index]?.payload || {};
 
   const { title } = data?.[index] || {};
 
@@ -41,7 +40,7 @@ export const ARModal = ({
   // because we want to navigate directly in case the file package is downloaded instead of hiding
   // the modal manually and then pressing a button to navigate.
   const modalHiddenButtonName =
-    itemDownloadType === DOWNLOAD_TYPE.DOWNLOADED && !isListView
+    downloadType === DOWNLOAD_TYPE.DOWNLOADED && !isListView
       ? texts.settingsTitles.arListLayouts.continue
       : texts.settingsTitles.arListLayouts.hide;
 
@@ -77,7 +76,7 @@ export const ARModal = ({
       ) : (
         <View>
           <View style={[styles.container, styles.iconAndByteText]}>
-            <IconForDownloadType itemDownloadType={itemDownloadType} />
+            <IconForDownloadType downloadType={downloadType} />
 
             <RegularText small style={styles.progressTextStyle}>
               {progressSizeGenerator(progressSize, totalSize)}

--- a/src/components/augmentedReality/ARObjectList.js
+++ b/src/components/augmentedReality/ARObjectList.js
@@ -5,7 +5,6 @@ import { Alert, FlatList } from 'react-native';
 
 import { consts, device, texts } from '../../config';
 import { deleteAllData, downloadAllData, formatSize } from '../../helpers';
-import { usePullToRefetch } from '../../hooks';
 import { Button } from '../Button';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { RegularText } from '../Text';
@@ -42,14 +41,13 @@ const deleteAllDataAlert = (deleteAll) =>
     ]
   );
 
-const renderItem = ({ data, index, item, navigation, setData, refetch, showOnDetailPage }) => (
+const renderItem = ({ data, index, item, navigation, setData, showOnDetailPage }) => (
   <ARObjectListItem
     data={data}
     index={index}
     item={item}
     navigation={navigation}
     setData={setData}
-    refetch={refetch}
     showOnDetailPage={showOnDetailPage}
   />
 );
@@ -59,7 +57,6 @@ export const ARObjectList = ({
   setData,
   isLoading,
   navigation,
-  refetch,
   showDeleteAllButton,
   showDownloadAllButton,
   showFreeSpace,
@@ -85,7 +82,6 @@ export const ARObjectList = ({
     await deleteAllData({ data, setData });
   };
 
-  const RefreshControl = usePullToRefetch(refetch);
   const a11yText = consts.a11yLabel;
 
   if (isLoading || !data?.length) return <LoadingSpinner loading />;
@@ -106,7 +102,6 @@ export const ARObjectList = ({
       )}
 
       <FlatList
-        refreshControl={RefreshControl}
         data={data}
         renderItem={({ item, index }) =>
           renderItem({
@@ -115,7 +110,6 @@ export const ARObjectList = ({
             index,
             item,
             navigation,
-            refetch,
             showOnDetailPage
           })
         }
@@ -153,7 +147,6 @@ ARObjectList.propTypes = {
   data: PropTypes.array,
   setData: PropTypes.func,
   isLoading: PropTypes.bool,
-  refetch: PropTypes.func,
   navigation: PropTypes.object,
   showDeleteAllButton: PropTypes.bool,
   showDownloadAllButton: PropTypes.bool,

--- a/src/components/augmentedReality/ARObjectListItem.js
+++ b/src/components/augmentedReality/ARObjectListItem.js
@@ -13,7 +13,7 @@ import { IconForDownloadType } from './IconForDownloadType';
 
 export const ARObjectListItem = ({ data, index, item, navigation, setData, showOnDetailPage }) => {
   const {
-    payload: { downloadType: itemDownloadType, progressSize, totalSize, locationInfo },
+    payload: { downloadType, progressSize, totalSize, locationInfo },
     title
   } = item;
 
@@ -23,9 +23,9 @@ export const ARObjectListItem = ({ data, index, item, navigation, setData, showO
       return;
     }
 
-    if (itemDownloadType === DOWNLOAD_TYPE.DOWNLOADABLE) {
+    if (downloadType === DOWNLOAD_TYPE.DOWNLOADABLE) {
       await downloadObject({ index, data, setData });
-    } else if (itemDownloadType === DOWNLOAD_TYPE.DOWNLOADED) {
+    } else if (downloadType === DOWNLOAD_TYPE.DOWNLOADED) {
       Alert.alert(
         texts.settingsTitles.arListLayouts.alertTitle,
         texts.settingsTitles.arListLayouts.deleteAlertMessage,
@@ -59,7 +59,7 @@ export const ARObjectListItem = ({ data, index, item, navigation, setData, showO
       rightIcon={
         <IconForDownloadType
           isListView
-          itemDownloadType={itemDownloadType}
+          downloadType={downloadType}
           showOnDetailPage={showOnDetailPage}
         />
       }

--- a/src/components/augmentedReality/ARObjectListItem.js
+++ b/src/components/augmentedReality/ARObjectListItem.js
@@ -11,20 +11,15 @@ import { Touchable } from '../Touchable';
 
 import { IconForDownloadType } from './IconForDownloadType';
 
-export const ARObjectListItem = ({
-  data,
-  index,
-  item,
-  navigation,
-  setData,
-  refetch,
-  showOnDetailPage
-}) => {
-  const { DOWNLOAD_TYPE: itemDownloadType, progressSize, title, totalSize, locationInfo } = item;
+export const ARObjectListItem = ({ data, index, item, navigation, setData, showOnDetailPage }) => {
+  const {
+    payload: { downloadType: itemDownloadType, progressSize, totalSize, locationInfo },
+    title
+  } = item;
 
   const onPress = async () => {
     if (showOnDetailPage) {
-      navigation.navigate(ScreenName.ArtworkDetail, { data, index, refetch });
+      navigation.navigate(ScreenName.ArtworkDetail, { data, index });
       return;
     }
 
@@ -90,6 +85,5 @@ ARObjectListItem.propTypes = {
   index: PropTypes.number,
   item: PropTypes.object.isRequired,
   navigation: PropTypes.object,
-  refetch: PropTypes.func,
   showOnDetailPage: PropTypes.bool
 };

--- a/src/components/augmentedReality/AugmentedReality.js
+++ b/src/components/augmentedReality/AugmentedReality.js
@@ -15,23 +15,12 @@ import { ARModal } from './ARModal';
 import { ARObjectList } from './ARObjectList';
 import { WhatIsARButton } from './WhatIsARButton';
 
-const OnSettingsScreen = ({ id, isLoading, setData }) => {
-  const { data } = useQuery(getQuery(QUERY_TYPES.TOUR_STOPS), { variables: { id } });
-
-  return (
-    <ARObjectList
-      data={data?.tour?.tourStops}
-      setData={setData}
-      isLoading={isLoading}
-      showDeleteAllButton
-      showDownloadAllButton
-      showFreeSpace
-      showTitle
-    />
-  );
-};
-
 export const AugmentedReality = ({ id, navigation, onSettingsScreen, tourStops }) => {
+  const { data: tourData } = useQuery(getQuery(QUERY_TYPES.TOUR_STOPS), {
+    variables: { id },
+    skip: !onSettingsScreen
+  });
+
   const [isARSupported, setIsARSupported] = useState(false);
   const [data, setData] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -61,7 +50,17 @@ export const AugmentedReality = ({ id, navigation, onSettingsScreen, tourStops }
   if (!isARSupported) return null;
 
   if (onSettingsScreen) {
-    return <OnSettingsScreen {...{ id, isLoading, setData }} />;
+    return (
+      <ARObjectList
+        data={tourData?.tour?.tourStops}
+        setData={setData}
+        isLoading={isLoading}
+        showDeleteAllButton
+        showDownloadAllButton
+        showFreeSpace
+        showTitle
+      />
+    );
   }
 
   if (isLoading) return <LoadingSpinner loading />;
@@ -112,10 +111,4 @@ AugmentedReality.propTypes = {
   navigation: PropTypes.object,
   onSettingsScreen: PropTypes.bool,
   tourStops: PropTypes.array
-};
-
-OnSettingsScreen.propTypes = {
-  id: PropTypes.string,
-  isLoading: PropTypes.bool,
-  setData: PropTypes.func
 };

--- a/src/components/augmentedReality/AugmentedReality.js
+++ b/src/components/augmentedReality/AugmentedReality.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { isARSupportedOnDevice } from '@viro-community/react-viro';
+import { useQuery } from 'react-apollo';
 
 import { consts, device, texts } from '../../config';
 import { checkDownloadedData } from '../../helpers';
@@ -8,15 +9,24 @@ import { Button } from '../Button';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { Title, TitleContainer, TitleShadow } from '../Title';
 import { Wrapper } from '../Wrapper';
+import { GET_TOUR_STOPS } from '../../queries/tours';
 
 import { ARModal } from './ARModal';
 import { ARObjectList } from './ARObjectList';
 import { WhatIsARButton } from './WhatIsARButton';
+import { getQuery, QUERY_TYPES } from '../../queries';
 
-export const AugmentedReality = ({ tourStops, navigation, onSettingsScreen }) => {
+export const AugmentedReality = ({ id, navigation, onSettingsScreen }) => {
+  const {
+    data: {
+      tour: { tourStops }
+    },
+    loading
+  } = useQuery(getQuery(QUERY_TYPES.TOUR_STOPS), { variables: { id } });
+
   const [isARSupported, setIsARSupported] = useState(false);
   const [data, setData] = useState([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(loading);
   const [isModalVisible, setIsModalVisible] = useState(false);
 
   useEffect(() => {
@@ -42,7 +52,7 @@ export const AugmentedReality = ({ tourStops, navigation, onSettingsScreen }) =>
 
   if (!isARSupported) return null;
 
-  if (isLoading || !tourStops) return <LoadingSpinner loading />;
+  if (isLoading || !tourStops?.length) return <LoadingSpinner loading />;
 
   const a11yText = consts.a11yLabel;
 
@@ -101,6 +111,7 @@ export const AugmentedReality = ({ tourStops, navigation, onSettingsScreen }) =>
 
 AugmentedReality.propTypes = {
   tourStops: PropTypes.array,
+  id: PropTypes.string,
   navigation: PropTypes.object,
   onSettingsScreen: PropTypes.bool
 };

--- a/src/components/augmentedReality/AugmentedReality.js
+++ b/src/components/augmentedReality/AugmentedReality.js
@@ -13,7 +13,7 @@ import { ARModal } from './ARModal';
 import { ARObjectList } from './ARObjectList';
 import { WhatIsARButton } from './WhatIsARButton';
 
-export const AugmentedReality = ({ data: staticData, navigation, onSettingsScreen }) => {
+export const AugmentedReality = ({ tourStops, navigation, onSettingsScreen }) => {
   const [isARSupported, setIsARSupported] = useState(false);
   const [data, setData] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -27,12 +27,12 @@ export const AugmentedReality = ({ data: staticData, navigation, onSettingsScree
   }, []);
 
   useEffect(() => {
-    setData(staticData);
+    setData(tourStops);
 
-    if (staticData?.length) {
-      checkDownloadData({ data: staticData });
+    if (tourStops?.length) {
+      checkDownloadData({ data: tourStops });
     }
-  }, [staticData]);
+  }, [tourStops]);
 
   const checkDownloadData = async ({ data }) => {
     setIsLoading(true);
@@ -42,7 +42,7 @@ export const AugmentedReality = ({ data: staticData, navigation, onSettingsScree
 
   if (!isARSupported) return null;
 
-  if (isLoading || !staticData) return <LoadingSpinner loading />;
+  if (isLoading || !tourStops) return <LoadingSpinner loading />;
 
   const a11yText = consts.a11yLabel;
 
@@ -100,7 +100,7 @@ export const AugmentedReality = ({ data: staticData, navigation, onSettingsScree
 };
 
 AugmentedReality.propTypes = {
-  data: PropTypes.array,
+  tourStops: PropTypes.array,
   navigation: PropTypes.object,
   onSettingsScreen: PropTypes.bool
 };

--- a/src/components/augmentedReality/AugmentedReality.js
+++ b/src/components/augmentedReality/AugmentedReality.js
@@ -1,32 +1,40 @@
+import { isARSupportedOnDevice } from '@viro-community/react-viro';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
-import { isARSupportedOnDevice } from '@viro-community/react-viro';
 import { useQuery } from 'react-apollo';
 
 import { consts, device, texts } from '../../config';
 import { checkDownloadedData } from '../../helpers';
+import { getQuery, QUERY_TYPES } from '../../queries';
 import { Button } from '../Button';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { Title, TitleContainer, TitleShadow } from '../Title';
 import { Wrapper } from '../Wrapper';
-import { GET_TOUR_STOPS } from '../../queries/tours';
 
 import { ARModal } from './ARModal';
 import { ARObjectList } from './ARObjectList';
 import { WhatIsARButton } from './WhatIsARButton';
-import { getQuery, QUERY_TYPES } from '../../queries';
 
-export const AugmentedReality = ({ id, navigation, onSettingsScreen }) => {
-  const {
-    data: {
-      tour: { tourStops }
-    },
-    loading
-  } = useQuery(getQuery(QUERY_TYPES.TOUR_STOPS), { variables: { id } });
+const OnSettingsScreen = ({ id, isLoading, setData }) => {
+  const { data } = useQuery(getQuery(QUERY_TYPES.TOUR_STOPS), { variables: { id } });
 
+  return (
+    <ARObjectList
+      data={data?.tour?.tourStops}
+      setData={setData}
+      isLoading={isLoading}
+      showDeleteAllButton
+      showDownloadAllButton
+      showFreeSpace
+      showTitle
+    />
+  );
+};
+
+export const AugmentedReality = ({ id, navigation, onSettingsScreen, tourStops }) => {
   const [isARSupported, setIsARSupported] = useState(false);
   const [data, setData] = useState([]);
-  const [isLoading, setIsLoading] = useState(loading);
+  const [isLoading, setIsLoading] = useState(false);
   const [isModalVisible, setIsModalVisible] = useState(false);
 
   useEffect(() => {
@@ -52,23 +60,13 @@ export const AugmentedReality = ({ id, navigation, onSettingsScreen }) => {
 
   if (!isARSupported) return null;
 
-  if (isLoading || !tourStops?.length) return <LoadingSpinner loading />;
+  if (onSettingsScreen) {
+    return <OnSettingsScreen {...{ id, isLoading, setData }} />;
+  }
+
+  if (isLoading) return <LoadingSpinner loading />;
 
   const a11yText = consts.a11yLabel;
-
-  if (onSettingsScreen) {
-    return (
-      <ARObjectList
-        data={data}
-        setData={setData}
-        isLoading={isLoading}
-        showDeleteAllButton
-        showDownloadAllButton
-        showFreeSpace
-        showTitle
-      />
-    );
-  }
 
   return (
     <>
@@ -110,8 +108,14 @@ export const AugmentedReality = ({ id, navigation, onSettingsScreen }) => {
 };
 
 AugmentedReality.propTypes = {
-  tourStops: PropTypes.array,
   id: PropTypes.string,
   navigation: PropTypes.object,
-  onSettingsScreen: PropTypes.bool
+  onSettingsScreen: PropTypes.bool,
+  tourStops: PropTypes.array
+};
+
+OnSettingsScreen.propTypes = {
+  id: PropTypes.string,
+  isLoading: PropTypes.bool,
+  setData: PropTypes.func
 };

--- a/src/components/augmentedReality/AugmentedReality.js
+++ b/src/components/augmentedReality/AugmentedReality.js
@@ -4,7 +4,6 @@ import { isARSupportedOnDevice } from '@viro-community/react-viro';
 
 import { consts, device, texts } from '../../config';
 import { checkDownloadedData } from '../../helpers';
-import { useStaticContent } from '../../hooks';
 import { Button } from '../Button';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { Title, TitleContainer, TitleShadow } from '../Title';
@@ -14,20 +13,10 @@ import { ARModal } from './ARModal';
 import { ARObjectList } from './ARObjectList';
 import { WhatIsARButton } from './WhatIsARButton';
 
-export const AugmentedReality = ({ navigation, onSettingsScreen, tourID }) => {
-  const {
-    data: staticData,
-    error,
-    loading,
-    refetch
-  } = useStaticContent({
-    name: `arDownloadableDataList-${tourID}`,
-    type: 'json'
-  });
-
+export const AugmentedReality = ({ data: staticData, navigation, onSettingsScreen }) => {
   const [isARSupported, setIsARSupported] = useState(false);
   const [data, setData] = useState([]);
-  const [isLoading, setIsLoading] = useState(loading);
+  const [isLoading, setIsLoading] = useState(false);
   const [isModalVisible, setIsModalVisible] = useState(false);
 
   useEffect(() => {
@@ -51,7 +40,7 @@ export const AugmentedReality = ({ navigation, onSettingsScreen, tourID }) => {
     setIsLoading(false);
   };
 
-  if (error || !isARSupported) return null;
+  if (!isARSupported) return null;
 
   if (isLoading || !staticData) return <LoadingSpinner loading />;
 
@@ -63,7 +52,6 @@ export const AugmentedReality = ({ navigation, onSettingsScreen, tourID }) => {
         data={data}
         setData={setData}
         isLoading={isLoading}
-        refetch={refetch}
         showDeleteAllButton
         showDownloadAllButton
         showFreeSpace
@@ -74,7 +62,7 @@ export const AugmentedReality = ({ navigation, onSettingsScreen, tourID }) => {
 
   return (
     <>
-      <WhatIsARButton {...{ data, isLoading, navigation, refetch }} />
+      <WhatIsARButton {...{ data, isLoading, navigation }} />
 
       <Wrapper>
         <Button
@@ -95,7 +83,6 @@ export const AugmentedReality = ({ navigation, onSettingsScreen, tourID }) => {
         setData={setData}
         isLoading={isLoading}
         navigation={navigation}
-        refetch={refetch}
         showOnDetailPage
       />
 
@@ -106,7 +93,6 @@ export const AugmentedReality = ({ navigation, onSettingsScreen, tourID }) => {
         isLoading={isLoading}
         isModalVisible={isModalVisible}
         setIsModalVisible={setIsModalVisible}
-        refetch={refetch}
         showTitle
       />
     </>
@@ -114,7 +100,7 @@ export const AugmentedReality = ({ navigation, onSettingsScreen, tourID }) => {
 };
 
 AugmentedReality.propTypes = {
+  data: PropTypes.array,
   navigation: PropTypes.object,
-  onSettingsScreen: PropTypes.bool,
-  tourID: PropTypes.string
+  onSettingsScreen: PropTypes.bool
 };

--- a/src/components/augmentedReality/AugmentedRealityView.js
+++ b/src/components/augmentedReality/AugmentedRealityView.js
@@ -100,7 +100,7 @@ const ViroSoundAnd3DObject = (item) => {
 
       <Viro3DObject
         source={{ uri: object.vrx }}
-        resources={[{ uri: object.png }]}
+        resources={[{ uri: object.texture }]}
         type="VRX"
         position={position}
         rotation={rotation}

--- a/src/components/augmentedReality/IconForDownloadType.js
+++ b/src/components/augmentedReality/IconForDownloadType.js
@@ -5,21 +5,20 @@ import { ActivityIndicator } from 'react-native';
 import { colors, Icon, normalize } from '../../config';
 import { DOWNLOAD_TYPE } from '../../helpers';
 
-export const IconForDownloadType = ({ isListView, itemDownloadType, showOnDetailPage }) => {
+export const IconForDownloadType = ({ isListView, downloadType, showOnDetailPage }) => {
   if (showOnDetailPage) {
     return <Icon.ArrowRight size={normalize(20)} />;
   }
 
-  switch (itemDownloadType) {
+  switch (downloadType) {
     case DOWNLOAD_TYPE.DOWNLOADABLE:
       return <Icon.ArrowDownCircle color={colors.primary} size={normalize(16)} />;
     case DOWNLOAD_TYPE.DOWNLOADED:
-      return isListView ? (
-        <Icon.CloseCircle color={colors.darkText} size={normalize(16)} />
-      ) : (
-        <Icon.Check color={colors.primary} size={normalize(20)} />
-      );
+      if (isListView) {
+        return <Icon.CloseCircle color={colors.darkText} size={normalize(16)} />;
+      }
 
+      return <Icon.Check color={colors.primary} size={normalize(20)} />;
     default:
       return <ActivityIndicator size="small" color={colors.accent} />;
   }
@@ -27,6 +26,6 @@ export const IconForDownloadType = ({ isListView, itemDownloadType, showOnDetail
 
 IconForDownloadType.propTypes = {
   isListView: PropTypes.bool,
-  itemDownloadType: PropTypes.string.isRequired,
+  downloadType: PropTypes.string.isRequired,
   showOnDetailPage: PropTypes.bool
 };

--- a/src/components/screens/Tour.js
+++ b/src/components/screens/Tour.js
@@ -30,6 +30,7 @@ export const Tour = ({ data, navigation, route }) => {
     contact,
     dataProvider,
     description,
+    id,
     lengthKm,
     mediaContents,
     operatingCompany,
@@ -95,7 +96,7 @@ export const Tour = ({ data, navigation, route }) => {
           </View>
         )}
 
-        {!!tourStops?.length && <AugmentedReality tourStops={tourStops} navigation={navigation} />}
+        {!!tourStops?.length && <AugmentedReality {...{ id, navigation }} />}
 
         <OperatingCompany
           openWebScreen={openWebScreen}

--- a/src/components/screens/Tour.js
+++ b/src/components/screens/Tour.js
@@ -96,7 +96,7 @@ export const Tour = ({ data, navigation, route }) => {
           </View>
         )}
 
-        {!!tourStops?.length && <AugmentedReality {...{ id, navigation }} />}
+        {!!tourStops?.length && <AugmentedReality {...{ id, tourStops, navigation }} />}
 
         <OperatingCompany
           openWebScreen={openWebScreen}

--- a/src/components/screens/Tour.js
+++ b/src/components/screens/Tour.js
@@ -95,7 +95,7 @@ export const Tour = ({ data, navigation, route }) => {
           </View>
         )}
 
-        {!!tourStops.length && <AugmentedReality data={tourStops} navigation={navigation} />}
+        {!!tourStops?.length && <AugmentedReality tourStops={tourStops} navigation={navigation} />}
 
         <OperatingCompany
           openWebScreen={openWebScreen}

--- a/src/components/screens/Tour.js
+++ b/src/components/screens/Tour.js
@@ -30,11 +30,11 @@ export const Tour = ({ data, navigation, route }) => {
     contact,
     dataProvider,
     description,
-    id,
     lengthKm,
     mediaContents,
     operatingCompany,
     title,
+    tourStops,
     webUrls
   } = data;
   // action to open source urls
@@ -47,9 +47,6 @@ export const Tour = ({ data, navigation, route }) => {
   const logo = dataProvider && dataProvider.logo && dataProvider.logo.url;
   // the categories of a news item can be nested and we need the map of all names of all categories
   const categoryNames = categories && categories.map((category) => category.name).join(' / ');
-
-  // TODO: DEVELOP! - it will be deleted, it was only made to development!
-  let augmentedReality = true;
 
   useMatomoTrackScreenView(
     matomoTrackingString([
@@ -98,7 +95,7 @@ export const Tour = ({ data, navigation, route }) => {
           </View>
         )}
 
-        {!!augmentedReality && <AugmentedReality navigation={navigation} tourID={id} />}
+        {!!tourStops.length && <AugmentedReality data={tourStops} navigation={navigation} />}
 
         <OperatingCompany
           openWebScreen={openWebScreen}

--- a/src/helpers/augmentedReality/checkDownloadedData.js
+++ b/src/helpers/augmentedReality/checkDownloadedData.js
@@ -8,20 +8,20 @@ export const checkDownloadedData = async ({ data, setData }) => {
   const checkedData = [...data];
 
   for (const [index, dataItem] of checkedData.entries()) {
-    for (const objectItem of dataItem?.downloadableUris) {
+    for (const objectItem of dataItem?.payload?.downloadableUris) {
       const { storageName } = storageNameCreator({ dataItem, objectItem });
 
       try {
         const downloadedItem = await readFromStore(storageName);
 
-        if (downloadedItem?.localUris) {
+        if (downloadedItem?.payload?.localUris) {
           checkedData[index] = downloadedItem;
         } else {
-          checkedData[index].DOWNLOAD_TYPE = DOWNLOAD_TYPE.DOWNLOADABLE;
-          checkedData[index].localUris = [];
-          checkedData[index].progress = 0;
-          checkedData[index].progressSize = 0;
-          checkedData[index].size = 0;
+          checkedData[index].payload.downloadType = DOWNLOAD_TYPE.DOWNLOADABLE;
+          checkedData[index].payload.localUris = [];
+          checkedData[index].payload.progress = 0;
+          checkedData[index].payload.progressSize = 0;
+          checkedData[index].payload.size = 0;
         }
       } catch (error) {
         console.error(error);

--- a/src/helpers/augmentedReality/deleteObject.js
+++ b/src/helpers/augmentedReality/deleteObject.js
@@ -19,18 +19,18 @@ export const deleteObject = async ({ index, data, setData }) => {
   const deletedData = [...data];
   const dataItem = data[index];
 
-  for (const objectItem of dataItem?.localUris) {
+  for (const objectItem of dataItem?.payload?.localUris) {
     const { storageName } = storageNameCreator({ dataItem, objectItem });
 
     try {
       await FileSystem.deleteAsync(objectItem?.uri);
       await AsyncStorage.removeItem(storageName);
 
-      deletedData[index].DOWNLOAD_TYPE = DOWNLOAD_TYPE.DOWNLOADABLE;
-      deletedData[index].localUris = [];
-      deletedData[index].progress = 0;
-      deletedData[index].progressSize = 0;
-      deletedData[index].size = 0;
+      deletedData[index].payload.downloadType = DOWNLOAD_TYPE.DOWNLOADABLE;
+      deletedData[index].payload.localUris = [];
+      deletedData[index].payload.progress = 0;
+      deletedData[index].payload.progressSize = 0;
+      deletedData[index].payload.size = 0;
     } catch (error) {
       console.error(error);
 

--- a/src/helpers/augmentedReality/downloadAndDeleteAllData.js
+++ b/src/helpers/augmentedReality/downloadAndDeleteAllData.js
@@ -7,7 +7,7 @@ import { storageNameCreator } from './storageNameCreator';
 // function to download all AR objects using `downloadObject`
 export const downloadAllData = async ({ data, setData }) => {
   for (const [index, dataItem] of data.entries()) {
-    for (const objectItem of dataItem?.downloadableUris) {
+    for (const objectItem of dataItem?.payload?.downloadableUris) {
       const { storageName } = storageNameCreator({ dataItem, objectItem });
 
       try {

--- a/src/helpers/augmentedReality/downloadObject.js
+++ b/src/helpers/augmentedReality/downloadObject.js
@@ -10,7 +10,7 @@ export const downloadObject = async ({ index, data, setData }) => {
   const downloadedData = [...data];
   const dataItem = data[index];
 
-  for (const objectItem of dataItem?.downloadableUris) {
+  for (const objectItem of dataItem?.payload?.downloadableUris) {
     const { uri, title, type, id } = objectItem;
 
     const { directoryName, folderName, storageName } = storageNameCreator({ dataItem, objectItem });
@@ -37,9 +37,9 @@ export const downloadObject = async ({ index, data, setData }) => {
       const { uri } = await downloadResumable.downloadAsync();
       const { size } = await FileSystem.getInfoAsync(uri);
 
-      downloadedData[index].DOWNLOAD_TYPE = DOWNLOAD_TYPE.DOWNLOADED;
-      downloadedData[index].size += size;
-      downloadedData[index].localUris.push({ uri, id, size, title, type });
+      downloadedData[index].payload.downloadType = DOWNLOAD_TYPE.DOWNLOADED;
+      downloadedData[index].payload.size += size;
+      downloadedData[index].payload.localUris.push({ uri, id, size, title, type });
 
       addToStore(storageName, downloadedData[index]);
     } catch (e) {
@@ -62,10 +62,11 @@ export const downloadObject = async ({ index, data, setData }) => {
  *                                  the screen to show the download size
  */
 const downloadProgressInBytes = (progress, index, downloadedData, setData) => {
-  downloadedData[index].DOWNLOAD_TYPE = DOWNLOAD_TYPE.DOWNLOADING;
-  downloadedData[index].progressSize = downloadedData[index].size + progress.totalBytesWritten;
-  downloadedData[index].progress =
-    downloadedData[index].progressSize / downloadedData[index].totalSize;
+  downloadedData[index].payload.downloadType = DOWNLOAD_TYPE.DOWNLOADING;
+  downloadedData[index].payload.progressSize =
+    downloadedData[index].payload.size + progress.totalBytesWritten;
+  downloadedData[index].payload.progress =
+    downloadedData[index].payload.progressSize / downloadedData[index].payload.totalSize;
 
   // we create a copy of the array to make the set state method aware of "there is something new"
   // that should be rendered

--- a/src/helpers/augmentedReality/storageNameCreator.js
+++ b/src/helpers/augmentedReality/storageNameCreator.js
@@ -1,9 +1,14 @@
 import { documentDirectory } from 'expo-file-system';
 
+import { consts } from '../../config';
+
+const { IMAGE_TYPE_REGEX } = consts;
+
 export const storageNameCreator = ({ dataItem, objectItem }) => {
+  const imageType = IMAGE_TYPE_REGEX.exec(objectItem.uri);
   const objectItemTitleWithoutSpaces = dataItem.title.replace(/\s+/g, '');
   const dataDirectoryName = `${objectItemTitleWithoutSpaces}_${dataItem.id}`;
-  const objectName = `${objectItem.title}.${objectItem.type}`;
+  const objectName = `${objectItem.title}.${imageType ? imageType[1] : objectItem.type}`;
 
   return {
     directoryName: documentDirectory + `${dataDirectoryName}/${objectName}`,

--- a/src/helpers/augmentedReality/storageNameCreator.js
+++ b/src/helpers/augmentedReality/storageNameCreator.js
@@ -5,10 +5,22 @@ import { consts } from '../../config';
 const { IMAGE_TYPE_REGEX } = consts;
 
 export const storageNameCreator = ({ dataItem, objectItem }) => {
-  const imageType = IMAGE_TYPE_REGEX.exec(objectItem.uri);
+  /* `textureType` has been added because we need the type of texture data. with the `REGEX` we have 
+	  prepared in advance, we must find out exactly what type the texture data is and add this type 
+		to the end of the texture name. otherwise the texture files cannot be read properly and will 
+		not work.
+		for example:
+		file type from server   = edited file type
+		Ch17_1001.texture 	    = Ch17_1001.png
+		Ch17_1002.texture       = Ch17_1002.jpg
+		augmentedReality.target = augmentedReality.png
+		Musik.mp3               = Musik.mp3
+		test.vrx                = test.vrx
+ 	*/
+  const textureType = IMAGE_TYPE_REGEX.exec(objectItem.uri);
   const objectItemTitleWithoutSpaces = dataItem.title.replace(/\s+/g, '');
   const dataDirectoryName = `${objectItemTitleWithoutSpaces}_${dataItem.id}`;
-  const objectName = `${objectItem.title}.${imageType ? imageType[1] : objectItem.type}`;
+  const objectName = `${objectItem.title}.${textureType ? textureType[1] : objectItem.type}`;
 
   return {
     directoryName: documentDirectory + `${dataDirectoryName}/${objectName}`,

--- a/src/helpers/augmentedReality/storageNameCreator.js
+++ b/src/helpers/augmentedReality/storageNameCreator.js
@@ -5,26 +5,42 @@ import { consts } from '../../config';
 const { IMAGE_TYPE_REGEX } = consts;
 
 export const storageNameCreator = ({ dataItem, objectItem }) => {
-  /* `textureType` has been added because we need the type of texture data. with the `REGEX` we have 
-	  prepared in advance, we must find out exactly what type the texture data is and add this type 
-		to the end of the texture name. otherwise the texture files cannot be read properly and will 
-		not work.
-		for example:
-		file type from server   = edited file type
-		Ch17_1001.texture 	    = Ch17_1001.png
-		Ch17_1002.texture       = Ch17_1002.jpg
-		augmentedReality.target = augmentedReality.png
-		Musik.mp3               = Musik.mp3
-		test.vrx                = test.vrx
- 	*/
-  const textureType = IMAGE_TYPE_REGEX.exec(objectItem.uri);
   const objectItemTitleWithoutSpaces = dataItem.title.replace(/\s+/g, '');
   const dataDirectoryName = `${objectItemTitleWithoutSpaces}_${dataItem.id}`;
-  const objectName = `${objectItem.title}.${textureType ? textureType[1] : objectItem.type}`;
+  const modelName = objectNameParser(objectItem);
 
   return {
-    directoryName: documentDirectory + `${dataDirectoryName}/${objectName}`,
+    directoryName: documentDirectory + `${dataDirectoryName}/${modelName}`,
     folderName: documentDirectory + `${dataDirectoryName}`,
-    storageName: `${dataDirectoryName}_${objectName}`
+    storageName: `${dataDirectoryName}_${modelName}`
   };
+};
+
+/**
+ * `textureType` has been added because we need the type of texture data. with the `REGEX` we have
+ *	  prepared in advance, we must find out exactly what type the texture data is and add this type
+ *		to the end of the texture name. otherwise the texture files cannot be read properly and will
+ *		not work
+ *		for example:
+ *		file type from server   = edited file type
+ *		Ch17_1001.texture 	    = Ch17_1001.png
+ *		Ch17_1002.texture       = Ch17_1002.jpg
+ *		augmentedReality.target = augmentedReality.png
+ *		Musik.mp3               = Musik.mp3
+ *		test.vrx                = test.vrx
+ *
+ * @param {string} title     model name
+ * @param {string} type      model type
+ * @param {string} uri       download link of the model
+ *
+ * @return {string}          concatenate parsed model name and type
+ */
+const objectNameParser = (objectItem) => {
+  const { title, type, uri } = objectItem;
+
+  if (!title && !type && !uri) return;
+
+  const textureType = IMAGE_TYPE_REGEX.exec(uri);
+
+  return `${title}.${textureType ? textureType[1] : type}`;
 };

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -27,7 +27,7 @@ import { GET_POINTS_OF_INTEREST, GET_POINT_OF_INTEREST } from './pointsOfInteres
 import { GET_POINTS_OF_INTEREST_AND_TOURS } from './pointsOfInterestAndTours';
 import { GET_PUBLIC_HTML_FILE } from './publicHtmlFiles';
 import { GET_PUBLIC_JSON_FILE } from './publicJsonFiles';
-import { GET_TOUR, GET_TOURS } from './tours';
+import { GET_TOUR, GET_TOURS, GET_TOUR_STOPS } from './tours';
 import { QUERY_TYPES } from './types';
 import {
   calendar,
@@ -66,6 +66,7 @@ export const getQuery = (query, filterOptions = {}) => {
     [QUERY_TYPES.NEWS_ITEMS_DATA_PROVIDER]: GET_NEWS_ITEMS_DATA_PROVIDERS,
     [QUERY_TYPES.TOUR]: GET_TOUR,
     [QUERY_TYPES.TOURS]: GET_TOURS,
+    [QUERY_TYPES.TOUR_STOPS]: GET_TOUR_STOPS,
     [QUERY_TYPES.POINT_OF_INTEREST]: GET_POINT_OF_INTEREST,
     [QUERY_TYPES.POINTS_OF_INTEREST]: GET_POINTS_OF_INTEREST,
     [QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS]: GET_POINTS_OF_INTEREST_AND_TOURS,

--- a/src/queries/tours.js
+++ b/src/queries/tours.js
@@ -180,3 +180,22 @@ export const GET_TOUR = gql`
     }
   }
 `;
+
+export const GET_TOUR_STOPS = gql`
+  query Tour($id: ID!) {
+    tour(id: $id) {
+      tourStops {
+        id
+        title: name
+        description
+        location {
+          geoLocation {
+            latitude
+            longitude
+          }
+        }
+        payload
+      }
+    }
+  }
+`;

--- a/src/queries/tours.js
+++ b/src/queries/tours.js
@@ -92,6 +92,18 @@ export const GET_TOUR = gql`
         id
         name
       }
+      tourStops {
+        id
+        title: name
+        description
+        location {
+          geoLocation {
+            latitude
+            longitude
+          }
+        }
+        payload
+      }
       description
       mediaContents {
         id

--- a/src/queries/types.ts
+++ b/src/queries/types.ts
@@ -48,6 +48,7 @@ export const QUERY_TYPES = {
   PUBLIC_HTML_FILE: 'publicHtmlFile',
   PUBLIC_JSON_FILE: 'publicJsonFile',
   TOUR: 'tour',
+  TOUR_STOPS: 'tourStops',
   TOURS: 'tours',
   VOLUNTEER: {
     ADDITIONAL: 'additional',

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -240,6 +240,7 @@ export const SettingsScreen = () => {
         />
       )}
       {selectedFilterId === TOP_FILTER.LIST_TYPES && <ListSettings />}
+      {/* TODO: this will crash now as the props were changed in `AugmentedReality`, right? */}
       {selectedFilterId === TOP_FILTER.AR_DOWNLOAD_LIST && (
         <AugmentedReality onSettingsScreen tourID="579" />
       )}

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -240,9 +240,8 @@ export const SettingsScreen = () => {
         />
       )}
       {selectedFilterId === TOP_FILTER.LIST_TYPES && <ListSettings />}
-      {/* TODO: this will crash now as the props were changed in `AugmentedReality`, right? */}
       {selectedFilterId === TOP_FILTER.AR_DOWNLOAD_LIST && (
-        <AugmentedReality onSettingsScreen tourID="579" />
+        <AugmentedReality id="579" onSettingsScreen />
       )}
     </SafeAreaViewFlex>
   );

--- a/src/screens/augmentedReality/ARShowScreen.js
+++ b/src/screens/augmentedReality/ARShowScreen.js
@@ -163,17 +163,21 @@ export const ARShowScreen = ({ navigation, route }) => {
 };
 
 const objectParser = async ({ item, setObject, setIsLoading, onPress }) => {
-  let parsedObject = {};
+  let parsedObject = { texture: [] };
 
-  if (item.animationName) {
-    parsedObject.animationName = item.animationName;
+  if (item?.payload?.animationName) {
+    parsedObject.animationName = item?.payload?.animationName;
   }
 
-  item?.localUris?.forEach((item) => {
-    parsedObject[item.type] = item.uri;
+  item?.payload?.localUris?.forEach((item) => {
+    if (item.type === 'texture') {
+      parsedObject[item.type].push({ uri: item.uri });
+    } else {
+      parsedObject[item.type] = item.uri;
+    }
   });
 
-  if (!parsedObject.png || !parsedObject.vrx) {
+  if (!parsedObject.texture || !parsedObject.vrx) {
     return Alert.alert(
       texts.augmentedReality.modalHiddenAlertTitle,
       texts.augmentedReality.invalidModelError,

--- a/src/screens/augmentedReality/ARShowScreen.js
+++ b/src/screens/augmentedReality/ARShowScreen.js
@@ -87,7 +87,7 @@ export const ARShowScreen = ({ navigation, route }) => {
         style={[styles.backButton, styles.generalButtonStyle]}
         onPress={() => {
           /*
-          to solve the Android crash problem, you must first remove the 3D object from the screen. 
+          to solve the Android crash problem, you must first remove the 3D object from the screen.
           then navigation can be done.
           */
           if (isVideoRecording) {
@@ -163,7 +163,7 @@ export const ARShowScreen = ({ navigation, route }) => {
 };
 
 const objectParser = async ({ item, setObject, setIsLoading, onPress }) => {
-  let parsedObject = { texture: [] };
+  const parsedObject = { texture: [] };
 
   if (item?.payload?.animationName) {
     parsedObject.animationName = item?.payload?.animationName;
@@ -177,7 +177,7 @@ const objectParser = async ({ item, setObject, setIsLoading, onPress }) => {
     }
   });
 
-  if (!parsedObject.texture || !parsedObject.vrx) {
+  if (!parsedObject?.texture?.length || !parsedObject?.vrx) {
     return Alert.alert(
       texts.augmentedReality.modalHiddenAlertTitle,
       texts.augmentedReality.invalidModelError,

--- a/src/screens/augmentedReality/ArtworkDetailScreen.js
+++ b/src/screens/augmentedReality/ArtworkDetailScreen.js
@@ -20,7 +20,12 @@ import { usePullToRefetch, useStaticContent } from '../../hooks';
 import { ScreenName } from '../../types';
 
 export const ArtworkDetailScreen = ({ route, navigation }) => {
-  const { data: artworkDetail = '', error, loading, refetch } = useStaticContent({
+  const {
+    data: artworkDetail = '',
+    error,
+    loading,
+    refetch
+  } = useStaticContent({
     type: 'html',
     name: 'artworkDetail'
   });
@@ -29,7 +34,7 @@ export const ArtworkDetailScreen = ({ route, navigation }) => {
   const [data, setData] = useState(route?.params?.data ?? []);
   const [isLoading, setIsLoading] = useState(loading);
   const index = route?.params?.index;
-  const { downloadType: itemDownloadType } = data[index]?.payload;
+  const { downloadType } = data[index]?.payload;
 
   const RefreshControl = usePullToRefetch(refetch);
 
@@ -46,7 +51,7 @@ export const ArtworkDetailScreen = ({ route, navigation }) => {
   };
 
   const onPress = async () => {
-    switch (itemDownloadType) {
+    switch (downloadType) {
       case DOWNLOAD_TYPE.DOWNLOADABLE:
         setIsModalVisible(true);
 
@@ -84,7 +89,7 @@ export const ArtworkDetailScreen = ({ route, navigation }) => {
             <Button
               onPress={onPress}
               title={
-                itemDownloadType === DOWNLOAD_TYPE.DOWNLOADED
+                downloadType === DOWNLOAD_TYPE.DOWNLOADED
                   ? texts.augmentedReality.artworkDetailScreen.lookAtArt
                   : texts.augmentedReality.artworkDetailScreen.downloadAndLookAtArt
               }
@@ -98,7 +103,7 @@ export const ArtworkDetailScreen = ({ route, navigation }) => {
         index={index}
         isModalVisible={isModalVisible}
         onModalVisible={() => {
-          switch (itemDownloadType) {
+          switch (downloadType) {
             case DOWNLOAD_TYPE.DOWNLOADING:
               HiddenModalAlert({ onPress: () => setIsModalVisible(!isModalVisible) });
 

--- a/src/screens/augmentedReality/ArtworkDetailScreen.js
+++ b/src/screens/augmentedReality/ArtworkDetailScreen.js
@@ -29,7 +29,7 @@ export const ArtworkDetailScreen = ({ route, navigation }) => {
   const [data, setData] = useState(route?.params?.data ?? []);
   const [isLoading, setIsLoading] = useState(loading);
   const index = route?.params?.index;
-  const { DOWNLOAD_TYPE: itemDownloadType } = data[index];
+  const { downloadType: itemDownloadType } = data[index]?.payload;
 
   const RefreshControl = usePullToRefetch(refetch);
 
@@ -78,7 +78,7 @@ export const ArtworkDetailScreen = ({ route, navigation }) => {
             <HtmlView html={artworkDetail} />
           </Wrapper>
 
-          <WhatIsARButton {...{ data, isLoading, navigation, refetch }} />
+          <WhatIsARButton {...{ data, isLoading, navigation }} />
 
           <Wrapper>
             <Button


### PR DESCRIPTION
- added `tourStops` query to `tour` query
- updated all helpers accordingly as the model
  information is included in the `payload` object
- changed from `png` to `texture` in the resource
  section to support different file types
- removed `refetch` because the data came with
  tour data
- updated `DOWNLOAD_TYPE` to `downloadType`
- added `imageType` to `storageNameCreator`
  and updated `objectName` to capture the actual
  name and extension of the texture file

SVA-633
