### PR TITLE
feature(event): not showing count in event widget

### DIFF
--- a/src/components/widgets/DefaultWidget.tsx
+++ b/src/components/widgets/DefaultWidget.tsx
@@ -16,11 +16,11 @@ type Props = {
 export const DefaultWidget = ({ Icon, count, onPress, text }: Props) => {
   return (
     <TouchableOpacity onPress={onPress}>
-      <WrapperVertical style={styles().container}>
+      <WrapperVertical style={styles.container}>
         <WrapperRow center>
-          <Icon style={styles(!!count?.toString()).icon} />
+          <Icon style={[styles.iconWithoutCount, !!count?.toString() && styles.iconWithCount]} />
           <BoldText primary big>
-            {count}
+            {count ?? ''}
           </BoldText>
         </WrapperRow>
         <RegularText primary small>
@@ -33,14 +33,15 @@ export const DefaultWidget = ({ Icon, count, onPress, text }: Props) => {
 
 /* eslint-disable react-native/no-unused-styles */
 /* this works properly, we do not want that warning */
-const styles = (count?: boolean) =>
-  StyleSheet.create({
-    container: {
-      alignItems: 'center'
-    },
-    icon: {
-      paddingRight: count ? normalize(8) : 0,
-      paddingBottom: normalize(3)
-    }
-  });
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center'
+  },
+  iconWithCount: {
+    paddingRight: normalize(8)
+  },
+  iconWithoutCount: {
+    paddingBottom: normalize(3)
+  }
+});
 /* eslint-enable react-native/no-unused-styles */

--- a/src/components/widgets/DefaultWidget.tsx
+++ b/src/components/widgets/DefaultWidget.tsx
@@ -31,8 +31,6 @@ export const DefaultWidget = ({ Icon, count, onPress, text }: Props) => {
   );
 };
 
-/* eslint-disable react-native/no-unused-styles */
-/* this works properly, we do not want that warning */
 const styles = StyleSheet.create({
   container: {
     alignItems: 'center'
@@ -44,4 +42,3 @@ const styles = StyleSheet.create({
     paddingBottom: normalize(3)
   }
 });
-/* eslint-enable react-native/no-unused-styles */

--- a/src/components/widgets/DefaultWidget.tsx
+++ b/src/components/widgets/DefaultWidget.tsx
@@ -16,11 +16,11 @@ type Props = {
 export const DefaultWidget = ({ Icon, count, onPress, text }: Props) => {
   return (
     <TouchableOpacity onPress={onPress}>
-      <WrapperVertical style={styles.container}>
+      <WrapperVertical style={styles().container}>
         <WrapperRow center>
-          <Icon style={styles.icon} />
+          <Icon style={styles(!!count?.toString()).icon} />
           <BoldText primary big>
-            {count ?? ' '}
+            {count}
           </BoldText>
         </WrapperRow>
         <RegularText primary small>
@@ -31,11 +31,16 @@ export const DefaultWidget = ({ Icon, count, onPress, text }: Props) => {
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    alignItems: 'center'
-  },
-  icon: {
-    paddingRight: normalize(8)
-  }
-});
+/* eslint-disable react-native/no-unused-styles */
+/* this works properly, we do not want that warning */
+const styles = (count?: boolean) =>
+  StyleSheet.create({
+    container: {
+      alignItems: 'center'
+    },
+    icon: {
+      paddingRight: count ? normalize(8) : 0,
+      paddingBottom: normalize(3)
+    }
+  });
+/* eslint-enable react-native/no-unused-styles */

--- a/src/components/widgets/EventWidget.tsx
+++ b/src/components/widgets/EventWidget.tsx
@@ -15,7 +15,7 @@ import { DefaultWidget } from './DefaultWidget';
 
 const currentDate = moment().format('YYYY-MM-DD');
 
-export const EventWidget = ({ text }: WidgetProps) => {
+export const EventWidget = ({ text, additionalProps }: WidgetProps) => {
   const navigation = useNavigation();
   const refreshTime = useRefreshTime('event-widget', consts.REFRESH_INTERVALS.ONCE_A_DAY);
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
@@ -71,7 +71,7 @@ export const EventWidget = ({ text }: WidgetProps) => {
 
   return (
     <DefaultWidget
-      count={eventCount}
+      count={additionalProps?.noCount ? null : eventCount}
       Icon={Icon.Calendar}
       onPress={onPress}
       text={text ?? texts.widgets.events}

--- a/src/components/widgets/EventWidget.tsx
+++ b/src/components/widgets/EventWidget.tsx
@@ -49,7 +49,7 @@ export const EventWidget = ({ text, additionalProps }: WidgetProps) => {
       query: QUERY_TYPES.EVENT_RECORDS,
       queryVariables,
       rootRouteName: 'EventRecords',
-      filterByDailyEvents: true
+      filterByDailyEvents: additionalProps?.noFilterByDailyEvents ? false : true
     });
   }, [navigation, text, queryVariables]);
 

--- a/src/types/WidgetProps.ts
+++ b/src/types/WidgetProps.ts
@@ -2,5 +2,6 @@ export type WidgetProps = {
   text?: string;
   additionalProps?: {
     dataProviderId?: string;
+    noCount?: boolean;
   };
 };

--- a/src/types/WidgetProps.ts
+++ b/src/types/WidgetProps.ts
@@ -3,5 +3,6 @@ export type WidgetProps = {
   additionalProps?: {
     dataProviderId?: string;
     noCount?: boolean;
+    noFilterByDailyEvents?: boolean;
   };
 };


### PR DESCRIPTION
- added `noCount` bool expression in
  `additionalProps` to catch changes
  on the server
- added `noFilterByDailyEvents` bool
  expression in `additionalProps` to
  catch changes on the server
- added not showing count on widget if
  `additionalProps.noCount` is set to
  `true` in `globalSettings`
- added control to `filterByDailyEvents`
  param to turn off the daily event filter
  when opening the index page
- converted `styles` to function and 
  added `count` prop to set styles 
  according to the number of widgets
- deleted the blank line rendered to 
  the screen in case there is no count 
  to centre the icon
- changed `count` to a boolean expression 
  by adding `!` at the beginning to 
  eliminate the problem of `false` if 
  `count` is `0`

SVA-664

⚠️ please add the necessary objects to `globalSettings` to try it out! 
you can find information about this in `Confluence` ⚠️

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode


## Screenshots:
|event widget with count|event widget without count|
|--|--|
![Simulator Screen Shot - iPhone 13 - 2022-08-16 at 11 55 59](https://user-images.githubusercontent.com/11755668/184852103-cd63bbc5-f7b0-48bb-b4fd-e84cbe44c9e1.png) | ![Simulator Screen Shot - iPhone 13 - 2022-09-07 at 16 20 18](https://user-images.githubusercontent.com/11755668/188902143-d58b5ecc-e5a2-4b7c-90f3-41e155d2f188.png)


