### PR TITLE
feat(ar): add format size for augmented reality

### DIFF
--- a/src/components/augmentedReality/ARObjectList.js
+++ b/src/components/augmentedReality/ARObjectList.js
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { Alert, FlatList } from 'react-native';
 
 import { consts, device, texts } from '../../config';
-import { deleteAllData, downloadAllData, formatSize } from '../../helpers';
+import { deleteAllData, downloadAllData, formatSizeForAugmentedReality } from '../../helpers';
 import { Button } from '../Button';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { RegularText } from '../Text';
@@ -71,7 +71,7 @@ export const ARObjectList = ({
 
   const checkFreeStorage = async () => {
     const storage = await FileSystem.getFreeDiskStorageAsync();
-    setFreeSize(formatSize(storage));
+    setFreeSize(formatSizeForAugmentedReality(storage));
   };
 
   const downloadAll = async () => {

--- a/src/helpers/augmentedReality/progressSizeGenerator.js
+++ b/src/helpers/augmentedReality/progressSizeGenerator.js
@@ -1,4 +1,4 @@
-import { formatSize } from '../fileSizeHelper';
+import { formatSizeForAugmentedReality } from '../fileSizeHelper';
 
 /**
  * display bytes downloaded per second in different formats
@@ -10,8 +10,10 @@ import { formatSize } from '../fileSizeHelper';
  */
 export const progressSizeGenerator = (progressSize, totalSize) => {
   if (!progressSize) {
-    return formatSize(totalSize);
+    return formatSizeForAugmentedReality(totalSize);
   }
 
-  return `${formatSize(progressSize)} / ${formatSize(totalSize)}`;
+  return `${formatSizeForAugmentedReality(progressSize)} / ${formatSizeForAugmentedReality(
+    totalSize
+  )}`;
 };

--- a/src/helpers/fileSizeHelper.ts
+++ b/src/helpers/fileSizeHelper.ts
@@ -9,3 +9,14 @@ export const formatSize = (size: number) => {
     return `${(size / 1000000000).toFixed(1)} GB`;
   }
 };
+
+// thanks for : https://gist.github.com/zentala/1e6f72438796d74531803cc3833c039c
+export const formatSizeForAugmentedReality = (bytes: number, decimals = 1) => {
+  if (bytes == 0) return '0 Bytes';
+
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const index = Math.floor(Math.log(bytes) / Math.log(1024));
+  const size = parseFloat((bytes / Math.pow(1024, index)).toFixed(decimals));
+
+  return `${size} ${sizes[index]}`;
+};

--- a/src/helpers/fileSizeHelper.ts
+++ b/src/helpers/fileSizeHelper.ts
@@ -14,7 +14,7 @@ export const formatSize = (size: number) => {
 export const formatSizeForAugmentedReality = (bytes: number, decimals = 1) => {
   if (bytes == 0) return '0 Bytes';
 
-  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const sizes = ['Bytes', 'KB', 'MB', 'GB'];
   const index = Math.floor(Math.log(bytes) / Math.log(1024));
   const size = parseFloat((bytes / Math.pow(1024, index)).toFixed(decimals));
 


### PR DESCRIPTION
- added `formatSizeForAugmentedReality` to `fileSizeHelper` to convert byte more accurately
- updated `formatSize` helper used in `ARObjectList` and `progressSizeGenerator` files with `formatSizeForAugmentedReality`

SVA-565
