### PR TITLE
feat(ar): add light props for viro ambient light

### DIFF
--- a/src/components/augmentedReality/AugmentedRealityView.js
+++ b/src/components/augmentedReality/AugmentedRealityView.js
@@ -55,7 +55,12 @@ export const AugmentedRealityView = ({ sceneNavigator }) => {
 
   return (
     <ViroARScene>
-      <ViroAmbientLight color={colors.surface} />
+      <ViroAmbientLight
+        color={object?.light?.color || colors.surface}
+        temperature={object?.light?.temperature || 6500}
+        intensity={object?.light?.intensity || 1000}
+        rotation={object?.light?.rotation || [0, 0, 0]}
+      />
 
       {object?.target ? (
         <ViroARImageMarker

--- a/src/helpers/augmentedReality/deleteObject.js
+++ b/src/helpers/augmentedReality/deleteObject.js
@@ -24,7 +24,9 @@ export const deleteObject = async ({ index, data, setData }) => {
       const { storageName } = storageNameCreator({ dataItem, objectItem, sceneIndex });
 
       try {
-        await FileSystem.deleteAsync(objectItem?.uri);
+        if (objectItem?.uri) {
+          await FileSystem.deleteAsync(objectItem.uri);
+        }
         await AsyncStorage.removeItem(storageName);
 
         deletedData[index].payload.downloadType = DOWNLOAD_TYPE.DOWNLOADABLE;

--- a/src/helpers/augmentedReality/downloadObject.js
+++ b/src/helpers/augmentedReality/downloadObject.js
@@ -14,7 +14,9 @@ export const downloadObject = async ({ index, data, setData }) => {
     for (const objectItem of sceneItem?.downloadableUris) {
       const {
         chromaKeyFilteredVideo,
+        color,
         id,
+        intensity,
         isSpatialSound,
         maxDistance,
         minDistance,
@@ -23,6 +25,7 @@ export const downloadObject = async ({ index, data, setData }) => {
         rolloffModel,
         rotation,
         scale,
+        temperature,
         title,
         type,
         uri
@@ -53,26 +56,35 @@ export const downloadObject = async ({ index, data, setData }) => {
           await FileSystem.makeDirectoryAsync(folderName, { intermediates: true });
         }
 
-        const fileSystemDownload = await downloadResumable.downloadAsync();
-        const { size } = await FileSystem.getInfoAsync(fileSystemDownload.uri);
+        let size = 0;
+        let fileSystemDownload = undefined;
+
+        if (uri) {
+          fileSystemDownload = await downloadResumable.downloadAsync();
+          const fileSystemInfo = await FileSystem.getInfoAsync(fileSystemDownload.uri);
+          size = fileSystemInfo.size;
+        }
 
         downloadedData[index].payload.downloadType = DOWNLOAD_TYPE.DOWNLOADED;
         downloadedData[index].payload.size += size;
         downloadedData[index].payload.scenes[sceneIndex].localUris?.push({
           chromaKeyFilteredVideo, // HEX Color Code
+          color, // HEX Color Code,
           id,
+          intensity, // Number
           isSpatialSound, // Boolean
-          maxDistance: parseFloat(maxDistance),
-          minDistance: parseFloat(minDistance),
-          physicalWidth: parseFloat(physicalWidth),
+          maxDistance: maxDistance && parseFloat(maxDistance),
+          minDistance: minDistance && parseFloat(minDistance),
+          physicalWidth: physicalWidth && parseFloat(physicalWidth),
           position, // Array [x,y,z]
           rolloffModel, // String (none, linear, or logarithmic)
           rotation, // Array [x,y,z]
           scale, // Array [x,y,z]
           size,
+          temperature, // Number
           title,
           type,
-          uri: fileSystemDownload.uri
+          uri: fileSystemDownload?.uri
         });
 
         addToStore(storageName, downloadedData[index]);

--- a/src/screens/augmentedReality/ARShowScreen.js
+++ b/src/screens/augmentedReality/ARShowScreen.js
@@ -128,6 +128,9 @@ const objectParser = async ({ item, setObject, setIsLoading, onPress }) => {
     } else {
       parsedObject[item.type] = {
         chromaKeyFilteredVideo: item?.chromaKeyFilteredVideo,
+        color: item?.color,
+        intensity: item?.intensity,
+        isSpatialSound: item?.isSpatialSound,
         maxDistance: item?.maxDistance,
         minDistance: item?.minDistance,
         physicalWidth: item?.physicalWidth,
@@ -135,7 +138,7 @@ const objectParser = async ({ item, setObject, setIsLoading, onPress }) => {
         rolloffModel: item?.rolloffModel,
         rotation: item?.rotation,
         scale: item?.scale,
-        isSpatialSound: item?.isSpatialSound,
+        temperature: item?.temperature,
         uri: item?.uri
       };
     }


### PR DESCRIPTION
- added light props from server to
  `ViroAmbientLight` component
- added uri check in `deleteObject`
  because the light prop has no
  downloadable link, otherwise
  `deleteAsync` will give an error
  because there is no uri
- added uri check to `downloadObject` 
  because `fileSystemDownload` will get 
  an error because the light prop does not 
  have a uri
- added new control to `maxDistance`, 
  `minDistance` and `physicalWidth` so 
  they don't take up unnecessary space in `JSON`
- added to the parser function in `ARShowSceen`
  to parse new light props

SVA-632