### PR TITLE
fix(maps): make polyline visible for android

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -88,7 +88,12 @@ export const Map = ({
           shouldReplaceMapContent={device.platform === 'ios'}
         />
         {!!geometryTourData?.length && (
-          <Polyline coordinates={geometryTourData} strokeWidth={2} strokeColor={colors.primary} />
+          <Polyline
+            coordinates={geometryTourData}
+            strokeWidth={2}
+            strokeColor={colors.primary}
+            zIndex={1}
+          />
         )}
         {locations?.map((marker, index) => (
           <Marker


### PR DESCRIPTION
- added `zIndex` prop to `Polyline` component in `Maps` to make polyline visible on Android devices

SVA-634

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [ ] iOS landscape mode


## Screenshots:

|iOS|android portrait|android landscape|
|--|--|--|
![IMG_B6B28F4EA531-1](https://user-images.githubusercontent.com/11755668/194519655-ba1f0048-6a11-4c2d-9aaf-c595c0e47fdb.jpeg) | ![Screenshot_20221007-121614](https://user-images.githubusercontent.com/11755668/194519707-3ffb2683-31c0-47c6-8746-a4b8cb33a42a.png) | ![Screenshot_20221007-121938](https://user-images.githubusercontent.com/11755668/194520010-8c40bd24-b7ca-4cf0-aea2-9217c3059048.png)




