### PR TITLE
fix(map): fix map on settings screen

### DIFF
--- a/src/components/settings/LocationSettings.js
+++ b/src/components/settings/LocationSettings.js
@@ -32,6 +32,8 @@ const useSystemPermission = () => {
 const getLocationMarker = (locationObject) => ({
   ...baseLocationMarker,
   position: {
+    latitude: locationObject?.coords?.lat,
+    longitude: locationObject?.coords?.lng,
     ...locationObject.coords
   }
 });


### PR DESCRIPTION
- added `latitude` and `longitude` information for the application to read since the location information from `globalSettings` is `lat` and `lng`

SVA-634