### PR TITLE
fix(viro): remove plugin integration by default

### DIFF
--- a/app.json
+++ b/app.json
@@ -65,7 +65,6 @@
           "microphonePermission": false
         }
       ],
-      "@viro-community/react-viro",
       "sentry-expo"
     ]
   }


### PR DESCRIPTION
- iOS simulator builds are not running with viro package integrated
- if apps do need viro for AR features, `"@viro-community/react-viro"` needs to be added individually from now on
  - for development purposes that is needed as well temporarily