### PR TITLE
feat(ar): multiple model management

### DIFF
--- a/src/helpers/augmentedReality/checkDownloadedData.js
+++ b/src/helpers/augmentedReality/checkDownloadedData.js
@@ -15,7 +15,7 @@ export const checkDownloadedData = async ({ data, setData }) => {
         try {
           const downloadedItem = await readFromStore(storageName);
 
-          if (downloadedItem?.payload?.scenes?.[sceneIndex].localUris) {
+          if (downloadedItem?.payload?.scenes?.[sceneIndex]?.localUris) {
             checkedData[index] = downloadedItem;
           } else {
             checkedData[index].payload.downloadType = DOWNLOAD_TYPE.DOWNLOADABLE;

--- a/src/helpers/augmentedReality/checkDownloadedData.js
+++ b/src/helpers/augmentedReality/checkDownloadedData.js
@@ -8,23 +8,25 @@ export const checkDownloadedData = async ({ data, setData }) => {
   const checkedData = [...data];
 
   for (const [index, dataItem] of checkedData.entries()) {
-    for (const objectItem of dataItem?.payload?.downloadableUris) {
-      const { storageName } = storageNameCreator({ dataItem, objectItem });
+    for (const [sceneIndex, sceneItem] of dataItem?.payload?.scenes.entries()) {
+      for (const objectItem of sceneItem.downloadableUris) {
+        const { storageName } = storageNameCreator({ dataItem, objectItem, sceneIndex });
 
-      try {
-        const downloadedItem = await readFromStore(storageName);
+        try {
+          const downloadedItem = await readFromStore(storageName);
 
-        if (downloadedItem?.payload?.localUris) {
-          checkedData[index] = downloadedItem;
-        } else {
-          checkedData[index].payload.downloadType = DOWNLOAD_TYPE.DOWNLOADABLE;
-          checkedData[index].payload.localUris = [];
-          checkedData[index].payload.progress = 0;
-          checkedData[index].payload.progressSize = 0;
-          checkedData[index].payload.size = 0;
+          if (downloadedItem?.payload?.scenes[sceneIndex]?.localUris) {
+            checkedData[index] = downloadedItem;
+          } else {
+            checkedData[index].payload.downloadType = DOWNLOAD_TYPE.DOWNLOADABLE;
+            checkedData[index].payload.scenes[sceneIndex].localUris = [];
+            checkedData[index].payload.progress = 0;
+            checkedData[index].payload.progressSize = 0;
+            checkedData[index].payload.size = 0;
+          }
+        } catch (error) {
+          console.error(error);
         }
-      } catch (error) {
-        console.error(error);
       }
     }
   }

--- a/src/helpers/augmentedReality/checkDownloadedData.js
+++ b/src/helpers/augmentedReality/checkDownloadedData.js
@@ -8,14 +8,14 @@ export const checkDownloadedData = async ({ data, setData }) => {
   const checkedData = [...data];
 
   for (const [index, dataItem] of checkedData.entries()) {
-    for (const [sceneIndex, sceneItem] of dataItem?.payload?.scenes.entries()) {
+    for (const [sceneIndex, sceneItem] of dataItem?.payload?.scenes?.entries()) {
       for (const objectItem of sceneItem.downloadableUris) {
         const { storageName } = storageNameCreator({ dataItem, objectItem, sceneIndex });
 
         try {
           const downloadedItem = await readFromStore(storageName);
 
-          if (downloadedItem?.payload?.scenes[sceneIndex]?.localUris) {
+          if (downloadedItem?.payload?.scenes?.[sceneIndex].localUris) {
             checkedData[index] = downloadedItem;
           } else {
             checkedData[index].payload.downloadType = DOWNLOAD_TYPE.DOWNLOADABLE;

--- a/src/helpers/augmentedReality/deleteObject.js
+++ b/src/helpers/augmentedReality/deleteObject.js
@@ -19,23 +19,25 @@ export const deleteObject = async ({ index, data, setData }) => {
   const deletedData = [...data];
   const dataItem = data[index];
 
-  for (const objectItem of dataItem?.payload?.localUris) {
-    const { storageName } = storageNameCreator({ dataItem, objectItem });
+  for (const [sceneIndex, sceneItem] of dataItem?.payload?.scenes?.entries()) {
+    for (const objectItem of sceneItem?.localUris) {
+      const { storageName } = storageNameCreator({ dataItem, objectItem, sceneIndex });
 
-    try {
-      await FileSystem.deleteAsync(objectItem?.uri);
-      await AsyncStorage.removeItem(storageName);
+      try {
+        await FileSystem.deleteAsync(objectItem?.uri);
+        await AsyncStorage.removeItem(storageName);
 
-      deletedData[index].payload.downloadType = DOWNLOAD_TYPE.DOWNLOADABLE;
-      deletedData[index].payload.localUris = [];
-      deletedData[index].payload.progress = 0;
-      deletedData[index].payload.progressSize = 0;
-      deletedData[index].payload.size = 0;
-    } catch (error) {
-      console.error(error);
+        deletedData[index].payload.downloadType = DOWNLOAD_TYPE.DOWNLOADABLE;
+        deletedData[index].payload.scenes[sceneIndex].localUris = [];
+        deletedData[index].payload.progress = 0;
+        deletedData[index].payload.progressSize = 0;
+        deletedData[index].payload.size = 0;
+      } catch (error) {
+        console.error(error);
 
-      // return is used to prevent the for loop from continuing
-      return deleteErrorAlert();
+        // return is used to prevent the for loop from continuing
+        return deleteErrorAlert(storageName);
+      }
     }
   }
 

--- a/src/helpers/augmentedReality/downloadAndDeleteAllData.js
+++ b/src/helpers/augmentedReality/downloadAndDeleteAllData.js
@@ -7,17 +7,19 @@ import { storageNameCreator } from './storageNameCreator';
 // function to download all AR objects using `downloadObject`
 export const downloadAllData = async ({ data, setData }) => {
   for (const [index, dataItem] of data.entries()) {
-    for (const objectItem of dataItem?.payload?.downloadableUris) {
-      const { storageName } = storageNameCreator({ dataItem, objectItem });
+    for (const [sceneIndex, sceneItem] of dataItem?.payload?.scenes?.entries()) {
+      for (const objectItem of sceneItem?.downloadableUris) {
+        const { storageName } = storageNameCreator({ dataItem, objectItem, sceneIndex });
 
-      try {
-        const downloadedItem = await readFromStore(storageName);
+        try {
+          const downloadedItem = await readFromStore(storageName);
 
-        if (!downloadedItem) {
-          await downloadObject({ index, data, setData });
+          if (!downloadedItem) {
+            await downloadObject({ index, data, setData });
+          }
+        } catch (error) {
+          console.error(error);
         }
-      } catch (error) {
-        console.error(error);
       }
     }
   }

--- a/src/helpers/augmentedReality/storageNameCreator.js
+++ b/src/helpers/augmentedReality/storageNameCreator.js
@@ -6,7 +6,7 @@ const { IMAGE_TYPE_REGEX } = consts;
 
 export const storageNameCreator = ({ dataItem, objectItem, sceneIndex }) => {
   const objectItemTitleWithoutSpaces = dataItem.title.replace(/\s+/g, '');
-  const dataDirectoryName = `${objectItemTitleWithoutSpaces}_${dataItem.id}` + sceneIndex;
+  const dataDirectoryName = `${objectItemTitleWithoutSpaces}_${dataItem.id}_${sceneIndex}`;
   const modelName = objectNameParser(objectItem);
 
   return {

--- a/src/helpers/augmentedReality/storageNameCreator.js
+++ b/src/helpers/augmentedReality/storageNameCreator.js
@@ -4,9 +4,9 @@ import { consts } from '../../config';
 
 const { IMAGE_TYPE_REGEX } = consts;
 
-export const storageNameCreator = ({ dataItem, objectItem }) => {
+export const storageNameCreator = ({ dataItem, objectItem, sceneIndex }) => {
   const objectItemTitleWithoutSpaces = dataItem.title.replace(/\s+/g, '');
-  const dataDirectoryName = `${objectItemTitleWithoutSpaces}_${dataItem.id}`;
+  const dataDirectoryName = `${objectItemTitleWithoutSpaces}_${dataItem.id}` + sceneIndex;
   const modelName = objectNameParser(objectItem);
 
   return {

--- a/src/screens/augmentedReality/ARShowScreen.js
+++ b/src/screens/augmentedReality/ARShowScreen.js
@@ -114,6 +114,8 @@ export const ARShowScreen = ({ navigation, route }) => {
 
 const objectParser = async ({ item, setObject, setIsLoading, onPress }) => {
   const parsedObject = { texture: [] };
+
+  // TODO: in the future the index 0 used here will be changed according to time logic!
   const localUris = item?.payload?.scenes?.[0]?.localUris;
 
   if (localUris?.animationName) {

--- a/src/screens/augmentedReality/ARShowScreen.js
+++ b/src/screens/augmentedReality/ARShowScreen.js
@@ -114,12 +114,13 @@ export const ARShowScreen = ({ navigation, route }) => {
 
 const objectParser = async ({ item, setObject, setIsLoading, onPress }) => {
   const parsedObject = { texture: [] };
+  const localUris = item?.payload?.scenes?.[0]?.localUris;
 
-  if (item?.payload?.animationName) {
-    parsedObject.animationName = item?.payload?.animationName;
+  if (localUris?.animationName) {
+    parsedObject.animationName = localUris?.animationName;
   }
 
-  item?.payload?.localUris?.forEach((item) => {
+  localUris?.forEach((item) => {
     if (item.type === 'texture') {
       parsedObject[item.type]?.push({ uri: item?.uri });
     } else {


### PR DESCRIPTION
- added `for..of` loop for downloading multiple 
  3D models and downloading scenes within a 
  `scenes` array
- added `sceneIndex` to add the uri of whichever 
  index in `scenes` was downloaded to `localUris`
- added `sceneIndex` to `storageNameCreator` 
  to ensure that the file names are different if the 
  names of the objects in the scene are the same
- added control of the `scenes` array with a `for..of` 
  loop to ensure that different downloaded scenes 
  are deleted from the device
- added `sceneIndex` to access the uri of the 
  downloaded scene added to `localUris` and empty 
  the array
- added check with `for...of` loop to the `scenes`
  array to check if the downloaded scenes are on
  the device
- added `for...of` loop to `scenes` array 
  to download all scenes with a single button
- added `sceneIndex` to `storageNameCreator` 
  to check if the file has been downloaded
- updated `objectParser` in `ARShowScreen` to
  use augmented reality with information from index
  0 of the scene downloaded to the device

SVA-632

⚠️ for now, the reason why the augmented reality scene is created according to index 0 is to try it out. then the index information will be changed ⚠️

## How to test:

- download `dummyData`
[dummyData.zip](https://github.com/ikuseiGmbH/smart-village-app-app/files/9817556/dummyData.js.zip)

- add `dummyData` to the `src/helpers/augmentedReality` directory

- import `dummyData` into `Tour.js`
```import { dummyData } from '../../helpers/augmentedReality/dummyData';```

- send `dummyData` to `tourStops` in the `AugmentedReality` component in `Tour.js`
 ```<AugmentedReality {...{ geometryTourData, id, navigation, tourStops: dummyData }} />```