### PR TITLE
fix(volunteer): solve `useNativeDrive` warn

### DIFF
--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -208,7 +208,12 @@ export const Chat = ({
       )}
       renderMessageImage={(props) =>
         props?.currentMessage?.image?.map(({ uri }, index) => (
-          <MessageImage {...props} key={`image-${index}`} currentMessage={{ image: uri }} />
+          <MessageImage
+            {...props}
+            key={`image-${index}`}
+            currentMessage={{ image: uri }}
+            lightboxProps={{ springConfig: { useNativeDriver: false } }}
+          />
         ))
       }
       renderMessageVideo={(props) =>


### PR DESCRIPTION
- added `lightboxProps` to the `MessageImage` component to remove the `useNativeDrive` warning when an image is opened in the `GiftedChat` component

SVA-767
