### PR TITLE
feat(volunteer): render documents for volunteer events

### DIFF
--- a/src/config/Icon.tsx
+++ b/src/config/Icon.tsx
@@ -110,6 +110,7 @@ export const Icon = {
     <NamedIcon name={device.platform === 'ios' ? 'ios-briefcase' : 'md-briefcase'} {...props} />
   ),
   ConstructionSite: (props: IconProps) => <SvgIcon xml={constructionSite} {...props} />,
+  Document: (props: IconProps) => <NamedIcon name="md-document-text-outline" {...props} />,
   DrawerMenu: (props: IconProps) => <SvgIcon xml={drawerMenu} {...props} />,
   EditSetting: (props: IconProps) => <NamedIcon name="md-create" {...props} />,
   EmptySection: (props: IconProps) => <SvgIcon xml={emptySection} {...props} />,


### PR DESCRIPTION
- added method to filter for files on their mimetype to differentiate
  between image and file (application)
- added rendering of files/documents with same style like in uploads
  but with new icon on the left

HDVT-55

|render|press|
|---|---|
|![simulator_screenshot_5181392D-6317-4F92-87C7-AF79EECC47B8](https://user-images.githubusercontent.com/1942953/183933225-25a33560-51f4-4030-9c3e-3518395f033c.png)|![Simulator Screen Shot - iPhone 11 - 2022-08-10 at 16 37 55](https://user-images.githubusercontent.com/1942953/183933124-030cdd34-02a1-4c75-bda2-3fd7a3a34182.png)|