### PR TITLE
feature(volunteer): editing of group data

### DIFF
--- a/src/components/volunteer/VolunteerEventRecord.tsx
+++ b/src/components/volunteer/VolunteerEventRecord.tsx
@@ -112,7 +112,8 @@ export const VolunteerEventRecord = ({
             <WrapperRow style={styles.headerRight}>
               <TouchableOpacity
                 onPress={() =>
-                  navigation?.navigate(ScreenName.VolunteerForm, {
+                  // eslint-disable-next-line react/prop-types
+                  navigation.navigate(ScreenName.VolunteerForm, {
                     query: QUERY_TYPES.VOLUNTEER.CALENDAR,
                     calendarData: data,
                     groupId: content?.metadata?.contentcontainer_id

--- a/src/components/volunteer/VolunteerFormCalendar.tsx
+++ b/src/components/volunteer/VolunteerFormCalendar.tsx
@@ -201,7 +201,7 @@ export const VolunteerFormCalendar = ({
     );
     reset();
   } else if (isSuccess && isFocused) {
-    isEditMode ? navigation.pop(2) : navigation.goBack();
+    navigation.goBack();
 
     Alert.alert(
       'Erfolgreich',

--- a/src/components/volunteer/VolunteerFormGroup.tsx
+++ b/src/components/volunteer/VolunteerFormGroup.tsx
@@ -7,13 +7,19 @@ import { CheckBox } from 'react-native-elements';
 import { useMutation } from 'react-query';
 
 import { colors, texts } from '../../config';
-import { groupEdit, groupNew } from '../../queries/volunteer';
-import { JOIN_POLICY_TYPES, VISIBILITY_TYPES, VolunteerGroup } from '../../types';
+import { groupDelete, groupEdit, groupNew } from '../../queries/volunteer';
+import { JOIN_POLICY_TYPES, ScreenName, VISIBILITY_TYPES, VolunteerGroup } from '../../types';
 import { Button } from '../Button';
 import { Input } from '../form/Input';
 import { BoldText } from '../Text';
 import { Touchable } from '../Touchable';
 import { Wrapper } from '../Wrapper';
+
+const deleteGroupAlert = (onPress: () => Promise<void>) =>
+  Alert.alert('Hinweis', 'Möchten Sie das Group löschen?', [
+    { text: 'Abbrechen', style: 'cancel' },
+    { text: 'Löschen', onPress, style: 'destructive' }
+  ]);
 
 // eslint-disable-next-line complexity
 export const VolunteerFormGroup = ({
@@ -63,6 +69,18 @@ export const VolunteerFormGroup = ({
           });
         }
       });
+    }
+  };
+
+  const onGroupDelete = async () => {
+    try {
+      await groupDelete(groupData?.id);
+      navigation.navigate(ScreenName.VolunteerHome);
+
+      Alert.alert('Erfolgreich', 'Das Group wurde erfolgreich gelöscht.');
+    } catch (error) {
+      Alert.alert('Fehler beim Löschen des Group', 'Bitte versuchen Sie es noch einmal.');
+      console.error(error);
     }
   };
 
@@ -172,6 +190,14 @@ export const VolunteerFormGroup = ({
           title={texts.volunteer.save}
           disabled={isLoading}
         />
+        {!!groupData && (
+          <Button
+            disabled={isLoading}
+            invert
+            onPress={() => deleteGroupAlert(onGroupDelete)}
+            title={texts.volunteer.delete}
+          />
+        )}
         <Touchable onPress={() => navigation.goBack()}>
           <BoldText center primary underline>
             {texts.volunteer.abort.toUpperCase()}

--- a/src/components/volunteer/VolunteerFormGroup.tsx
+++ b/src/components/volunteer/VolunteerFormGroup.tsx
@@ -15,10 +15,14 @@ import { BoldText } from '../Text';
 import { Touchable } from '../Touchable';
 import { Wrapper } from '../Wrapper';
 
+// eslint-disable-next-line complexity
 export const VolunteerFormGroup = ({
   navigation,
+  route,
   scrollToTop
 }: StackScreenProps<any> & { scrollToTop: () => void }) => {
+  const groupData = route.params?.groupData ?? undefined;
+
   const {
     control,
     formState: { errors, isValid, isSubmitted },
@@ -26,8 +30,13 @@ export const VolunteerFormGroup = ({
   } = useForm<VolunteerGroup>({
     mode: 'onBlur',
     defaultValues: {
-      visibility: VISIBILITY_TYPES.ALL,
-      joinPolicy: JOIN_POLICY_TYPES.OPEN
+      contentContainerId: groupData?.contentcontainer_id || '',
+      description: groupData?.description || '',
+      joinPolicy: JOIN_POLICY_TYPES.OPEN,
+      name: groupData?.name || '',
+      owner: groupData?.owner?.display_name || '',
+      tags: groupData?.tags?.toString() || '',
+      visibility: VISIBILITY_TYPES.ALL
     }
   });
 

--- a/src/components/volunteer/VolunteerFormGroup.tsx
+++ b/src/components/volunteer/VolunteerFormGroup.tsx
@@ -168,9 +168,6 @@ export const VolunteerFormGroup = ({
           title={texts.volunteer.save}
           disabled={isLoading}
         />
-        {isEditMode && (
-          <Button onPress={() => deleteGroupAlert(onGroupDelete)} title={texts.volunteer.delete} />
-        )}
         <Touchable onPress={() => navigation.goBack()}>
           <BoldText center primary underline>
             {texts.volunteer.abort.toUpperCase()}

--- a/src/components/volunteer/VolunteerFormGroup.tsx
+++ b/src/components/volunteer/VolunteerFormGroup.tsx
@@ -46,17 +46,24 @@ export const VolunteerFormGroup = ({
   const { mutate: mutateEdit, isSuccess: isSuccessEdit } = useMutation(groupEdit);
 
   const onSubmit = (groupNewData: VolunteerGroup) => {
-    mutateAsync(groupNewData).then((dataAsync) => {
-      // tags are not possible to send with creation and need to be updated after creation, which we
-      // do automatically here
-      if (dataAsync?.id) {
-        mutateEdit({
-          id: dataAsync.id,
-          name: dataAsync.name,
-          tags: groupNewData.tags
-        });
-      }
-    });
+    if (groupData) {
+      const { description, name, tags, visibility } = groupNewData;
+      const { id, joinPolicy } = groupData;
+
+      mutateEdit({ name, description, visibility, joinPolicy, tags, id });
+    } else {
+      mutateAsync(groupNewData).then((dataAsync) => {
+        // tags are not possible to send with creation and need to be updated after creation, which we
+        // do automatically here
+        if (dataAsync?.id) {
+          mutateEdit({
+            id: dataAsync.id,
+            name: dataAsync.name,
+            tags: groupNewData.tags
+          });
+        }
+      });
+    }
   };
 
   if (!isValid) {

--- a/src/components/volunteer/VolunteerFormGroup.tsx
+++ b/src/components/volunteer/VolunteerFormGroup.tsx
@@ -40,7 +40,6 @@ export const VolunteerFormGroup = ({
       description: groupData?.description || '',
       joinPolicy: JOIN_POLICY_TYPES.OPEN,
       name: groupData?.name || '',
-      owner: groupData?.owner?.display_name || '',
       tags: groupData?.tags?.toString() || '',
       visibility: VISIBILITY_TYPES.ALL
     }
@@ -122,16 +121,6 @@ export const VolunteerFormGroup = ({
           name="description"
           label={texts.volunteer.description}
           placeholder={texts.volunteer.description}
-          multiline
-          validate
-          control={control}
-        />
-      </Wrapper>
-      <Wrapper style={styles.noPaddingTop}>
-        <Input
-          name="owner"
-          label={texts.volunteer.owner}
-          placeholder={texts.volunteer.owner}
           multiline
           validate
           control={control}

--- a/src/components/volunteer/VolunteerGroup.tsx
+++ b/src/components/volunteer/VolunteerGroup.tsx
@@ -1,10 +1,11 @@
 import { useFocusEffect } from '@react-navigation/native';
 import { StackScreenProps } from '@react-navigation/stack';
-import React, { useCallback, useEffect, useState } from 'react';
-import { DeviceEventEmitter, View } from 'react-native';
+import React, { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import { DeviceEventEmitter, StyleSheet, View } from 'react-native';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 import { useMutation } from 'react-query';
 
-import { consts, device, texts } from '../../config';
+import { consts, device, Icon, normalize, texts } from '../../config';
 import {
   isOwner,
   volunteerBannerImage,
@@ -20,9 +21,10 @@ import { HtmlView } from '../HtmlView';
 import { ImageSection } from '../ImageSection';
 import { InfoCard } from '../infoCard';
 import { Logo } from '../Logo';
+import { ShareHeader } from '../ShareHeader';
 import { RegularText } from '../Text';
 import { Title, TitleContainer, TitleShadow } from '../Title';
-import { Wrapper, WrapperWithOrientation } from '../Wrapper';
+import { Wrapper, WrapperRow, WrapperWithOrientation } from '../Wrapper';
 
 import { VolunteerGroupMembersAndApplicants } from './VolunteerGroupMembersAndApplicants';
 import { VolunteerHomeSection } from './VolunteerHomeSection';
@@ -112,6 +114,37 @@ export const VolunteerGroup = ({
     // in other components.
     DeviceEventEmitter.emit(VOLUNTEER_GROUP_REFRESH_EVENT);
   }, []);
+
+  const shareContent = route.params?.shareContent || undefined;
+
+  useLayoutEffect(() => {
+    if (isGroupOwner) {
+      navigation.setOptions({
+        headerRight: () =>
+          isGroupOwner && (
+            <WrapperRow style={styles.headerRight}>
+              <TouchableOpacity
+                onPress={() =>
+                  // eslint-disable-next-line react/prop-types
+                  navigation?.navigate(ScreenName.VolunteerForm, {
+                    query: QUERY_TYPES.VOLUNTEER.GROUP,
+                    groupData: data,
+                    groupId: data.id
+                  })
+                }
+              >
+                <Icon.NamedIcon name="settings" color="white" style={styles.icon} />
+              </TouchableOpacity>
+
+              <ShareHeader
+                shareContent={shareContent}
+                style={{ paddingHorizontal: normalize(10) }}
+              />
+            </WrapperRow>
+          )
+      });
+    }
+  }, [isGroupOwner]);
 
   useFocusEffect(refreshGroup);
 
@@ -242,3 +275,13 @@ export const VolunteerGroup = ({
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  headerRight: {
+    alignItems: 'center',
+    paddingRight: normalize(7)
+  },
+  icon: {
+    paddingHorizontal: normalize(10)
+  }
+});

--- a/src/components/volunteer/VolunteerGroup.tsx
+++ b/src/components/volunteer/VolunteerGroup.tsx
@@ -144,7 +144,7 @@ export const VolunteerGroup = ({
           )
       });
     }
-  }, [isGroupOwner]);
+  }, [isGroupOwner, data]);
 
   useFocusEffect(refreshGroup);
 

--- a/src/components/volunteer/VolunteerGroup.tsx
+++ b/src/components/volunteer/VolunteerGroup.tsx
@@ -5,7 +5,7 @@ import { DeviceEventEmitter, StyleSheet, View } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { useMutation } from 'react-query';
 
-import { consts, device, Icon, normalize, texts } from '../../config';
+import { colors, consts, device, Icon, normalize, texts } from '../../config';
 import {
   isOwner,
   volunteerBannerImage,
@@ -37,11 +37,13 @@ const a11yText = consts.a11yLabel;
 // eslint-disable-next-line complexity
 export const VolunteerGroup = ({
   data,
+  refetch,
   isRefetching,
   navigation,
   route
 }: {
   data: TVolunteerGroup & { contentcontainer_id: number; join_policy: number };
+  refetch: () => void;
   isRefetching: boolean;
 } & StackScreenProps<any>) => {
   const {
@@ -126,14 +128,14 @@ export const VolunteerGroup = ({
               <TouchableOpacity
                 onPress={() =>
                   // eslint-disable-next-line react/prop-types
-                  navigation?.navigate(ScreenName.VolunteerForm, {
+                  navigation.navigate(ScreenName.VolunteerForm, {
                     query: QUERY_TYPES.VOLUNTEER.GROUP,
                     groupData: data,
                     groupId: data.id
                   })
                 }
               >
-                <Icon.NamedIcon name="settings" color="white" style={styles.icon} />
+                <Icon.EditSetting color={colors.lightestText} style={styles.icon} />
               </TouchableOpacity>
 
               <ShareHeader
@@ -151,6 +153,12 @@ export const VolunteerGroup = ({
   useEffect(() => {
     checkIfOwner();
   }, [checkIfOwner]);
+
+  useFocusEffect(
+    useCallback(() => {
+      refetch();
+    }, [])
+  );
 
   return (
     <View>

--- a/src/queries/volunteer/group.ts
+++ b/src/queries/volunteer/group.ts
@@ -1,4 +1,3 @@
-import { texts } from '../../config';
 import {
   volunteerApiV1Url,
   volunteerApiV2Url,
@@ -54,16 +53,10 @@ export const group = async ({ id }: { id: number }) => {
 export const groupNew = async ({
   name,
   description = '',
-  owner = '',
   visibility = VISIBILITY_TYPES.ALL,
   joinPolicy = JOIN_POLICY_TYPES.OPEN
 }: VolunteerGroup) => {
   const authToken = await volunteerAuthToken();
-
-  // add owner information to the description field if present
-  description = owner?.length
-    ? `${description}\n\n\n<strong>${texts.volunteer.owner}</strong>\n\n${owner}`
-    : description;
 
   const formData = {
     name,

--- a/src/queries/volunteer/group.ts
+++ b/src/queries/volunteer/group.ts
@@ -85,7 +85,7 @@ export const groupEdit = async ({
   joinPolicy,
   tags,
   id
-}: VolunteerGroup & { id: number }) => {
+}: VolunteerGroup) => {
   const authToken = await volunteerAuthToken();
 
   const formData = {

--- a/src/queries/volunteer/group.ts
+++ b/src/queries/volunteer/group.ts
@@ -116,6 +116,19 @@ export const groupEdit = async ({
   return (await fetch(`${volunteerApiV1Url}space/${id}`, fetchObj)).json();
 };
 
+export const groupDelete = async (groupId: any) => {
+  const authToken = await volunteerAuthToken();
+
+  const fetchObj = {
+    method: 'DELETE',
+    headers: {
+      Authorization: authToken ? `Bearer ${authToken}` : ''
+    }
+  };
+
+  return await fetch(`${volunteerApiV1Url}space/${groupId}`, fetchObj);
+};
+
 export const groupMembership = async ({ id }: { id: number }) => {
   const authToken = await volunteerAuthToken();
 

--- a/src/types/volunteer/group.ts
+++ b/src/types/volunteer/group.ts
@@ -1,5 +1,3 @@
-import { VolunteerUser } from './user';
-
 export enum JOIN_POLICY_TYPES {
   INVITE,
   INVITE_AND_REQUEST,
@@ -24,7 +22,6 @@ export type VolunteerGroup = {
   id: number;
   name: string;
   description?: string;
-  owner: VolunteerUser;
   visibility?: VISIBILITY_TYPES;
   joinPolicy?: JOIN_POLICY_TYPES;
   tags?: string;


### PR DESCRIPTION
- added settings button to
  the header that only the
  group owner can see
- added new styles for buttons
  in the header
- added default values for
  editable data
- added route prop to receive
  editable data
- added `mutateEdit` to 
  update the edited information 
  on the server
- added control based on data 
  from param to use `mutateEdit`
- added `groupDelete` function 
  to `group` to delete group
- added new button to 
  `VolunteerFormGroup` to delete 
  group
- added alert to get user's 
  confirmation to delete group
- added `onGroupDelete` function 
  to send group delete request
- deleted as `owner` inputs not required
- deleted as the `owner` types are not needed
- deleted the `owner` sections that were added
  as html code to the `description` section when
  uploading to the server because they were not
  needed

HDVT-45

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode


## Screenshots:

|is not the owner of the group|is the owner of the group|group owner's edit page|
|--|--|--|
![Simulator Screen Shot - iPhone 13 - 2022-08-29 at 17 07 44](https://user-images.githubusercontent.com/11755668/187233429-25bf3773-95af-463c-8290-9a19fca5c217.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-29 at 17 07 40](https://user-images.githubusercontent.com/11755668/187233462-b7e75305-9da1-478e-b1fb-6c573d1abed0.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-29 at 17 07 53](https://user-images.githubusercontent.com/11755668/187233475-89d3119e-aca1-4c78-9cd0-e16a02f9501d.png)









