### PR TITLE
feat: add image to service page

### DIFF
--- a/src/components/screens/ServiceTiles.js
+++ b/src/components/screens/ServiceTiles.js
@@ -6,6 +6,7 @@ import { normalize } from 'react-native-elements';
 import { colors, consts, device } from '../../config';
 import { useStaticContent } from '../../hooks';
 import { NetworkContext } from '../../NetworkProvider';
+import { Image } from '../Image';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { SafeAreaViewFlex } from '../SafeAreaViewFlex';
 import { Title, TitleContainer, TitleShadow } from '../Title';
@@ -13,7 +14,7 @@ import { WrapperWrap } from '../Wrapper';
 
 import { ServiceTile } from './ServiceTile';
 
-export const ServiceTiles = ({ navigation, staticJsonName, title }) => {
+export const ServiceTiles = ({ image, navigation, staticJsonName, title }) => {
   const { isConnected } = useContext(NetworkContext);
   const [refreshing, setRefreshing] = useState(false);
 
@@ -52,6 +53,8 @@ export const ServiceTiles = ({ navigation, staticJsonName, title }) => {
             />
           }
         >
+          {!!image && <Image source={{ uri: image }} containerStyle={styles.imageContainerStyle} />}
+
           <View style={styles.padding}>
             <WrapperWrap spaceBetween>
               {data?.map((item, index) => (
@@ -70,12 +73,16 @@ export const ServiceTiles = ({ navigation, staticJsonName, title }) => {
 };
 
 const styles = StyleSheet.create({
+  imageContainerStyle: {
+    alignSelf: 'center'
+  },
   padding: {
     padding: normalize(14)
   }
 });
 
 ServiceTiles.propTypes = {
+  image: PropTypes.string,
   navigation: PropTypes.object.isRequired,
   staticJsonName: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired

--- a/src/config/navigation/defaultStackConfig.tsx
+++ b/src/config/navigation/defaultStackConfig.tsx
@@ -159,7 +159,8 @@ export const defaultStackConfig = ({
         matomoString: MATOMO_TRACKING.SCREEN_VIEW.COMPANY,
         staticJsonName: 'homeCompanies',
         titleFallback: texts.homeTitles.company,
-        titleKey: 'headlineCompany'
+        titleKey: 'headlineCompany',
+        imageKey: 'headlineCompanyImage'
       }),
       screenOptions: { title: texts.screenTitles.company }
     },
@@ -294,7 +295,8 @@ export const defaultStackConfig = ({
         matomoString: MATOMO_TRACKING.SCREEN_VIEW.SERVICE,
         staticJsonName: 'homeService',
         titleFallback: texts.homeTitles.service,
-        titleKey: 'headlineService'
+        titleKey: 'headlineService',
+        imageKey: 'headlineServiceImage'
       }),
       screenOptions: { title: texts.screenTitles.service }
     },

--- a/src/screens/TilesScreen.js
+++ b/src/screens/TilesScreen.js
@@ -5,15 +5,28 @@ import { ServiceTiles } from '../components';
 import { useMatomoTrackScreenView } from '../hooks';
 import { SettingsContext } from '../SettingsProvider';
 
-export const getTilesScreen = ({ matomoString, staticJsonName, titleFallback, titleKey }) => {
+export const getTilesScreen = ({
+  matomoString,
+  staticJsonName,
+  titleFallback,
+  titleKey,
+  imageKey
+}) => {
   const TilesScreen = ({ navigation }) => {
     const { globalSettings } = useContext(SettingsContext);
     const { sections = {} } = globalSettings;
-    const { [titleKey]: title = titleFallback } = sections;
+    const { [titleKey]: title = titleFallback, [imageKey]: image } = sections;
 
     useMatomoTrackScreenView(matomoString);
 
-    return <ServiceTiles navigation={navigation} staticJsonName={staticJsonName} title={title} />;
+    return (
+      <ServiceTiles
+        navigation={navigation}
+        staticJsonName={staticJsonName}
+        title={title}
+        image={image}
+      />
+    );
   };
 
   TilesScreen.propTypes = {


### PR DESCRIPTION
- added `imageKey` to `defaultStackNavigator` for the key of the image information added to the server
- added image link as a prop to `ServiceTiles`
- checking the image information and displaying it on the screen if there is an image

SVA-761

⚠️ add an image link to the image field in the required `globalSettings` on the development server to try it ⚠️

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode


## Screenshots:

|iOS portrait mode|android portrait mode|android landscape mode|
|--|--|--|
![Simulator Screen Shot - iPhone 14 Pro Max - 2022-10-05 at 17 36 58](https://user-images.githubusercontent.com/11755668/194104083-af2e3948-1873-4c6f-a160-56a30a5821cd.png) | ![Screenshot_1664984199](https://user-images.githubusercontent.com/11755668/194104054-089b5a1f-d944-4c71-834d-fefb205dcc9f.png) | ![Screenshot_1664984206](https://user-images.githubusercontent.com/11755668/194104096-bb94d3a9-5ddf-427a-ba1a-009865664d1b.png)




