### PR TITLE
refactor(map): relocate

### DIFF
--- a/src/components/settings/LocationSettings.js
+++ b/src/components/settings/LocationSettings.js
@@ -32,9 +32,9 @@ const useSystemPermission = () => {
 const getLocationMarker = (locationObject) => ({
   ...baseLocationMarker,
   position: {
+    ...locationObject.coords,
     latitude: locationObject?.coords?.lat,
-    longitude: locationObject?.coords?.lng,
-    ...locationObject.coords
+    longitude: locationObject?.coords?.lng
   }
 });
 


### PR DESCRIPTION
- moved `locationObject.coords` upwards to avoid overwriting longitude and latitude information

SVA-634