### PR TITLE
feat: add parameter to useEffect

### DIFF
--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -194,7 +194,7 @@ export const SettingsScreen = () => {
     };
 
     updateSectionedData();
-  }, []);
+  }, [selectedFilterId]);
 
   useEffect(() => {
     try {


### PR DESCRIPTION
- added `selectedFilterId` as second parameter to `useEffect` for `SettingsToggle` to update itself when switching between tabs on `SettingsScreen`

SVA-789


## Screenshots:



|before|after|
|--|--|
|<video src="https://user-images.githubusercontent.com/11755668/196155730-22338df6-862c-47fd-b01c-34bd34cd82e6.mp4" controls="controls" style="max-width: 300px;"></video>|<video src="https://user-images.githubusercontent.com/11755668/196155451-86eb751f-5da7-4012-9950-2eb5b788bbdb.mp4" controls="controls" style="max-width: 300px;"></video>|

