### PR TITLE
style(volunteer): change text input and media preview style

### DIFF
--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -294,7 +294,7 @@ const renderFooter = (medias, setMedias) => (
 const styles = StyleSheet.create({
   actionButtonContainer: {
     alignItems: 'center',
-    alignSelf: 'center',
+    height: normalize(30),
     justifyContent: 'center'
   },
   border: {

--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -3,7 +3,7 @@ import * as FileSystem from 'expo-file-system';
 import { MediaTypeOptions } from 'expo-image-picker';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
-import { Alert, ScrollView, StyleSheet, View } from 'react-native';
+import { Platform, ScrollView, StyleSheet, View } from 'react-native';
 import { Avatar } from 'react-native-elements';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import {
@@ -252,7 +252,7 @@ export const Chat = ({
 };
 
 const renderFooter = (medias, setMedias) => (
-  <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+  <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.footerStyle}>
     {medias.map(({ uri, type }, index) => {
       return (
         <Wrapper key={index}>
@@ -304,6 +304,10 @@ const styles = StyleSheet.create({
   containerStyle: {
     flexDirection: 'row',
     alignItems: 'center'
+  },
+  footerStyle: {
+    borderTopWidth: normalize(1),
+    borderTopColor: colors.gray20
   },
   inputToolbarContainer: {
     paddingVertical: normalize(24)
@@ -372,7 +376,11 @@ const styles = StyleSheet.create({
     maxHeight: normalize(200),
     minHeight: normalize(48),
     paddingHorizontal: normalize(10),
-    paddingTop: normalize(16)
+    ...Platform.select({
+      ios: {
+        paddingTop: normalize(16)
+      }
+    })
   },
   titleStyle: {
     color: colors.darkText,


### PR DESCRIPTION
- centred text typed in textInput for android
- added border over the media preview section as shown in the design

HDVT-85

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode


## Screenshots:


|before iOS (text input)|after iOS (text input)|before iOS (media preview)|after iOS (media preview)|
|--|--|--|--|
![IMG_0090](https://user-images.githubusercontent.com/11755668/191964484-681cd357-6c3b-429a-88ce-40503729372f.PNG) | ![IMG_0092](https://user-images.githubusercontent.com/11755668/191964506-199c9e71-803f-4f74-9eb6-f92e3e285ea3.PNG) | ![IMG_0091](https://user-images.githubusercontent.com/11755668/191964492-872f299a-efe4-4adc-8d09-a91deb16a178.PNG) | ![IMG_0093](https://user-images.githubusercontent.com/11755668/191964518-e15097cf-37dd-4308-b514-a23f5e93725d.PNG)
|before android (text input)|after android (text input)|before android (media preview)|after android (media preview)|
![Screenshot_20220923-145059](https://user-images.githubusercontent.com/11755668/191964815-3db083e4-072e-43ad-be56-ae216c29ceac.png) | ![Screenshot_20220923-144029](https://user-images.githubusercontent.com/11755668/191964832-715c68f5-dbba-4b69-9520-c4d8bc5b231d.png) | ![Screenshot_20220923-145107](https://user-images.githubusercontent.com/11755668/191964881-07f8dfa9-5d6b-43cc-976c-9e30a78f5ef9.png) | ![Screenshot_20220923-143905](https://user-images.githubusercontent.com/11755668/191964855-e4c7724a-23c0-4d7b-931a-78198a8a3adf.png)
