### PR TITLE
feat(volunteer): new personal screen

### DIFF
--- a/src/config/navigation/defaultStackConfig.tsx
+++ b/src/config/navigation/defaultStackConfig.tsx
@@ -1,3 +1,4 @@
+import { CardStyleInterpolators } from '@react-navigation/stack';
 import React from 'react';
 
 import { HeaderLeft } from '../../components';
@@ -49,6 +50,7 @@ import {
   VolunteerHomeScreen,
   VolunteerIndexScreen,
   VolunteerLoginScreen,
+  VolunteerLogoutScreen,
   VolunteerMeScreen,
   VolunteerPersonalScreen,
   VolunteerRegisteredScreen,
@@ -345,9 +347,16 @@ export const defaultStackConfig = ({
       screenOptions: { title: texts.screenTitles.volunteer.home }
     },
     {
+      routeName: ScreenName.VolunteerLogout,
+      screenComponent: VolunteerLogoutScreen,
+      screenOptions: getScreenOptions({
+        noHeaderLeft: true,
+        cardStyleInterpolator: CardStyleInterpolators.forScaleFromCenterAndroid
+      })
+    },
+    {
       routeName: ScreenName.VolunteerMe,
-      screenComponent: VolunteerMeScreen,
-      screenOptions: { title: texts.screenTitles.volunteer.me }
+      screenComponent: VolunteerMeScreen
     },
     {
       routeName: ScreenName.VolunteerPersonal,

--- a/src/hooks/HomeRefresh.ts
+++ b/src/hooks/HomeRefresh.ts
@@ -18,11 +18,12 @@ export const useHomeRefresh = (onRefresh?: () => void) => {
   }, [onRefresh]);
 };
 
-const getRefreshKey = (query?: string) => {
+const getRefreshKey = (query: string) => {
   switch (query) {
     case QUERY_TYPES.VOLUNTEER.GROUPS_MY:
     case QUERY_TYPES.VOLUNTEER.CALENDAR_ALL_MY:
     case QUERY_TYPES.VOLUNTEER.CONVERSATIONS:
+    case QUERY_TYPES.VOLUNTEER.PERSONAL:
       return VOLUNTEER_PERSONAL_REFRESH_EVENT;
     case QUERY_TYPES.VOLUNTEER.GROUP:
       return VOLUNTEER_GROUP_REFRESH_EVENT;

--- a/src/navigation/screenOptions.tsx
+++ b/src/navigation/screenOptions.tsx
@@ -24,6 +24,8 @@ type OptionConfig = {
   withDrawer?: boolean;
   withFavorites?: boolean;
   withShare?: boolean;
+  noHeaderLeft?: boolean;
+  cardStyleInterpolator?: StackNavigationOptions['cardStyleInterpolator'];
 };
 
 export const getScreenOptions =
@@ -31,7 +33,9 @@ export const getScreenOptions =
     withBookmark,
     withDrawer,
     withFavorites,
-    withShare
+    withShare,
+    noHeaderLeft = false,
+    cardStyleInterpolator
   }: OptionConfig): ((props: OptionProps) => StackNavigationOptions) =>
   ({ navigation, route }) => {
     const shareContent = route.params?.shareContent;
@@ -49,11 +53,13 @@ export const getScreenOptions =
           {withDrawer && <DrawerHeader navigation={navigation} style={styles.icon} />}
         </WrapperRow>
       ),
-      headerLeft: withFavorites
-        ? () => <FavoritesHeader navigation={navigation} style={styles.icon} />
-        : HeaderLeft,
+      headerLeft:
+        !noHeaderLeft &&
+        (withFavorites
+          ? () => <FavoritesHeader navigation={navigation} style={styles.icon} />
+          : HeaderLeft),
       title: route.params?.title ?? '',
-      cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS
+      cardStyleInterpolator: cardStyleInterpolator ?? CardStyleInterpolators.forHorizontalIOS
     };
   };
 

--- a/src/queries/types.ts
+++ b/src/queries/types.ts
@@ -64,6 +64,7 @@ export const QUERY_TYPES = {
     HOME: 'home',
     ME: 'me',
     MEMBERS: 'members',
+    PERSONAL: 'personal',
     POSTS: 'posts',
     PROFILE: 'profile',
     TASKS: 'tasks',

--- a/src/screens/volunteer/VolunteerLogoutScreen.tsx
+++ b/src/screens/volunteer/VolunteerLogoutScreen.tsx
@@ -1,0 +1,40 @@
+import { StackScreenProps } from '@react-navigation/stack';
+import React, { useEffect } from 'react';
+import { Alert, View } from 'react-native';
+
+import { colors } from '../../config';
+import { storeVolunteerAuthToken, storeVolunteerUserData } from '../../helpers';
+import { ScreenName } from '../../types';
+
+export const VolunteerLogoutScreen = ({ navigation }: StackScreenProps<any>) => {
+  useEffect(
+    () =>
+      Alert.alert(
+        'Abmelden',
+        'Bist du sicher, dass du dich abmelden möchtest?',
+        [
+          {
+            text: 'Abbrechen',
+            onPress: async () => {
+              navigation.goBack();
+            }
+          },
+          {
+            text: 'Ja, abmelden',
+            style: 'destructive',
+            onPress: async () => {
+              await storeVolunteerAuthToken();
+              await storeVolunteerUserData();
+              navigation?.navigate(ScreenName.VolunteerHome, {
+                refreshUser: new Date().valueOf()
+              });
+            }
+          }
+        ],
+        { cancelable: false }
+      ),
+    []
+  );
+
+  return null;
+};

--- a/src/screens/volunteer/VolunteerPersonalScreen.tsx
+++ b/src/screens/volunteer/VolunteerPersonalScreen.tsx
@@ -1,86 +1,28 @@
 import { useFocusEffect } from '@react-navigation/native';
+import { StackScreenProps } from '@react-navigation/stack';
 import { DeviceEventEmitter } from 'expo-modules-core';
-import React, { useCallback, useEffect } from 'react';
-import { RefreshControl, ScrollView, StyleSheet } from 'react-native';
+import React, { useCallback } from 'react';
+import { RefreshControl, ScrollView } from 'react-native';
 
-import {
-  SafeAreaViewFlex,
-  VolunteerConversationsSection,
-  VolunteerHeaderProfile,
-  VolunteerHomeSection,
-  WrapperRow
-} from '../../components';
-import { colors, consts, normalize, texts } from '../../config';
-import { VOLUNTEER_PERSONAL_REFRESH_EVENT } from '../../hooks';
+import { LoadingSpinner, SafeAreaViewFlex, ServiceTiles } from '../../components';
+import { colors } from '../../config';
+import { useStaticContent, VOLUNTEER_PERSONAL_REFRESH_EVENT } from '../../hooks';
 import { QUERY_TYPES } from '../../queries';
-import { ScreenName } from '../../types';
 
-const { ROOT_ROUTE_NAMES } = consts;
+export const VolunteerPersonalScreen = ({ navigation }: StackScreenProps<any>) => {
+  const {
+    data: dataPersonalText,
+    loading: loadingPersonalText,
+    refetch: refetchPersonalText
+  } = useStaticContent({
+    refreshTimeKey: 'publicJsonFile-volunteerPersonalText',
+    name: 'volunteerPersonalText',
+    type: 'html'
+  });
 
-const NAVIGATION = {
-  CALENDAR_MY_INDEX: {
-    name: ScreenName.VolunteerIndex,
-    params: {
-      title: texts.volunteer.calendarMy,
-      query: QUERY_TYPES.VOLUNTEER.CALENDAR_ALL_MY,
-      rootRouteName: ROOT_ROUTE_NAMES.VOLUNTEER
-    }
-  },
-  CALENDAR_NEW: {
-    name: ScreenName.VolunteerForm,
-    params: {
-      title: 'Termin eintragen',
-      query: QUERY_TYPES.VOLUNTEER.CALENDAR,
-      rootRouteName: ROOT_ROUTE_NAMES.VOLUNTEER
-    }
-  },
-  CONVERSATIONS_INDEX: {
-    name: ScreenName.VolunteerIndex,
-    params: {
-      title: texts.volunteer.conversations,
-      query: QUERY_TYPES.VOLUNTEER.CONVERSATIONS,
-      queryOptions: {
-        refetchInterval: 1000
-      },
-      rootRouteName: ROOT_ROUTE_NAMES.VOLUNTEER
-    }
-  },
-  CONVERSATION_NEW: {
-    name: ScreenName.VolunteerForm,
-    params: {
-      title: texts.volunteer.conversationStart,
-      query: QUERY_TYPES.VOLUNTEER.CONVERSATION,
-      rootRouteName: ROOT_ROUTE_NAMES.VOLUNTEER
-    }
-  },
-  GROUPS_MY_INDEX: {
-    name: ScreenName.VolunteerIndex,
-    params: {
-      title: texts.volunteer.groupsMy,
-      query: QUERY_TYPES.VOLUNTEER.GROUPS_MY,
-      rootRouteName: ROOT_ROUTE_NAMES.VOLUNTEER
-    }
-  },
-  GROUP_NEW: {
-    name: ScreenName.VolunteerForm,
-    params: {
-      title: 'Gruppe/Verein erstellen',
-      query: QUERY_TYPES.VOLUNTEER.GROUP,
-      rootRouteName: ROOT_ROUTE_NAMES.VOLUNTEER
-    }
-  },
-  TASKS_INDEX: {
-    name: ScreenName.VolunteerIndex,
-    params: {
-      title: 'Meine Aufgaben',
-      query: QUERY_TYPES.VOLUNTEER.TASKS,
-      rootRouteName: ROOT_ROUTE_NAMES.VOLUNTEER
-    }
-  }
-};
-
-export const VolunteerPersonalScreen = ({ navigation }: any) => {
   const refreshPersonal = useCallback(() => {
+    refetchPersonalText();
+
     // this will trigger the onRefresh functions provided to the `useVolunteerRefresh` hook
     // in other components.
     DeviceEventEmitter.emit(VOLUNTEER_PERSONAL_REFRESH_EVENT);
@@ -88,17 +30,9 @@ export const VolunteerPersonalScreen = ({ navigation }: any) => {
 
   useFocusEffect(refreshPersonal);
 
-  useEffect(
-    () =>
-      navigation.setOptions({
-        headerRight: () => (
-          <WrapperRow style={styles.headerRight}>
-            <VolunteerHeaderProfile navigation={navigation} style={styles.icon} />
-          </WrapperRow>
-        )
-      }),
-    [navigation]
-  );
+  if (loadingPersonalText) {
+    return <LoadingSpinner loading />;
+  }
 
   return (
     <SafeAreaViewFlex>
@@ -112,64 +46,13 @@ export const VolunteerPersonalScreen = ({ navigation }: any) => {
           />
         }
       >
-        <VolunteerHomeSection
-          linkTitle="Alle meine Gruppen und Vereine anzeigen"
-          buttonTitle="Gruppe/Verein erstellen"
-          navigateLink={() => navigation.navigate(NAVIGATION.GROUPS_MY_INDEX)}
-          navigateButton={() => navigation.navigate(NAVIGATION.GROUP_NEW)}
-          navigate={() => navigation.navigate(NAVIGATION.GROUPS_MY_INDEX)}
+        <ServiceTiles
+          html={dataPersonalText}
+          query={QUERY_TYPES.VOLUNTEER.PERSONAL}
           navigation={navigation}
-          query={QUERY_TYPES.VOLUNTEER.GROUPS_MY}
-          sectionTitle="Meine Gruppen und Vereine"
-          showLink
-          showButton
-        />
-        <VolunteerHomeSection
-          linkTitle="Alle meine Termine anzeigen"
-          buttonTitle="Termin eintragen"
-          navigateLink={() => navigation.navigate(NAVIGATION.CALENDAR_MY_INDEX)}
-          navigateButton={() => navigation.navigate(NAVIGATION.CALENDAR_NEW)}
-          navigate={() => navigation.navigate(NAVIGATION.CALENDAR_MY_INDEX)}
-          navigation={navigation}
-          query={QUERY_TYPES.VOLUNTEER.CALENDAR_ALL_MY}
-          sectionTitle="Mein Kalender"
-          showLink
-          showButton
-        />
-        {/* <DataListSection
-          linkTitle="Alle Aufgaben anzeigen"
-          loading={false}
-          navigateLink={() => navigation.navigate(NAVIGATION.TASKS_INDEX)}
-          navigate={() => navigation.navigate(NAVIGATION.TASKS_INDEX)}
-          navigation={navigation}
-          query={QUERY_TYPES.VOLUNTEER.TASKS}
-          sectionData={myTasks()}
-          sectionTitle="Meine Aufgaben"
-          showLink
-        /> */}
-        <VolunteerConversationsSection
-          linkTitle="Alle Nachrichten anzeigen"
-          buttonTitle={texts.volunteer.conversationStart}
-          navigateLink={() => navigation.navigate(NAVIGATION.CONVERSATIONS_INDEX)}
-          navigateButton={() => navigation.navigate(NAVIGATION.CONVERSATION_NEW)}
-          navigate={() => navigation.navigate(NAVIGATION.CONVERSATIONS_INDEX)}
-          navigation={navigation}
-          query={QUERY_TYPES.VOLUNTEER.CONVERSATIONS}
-          sectionTitle="Mein Postfach"
-          showLink
-          showButton
+          staticJsonName="volunteerPersonalTiles"
         />
       </ScrollView>
     </SafeAreaViewFlex>
   );
 };
-
-const styles = StyleSheet.create({
-  headerRight: {
-    alignItems: 'center',
-    paddingRight: normalize(7)
-  },
-  icon: {
-    paddingHorizontal: normalize(10)
-  }
-});

--- a/src/screens/volunteer/index.ts
+++ b/src/screens/volunteer/index.ts
@@ -3,6 +3,7 @@ export * from './VolunteerFormScreen';
 export * from './VolunteerHomeScreen';
 export * from './VolunteerIndexScreen';
 export * from './VolunteerLoginScreen';
+export * from './VolunteerLogoutScreen';
 export * from './VolunteerMeScreen';
 export * from './VolunteerPersonalScreen';
 export * from './VolunteerRegisteredScreen';

--- a/src/types/Navigation.ts
+++ b/src/types/Navigation.ts
@@ -54,6 +54,7 @@ export enum ScreenName {
   VolunteerHome = 'VolunteerHome',
   VolunteerIndex = 'VolunteerIndex',
   VolunteerLogin = 'VolunteerLogin',
+  VolunteerLogout = 'VolunteerLogout',
   VolunteerMe = 'VolunteerMe',
   VolunteerPersonal = 'VolunteerPersonal',
   VolunteerRegistered = 'VolunteerRegistered',


### PR DESCRIPTION
The new personal screen is working with different static contents for texts and service tiles. This way we can configure multiple things on the server more dynamically and customer can access and change these data and information as well.

HDVT-87

|personal screen|logout screen|
|---|---|
|![Simulator Screen Shot - iPhone 11 - 2022-11-01 at 16 10 59](https://user-images.githubusercontent.com/1942953/199267382-69ecdb35-dfac-4951-a31e-6f1273a5ad29.png)|![Simulator Screen Shot - iPhone 11 - 2022-11-01 at 16 11 10](https://user-images.githubusercontent.com/1942953/199267395-0db0b3d6-8c65-4bdb-b09f-034cfff557e9.png)|