### PR TITLE
feat(ar): add `tourId` to ar object in `globalSettings`

### DIFF
--- a/src/components/augmentedReality/AugmentedReality.js
+++ b/src/components/augmentedReality/AugmentedReality.js
@@ -55,7 +55,7 @@ export const AugmentedReality = ({
   useEffect(() => {
     const { settings = {} } = globalSettings;
 
-    settings.ar &&
+    !!settings.ar &&
       isARSupportedOnDevice(
         () => null,
         () => setIsARSupported(true)

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -64,6 +64,7 @@ const INITIAL_FILTER = [
 
 export const SettingsScreen = () => {
   const { globalSettings } = useContext(SettingsContext);
+  const { settings = {} } = globalSettings;
   const [sectionedData, setSectionedData] = useState([]);
   const [filter, setFilter] = useState(INITIAL_FILTER);
   const selectedFilterId = filter.find((entry) => entry.selected)?.id;
@@ -72,8 +73,6 @@ export const SettingsScreen = () => {
 
   useEffect(() => {
     const updateSectionedData = async () => {
-      const { settings = {} } = globalSettings;
-
       const additionalSectionedData = [];
 
       // add push notification option if they are enabled
@@ -198,9 +197,7 @@ export const SettingsScreen = () => {
   }, []);
 
   useEffect(() => {
-    const { settings = {} } = globalSettings;
-
-    settings.ar &&
+    !!settings.ar &&
       isARSupportedOnDevice(
         () => null,
         () =>
@@ -244,7 +241,7 @@ export const SettingsScreen = () => {
       )}
       {selectedFilterId === TOP_FILTER.LIST_TYPES && <ListSettings />}
       {selectedFilterId === TOP_FILTER.AR_DOWNLOAD_LIST && (
-        <AugmentedReality id="579" onSettingsScreen />
+        <AugmentedReality id={settings?.ar?.tourId} onSettingsScreen />
       )}
     </SafeAreaViewFlex>
   );

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -241,7 +241,7 @@ export const SettingsScreen = () => {
       )}
       {selectedFilterId === TOP_FILTER.LIST_TYPES && <ListSettings />}
       {selectedFilterId === TOP_FILTER.AR_DOWNLOAD_LIST && (
-        <AugmentedReality id={settings?.ar?.tourId} onSettingsScreen />
+        <AugmentedReality id={settings.ar.tourId} onSettingsScreen />
       )}
     </SafeAreaViewFlex>
   );


### PR DESCRIPTION
- updated id to send tourId added to `globalSettings` to `AugmentedReality` component in settings page
- changed the ar variable in `globalSettings` from a boolean expression to an object, so this value is changed to a boolean expression in `SettingsScreen` and `AugmentedReality` component
- updated settings object in `globalSettings` to be accessible from everywhere since it is used in multiple places in `SettingsScreen`

SVA-633
