### PR TITLE
feat(maps): add polyline to map

### DIFF
--- a/src/components/augmentedReality/AugmentedReality.js
+++ b/src/components/augmentedReality/AugmentedReality.js
@@ -28,7 +28,7 @@ const INITIAL_FILTER = [
   { id: TOP_FILTER.LIST_VIEW, title: texts.augmentedReality.filter.listView, selected: false }
 ];
 
-export const AugmentedReality = ({ navigation, onSettingsScreen, tourID }) => {
+export const AugmentedReality = ({ geometryTourData, navigation, onSettingsScreen, tourID }) => {
   const {
     data: staticData,
     error,
@@ -134,6 +134,7 @@ export const AugmentedReality = ({ navigation, onSettingsScreen, tourID }) => {
 
       {selectedFilterId === TOP_FILTER.MAP_VIEW && (
         <Map
+          geometryTourData={geometryTourData}
           locations={mapMarkers}
           onMarkerPress={setModelId}
           onMaximizeButtonPress={() =>
@@ -142,6 +143,7 @@ export const AugmentedReality = ({ navigation, onSettingsScreen, tourID }) => {
                 data,
                 refetch
               },
+              geometryTourData,
               isAugmentedReality: true,
               isMaximizeButtonVisible: false,
               locations: mapMarkers
@@ -168,8 +170,8 @@ export const AugmentedReality = ({ navigation, onSettingsScreen, tourID }) => {
 const mapToMapMarkers = (augmentedReality) => {
   return augmentedReality
     ?.map((item) => {
-      const latitude = item.location.lat;
-      const longitude = item.location.lng;
+      const latitude = item?.location?.lat;
+      const longitude = item?.location?.lng;
 
       if (!latitude || !longitude) return undefined;
       return {
@@ -186,6 +188,7 @@ const mapToMapMarkers = (augmentedReality) => {
 };
 
 AugmentedReality.propTypes = {
+  geometryTourData: PropTypes.array,
   navigation: PropTypes.object,
   onSettingsScreen: PropTypes.bool,
   tourID: PropTypes.string

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 import { StyleProp, StyleSheet, TouchableOpacity, View, ViewStyle } from 'react-native';
 import { normalize } from 'react-native-elements';
-import MapView, { MAP_TYPES, Marker, UrlTile } from 'react-native-maps';
+import MapView, { LatLng, MAP_TYPES, Marker, Polyline, UrlTile } from 'react-native-maps';
 import { SvgXml } from 'react-native-svg';
 
 import { colors, device, Icon } from '../../config';
@@ -9,6 +9,7 @@ import { imageHeight, imageWidth } from '../../helpers';
 import { MapMarker } from '../../types';
 
 type Props = {
+  geometryTourData?: LatLng[];
   isMaximizeButtonVisible?: boolean;
   locations?: MapMarker[];
   mapCenterPosition?: { lat: number; lng: number };
@@ -27,6 +28,7 @@ const LATITUDE_DELTA = 0.0922;
 const LONGITUDE_DELTA = LATITUDE_DELTA * (device.width / (device.height / 2));
 
 export const Map = ({
+  geometryTourData,
   isMaximizeButtonVisible,
   locations,
   mapCenterPosition,
@@ -80,6 +82,9 @@ export const Map = ({
           left: 0
         }}
       >
+        {!!geometryTourData?.length && (
+          <Polyline coordinates={geometryTourData} strokeWidth={2} strokeColor={colors.primary} />
+        )}
         <UrlTile
           urlTemplate="https://a.tile.opentopomap.org/{z}/{x}/{y}.png"
           shouldReplaceMapContent={device.platform === 'ios'}

--- a/src/components/screens/Tour.js
+++ b/src/components/screens/Tour.js
@@ -31,6 +31,7 @@ export const Tour = ({ data, navigation, route }) => {
     dataProvider,
     description,
     id,
+    geometryTourData,
     lengthKm,
     mediaContents,
     operatingCompany,
@@ -98,7 +99,13 @@ export const Tour = ({ data, navigation, route }) => {
           </View>
         )}
 
-        {!!augmentedReality && <AugmentedReality navigation={navigation} tourID={id} />}
+        {!!augmentedReality && (
+          <AugmentedReality
+            geometryTourData={geometryTourData}
+            navigation={navigation}
+            tourID={id}
+          />
+        )}
 
         <OperatingCompany
           openWebScreen={openWebScreen}

--- a/src/queries/tours.js
+++ b/src/queries/tours.js
@@ -124,6 +124,10 @@ export const GET_TOUR = gql`
           description
         }
       }
+      geometryTourData {
+        latitude
+        longitude
+      }
       webUrls {
         id
         url

--- a/src/screens/MapViewScreen.js
+++ b/src/screens/MapViewScreen.js
@@ -8,6 +8,7 @@ import { navigationToArtworksDetailScreen } from '../helpers';
 
 export const MapViewScreen = ({ navigation, route }) => {
   const {
+    geometryTourData,
     isAugmentedReality,
     isMaximizeButtonVisible,
     locations,
@@ -30,6 +31,7 @@ export const MapViewScreen = ({ navigation, route }) => {
     <>
       <Map
         {...{
+          geometryTourData,
           isMaximizeButtonVisible,
           locations,
           mapStyle: styles.mapStyle,


### PR DESCRIPTION
- added `Polyline` to `Map` component to show
  the route on the map
  -  to see the route we need location information
      of type `LatLng[]`
- added `geometryTourData` to `Tour` query for
  route information
- added the necessary props to display the route
  on the fullscreen map page
- added control to prevent an error if the
  `augmentedReality` object does not have location
  information

SVA-634

## How to test:
* [ ] Android portrait mode
* [x] iOS portrait mode
* [ ] Android landscape mode
* [ ] iOS landscape mode

**Add additional information for testing, if required**

## Screenshots:

|Polyline without loading the map|Polyline wit loading the map|Full screen Polyline on the map|
|--|--|--|
![IMG_0059](https://user-images.githubusercontent.com/11755668/184312733-42011312-a07e-4eab-9ecb-8b3ab42cfb94.PNG) | ![IMG_0061](https://user-images.githubusercontent.com/11755668/184312740-e3df61ca-fb14-46d0-aea6-243baeab098e.PNG) | ![IMG_0060](https://user-images.githubusercontent.com/11755668/184312735-48ec387d-a13f-4aa4-a92c-88f41b298693.PNG)


