### PR TITLE
fix: add try catch if Viro is not integrated per app.json

### DIFF
--- a/src/components/augmentedReality/AugmentedReality.js
+++ b/src/components/augmentedReality/AugmentedReality.js
@@ -55,11 +55,16 @@ export const AugmentedReality = ({
   useEffect(() => {
     const { settings = {} } = globalSettings;
 
-    !!settings.ar &&
-      isARSupportedOnDevice(
-        () => null,
-        () => setIsARSupported(true)
-      );
+    try {
+      !!settings.ar &&
+        isARSupportedOnDevice(
+          () => null,
+          () => setIsARSupported(true)
+        );
+    } catch (error) {
+      // if Viro is not integrated, we need to catch the error for `isARSupportedOnDevice of null`
+      console.warn(error);
+    }
   }, []);
 
   useEffect(() => {

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -197,19 +197,24 @@ export const SettingsScreen = () => {
   }, []);
 
   useEffect(() => {
-    !!settings.ar &&
-      isARSupportedOnDevice(
-        () => null,
-        () =>
-          setFilter([
-            ...filter,
-            {
-              id: TOP_FILTER.AR_DOWNLOAD_LIST,
-              title: texts.settingsTitles.tabs.arSettings,
-              selected: false
-            }
-          ])
-      );
+    try {
+      !!settings.ar &&
+        isARSupportedOnDevice(
+          () => null,
+          () =>
+            setFilter([
+              ...filter,
+              {
+                id: TOP_FILTER.AR_DOWNLOAD_LIST,
+                title: texts.settingsTitles.tabs.arSettings,
+                selected: false
+              }
+            ])
+        );
+    } catch (error) {
+      // if Viro is not integrated, we need to catch the error for `isARSupportedOnDevice of null`
+      console.warn(error);
+    }
   }, []);
 
   if (!sectionedData.length) {


### PR DESCRIPTION
I have tested locally with Android emulator, where Viro is not supported - it crashed.
So I needed to add a try catch to avoid crashes with Viro where we do not use Viro.