### PR TITLE
feat(volunteer): add visibility and `joinPolicy` to create a group

### DIFF
--- a/src/components/volunteer/VolunteerFormGroup.tsx
+++ b/src/components/volunteer/VolunteerFormGroup.tsx
@@ -26,6 +26,12 @@ const VISIBILITY_OPTIONS = [
   { value: VISIBILITY_TYPES.REGISTERED_ONLY, title: 'Öffentlich (Nur Mitglieder)' },
   { value: VISIBILITY_TYPES.PRIVATE, title: 'Privat (unsichtbar)' }
 ];
+const JOIN_POLICY_OPTIONS = [
+  { value: JOIN_POLICY_TYPES.OPEN, title: 'Jeder kann beitreten' },
+  { value: JOIN_POLICY_TYPES.INVITE_AND_REQUEST, title: 'Einladung und Anfrage' },
+  { value: JOIN_POLICY_TYPES.INVITE, title: 'Nur auf Einladung' }
+];
+
 // eslint-disable-next-line complexity
 export const VolunteerFormGroup = ({
   navigation,
@@ -38,6 +44,7 @@ export const VolunteerFormGroup = ({
   const {
     control,
     formState: { errors, isValid, isSubmitted },
+    watch,
     handleSubmit
   } = useForm<VolunteerGroup>({
     mode: 'onBlur',
@@ -158,9 +165,9 @@ export const VolunteerFormGroup = ({
                   onPress={() => onChange(visibilityItem.value)}
                   title={visibilityItem.title}
                   checkedColor={colors.accent}
-                  checkedIcon="check-square-o"
+                  checkedIcon="dot-circle-o"
                   uncheckedColor={colors.darkText}
-                  uncheckedIcon="square-o"
+                  uncheckedIcon="circle-o"
                   containerStyle={styles.checkboxContainerStyle}
                   textStyle={styles.checkboxTextStyle}
                 />
@@ -170,6 +177,39 @@ export const VolunteerFormGroup = ({
           control={control}
         />
       </Wrapper>
+      {watch('visibility') !== VISIBILITY_TYPES.PRIVATE && (
+        <Wrapper style={styles.noPaddingTop}>
+          <Controller
+            name="joinPolicy"
+            render={({ onChange, value }) => (
+              <>
+                <Input
+                  hidden
+                  name="Beitritts-Richtlinie"
+                  label={texts.volunteer.accessionDirective}
+                  placeholder={texts.volunteer.accessionDirective}
+                  control={control}
+                />
+                {JOIN_POLICY_OPTIONS.map((joinPolicyItem) => (
+                  <CheckBox
+                    key={joinPolicyItem.title}
+                    checked={value === joinPolicyItem.value}
+                    onPress={() => onChange(joinPolicyItem.value)}
+                    title={joinPolicyItem.title}
+                    checkedColor={colors.accent}
+                    checkedIcon="dot-circle-o"
+                    uncheckedColor={colors.darkText}
+                    uncheckedIcon="circle-o"
+                    containerStyle={styles.checkboxContainerStyle}
+                    textStyle={styles.checkboxTextStyle}
+                  />
+                ))}
+              </>
+            )}
+            control={control}
+          />
+        </Wrapper>
+      )}
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="tags"

--- a/src/components/volunteer/VolunteerFormGroup.tsx
+++ b/src/components/volunteer/VolunteerFormGroup.tsx
@@ -21,6 +21,11 @@ const deleteGroupAlert = (onPress: () => Promise<void>) =>
     { text: 'Löschen', onPress, style: 'destructive' }
   ]);
 
+const VISIBILITY_OPTIONS = [
+  { value: VISIBILITY_TYPES.ALL, title: 'Öffentlich (auch nicht registrierte Besucher)' },
+  { value: VISIBILITY_TYPES.REGISTERED_ONLY, title: 'Öffentlich (Nur Mitglieder)' },
+  { value: VISIBILITY_TYPES.PRIVATE, title: 'Privat (unsichtbar)' }
+];
 // eslint-disable-next-line complexity
 export const VolunteerFormGroup = ({
   navigation,
@@ -138,17 +143,29 @@ export const VolunteerFormGroup = ({
         <Controller
           name="visibility"
           render={({ onChange, value }) => (
-            <CheckBox
-              checked={!!value}
-              onPress={() => onChange(!value)}
-              title="Öffentlich"
-              checkedColor={colors.accent}
-              checkedIcon="check-square-o"
-              uncheckedColor={colors.darkText}
-              uncheckedIcon="square-o"
-              containerStyle={styles.checkboxContainerStyle}
-              textStyle={styles.checkboxTextStyle}
-            />
+            <>
+              <Input
+                hidden
+                name="Sichtbarkeit"
+                label={texts.volunteer.visibility}
+                placeholder={texts.volunteer.visibility}
+                control={control}
+              />
+              {VISIBILITY_OPTIONS.map((visibilityItem) => (
+                <CheckBox
+                  key={visibilityItem.title}
+                  checked={value === visibilityItem.value}
+                  onPress={() => onChange(visibilityItem.value)}
+                  title={visibilityItem.title}
+                  checkedColor={colors.accent}
+                  checkedIcon="check-square-o"
+                  uncheckedColor={colors.darkText}
+                  uncheckedIcon="square-o"
+                  containerStyle={styles.checkboxContainerStyle}
+                  textStyle={styles.checkboxTextStyle}
+                />
+              ))}
+            </>
           )}
           control={control}
         />

--- a/src/components/volunteer/VolunteerFormGroup.tsx
+++ b/src/components/volunteer/VolunteerFormGroup.tsx
@@ -11,6 +11,7 @@ import { groupDelete, groupEdit, groupNew } from '../../queries/volunteer';
 import { JOIN_POLICY_TYPES, VISIBILITY_TYPES, VolunteerGroup } from '../../types';
 import { Button } from '../Button';
 import { Input } from '../form/Input';
+import { Label } from '../Label';
 import { BoldText } from '../Text';
 import { Touchable } from '../Touchable';
 import { Wrapper } from '../Wrapper';
@@ -147,17 +148,11 @@ export const VolunteerFormGroup = ({
         />
       </Wrapper>
       <Wrapper style={styles.noPaddingTop}>
+        <Label>{texts.volunteer.visibility}</Label>
         <Controller
           name="visibility"
           render={({ onChange, value }) => (
             <>
-              <Input
-                hidden
-                name="Sichtbarkeit"
-                label={texts.volunteer.visibility}
-                placeholder={texts.volunteer.visibility}
-                control={control}
-              />
               {VISIBILITY_OPTIONS.map((visibilityItem) => (
                 <CheckBox
                   key={visibilityItem.title}
@@ -165,9 +160,7 @@ export const VolunteerFormGroup = ({
                   onPress={() => onChange(visibilityItem.value)}
                   title={visibilityItem.title}
                   checkedColor={colors.accent}
-                  checkedIcon="dot-circle-o"
                   uncheckedColor={colors.darkText}
-                  uncheckedIcon="circle-o"
                   containerStyle={styles.checkboxContainerStyle}
                   textStyle={styles.checkboxTextStyle}
                 />
@@ -179,17 +172,11 @@ export const VolunteerFormGroup = ({
       </Wrapper>
       {watch('visibility') !== VISIBILITY_TYPES.PRIVATE && (
         <Wrapper style={styles.noPaddingTop}>
+          <Label>{texts.volunteer.accessionDirective}</Label>
           <Controller
             name="joinPolicy"
             render={({ onChange, value }) => (
               <>
-                <Input
-                  hidden
-                  name="Beitritts-Richtlinie"
-                  label={texts.volunteer.accessionDirective}
-                  placeholder={texts.volunteer.accessionDirective}
-                  control={control}
-                />
                 {JOIN_POLICY_OPTIONS.map((joinPolicyItem) => (
                   <CheckBox
                     key={joinPolicyItem.title}
@@ -197,9 +184,7 @@ export const VolunteerFormGroup = ({
                     onPress={() => onChange(joinPolicyItem.value)}
                     title={joinPolicyItem.title}
                     checkedColor={colors.accent}
-                    checkedIcon="dot-circle-o"
                     uncheckedColor={colors.darkText}
-                    uncheckedIcon="circle-o"
                     containerStyle={styles.checkboxContainerStyle}
                     textStyle={styles.checkboxTextStyle}
                   />

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -819,6 +819,7 @@ export const texts = {
     abort: 'Abbrechen',
     about: 'Über mich',
     accept: 'Akzeptieren',
+    accessionDirective: 'Beitritts-Richtlinie',
     addDocument: 'Dokument hinzufügen',
     addImage: 'Bild hinzufügen',
     admin: 'Administrator',

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -949,6 +949,7 @@ export const texts = {
     usernameErrorLengthError: 'Der Benutzername sollte mindestens 4 Zeichen lang sein',
     usernameOrEmail: 'Benutzername oder E-Mail',
     vimeo: 'Vimeo',
+    visibility: 'Sichtbarkeit',
     website: 'Home page',
     xing: 'xing',
     xmpp: 'xmpp',

--- a/src/queries/volunteer/group.ts
+++ b/src/queries/volunteer/group.ts
@@ -61,8 +61,8 @@ export const groupNew = async ({
   const formData = {
     name,
     description,
-    visibility: visibility ? VISIBILITY_TYPES.ALL : VISIBILITY_TYPES.REGISTERED_ONLY,
     join_policy: joinPolicy ? JOIN_POLICY_TYPES.OPEN : JOIN_POLICY_TYPES.INVITE_AND_REQUEST
+    visibility: visibility,
   };
 
   const fetchObj = {
@@ -91,8 +91,8 @@ export const groupEdit = async ({
   const formData = {
     name,
     description,
-    visibility: visibility ? VISIBILITY_TYPES.ALL : VISIBILITY_TYPES.REGISTERED_ONLY,
     join_policy: joinPolicy ? JOIN_POLICY_TYPES.OPEN : JOIN_POLICY_TYPES.INVITE_AND_REQUEST,
+    visibility: visibility,
     tags
   };
 

--- a/src/queries/volunteer/group.ts
+++ b/src/queries/volunteer/group.ts
@@ -61,8 +61,8 @@ export const groupNew = async ({
   const formData = {
     name,
     description,
-    join_policy: joinPolicy ? JOIN_POLICY_TYPES.OPEN : JOIN_POLICY_TYPES.INVITE_AND_REQUEST
-    visibility: visibility,
+    visibility,
+    join_policy: joinPolicy
   };
 
   const fetchObj = {
@@ -91,8 +91,8 @@ export const groupEdit = async ({
   const formData = {
     name,
     description,
-    join_policy: joinPolicy ? JOIN_POLICY_TYPES.OPEN : JOIN_POLICY_TYPES.INVITE_AND_REQUEST,
-    visibility: visibility,
+    visibility,
+    join_policy: joinPolicy,
     tags
   };
 


### PR DESCRIPTION
- added selectable visibility properties 
  when creating a group
- created `VISIBILITY_OPTIONS` array 
  to select visibility options with checkbox
- updated the visibility values sent during 
  the request with the selected value
- added selectable `joinPolicy` properties 
  when creating a group
- created `JOIN_POLICY_OPTIONS` array 
  to select `joinPolicy` options with checkbox
- updated the `joinPolicy` values sent during 
  the request with the selected value
- added `watch` function to not show `joinPolicy` 
  Checkboxes if visibility value is 
  `VISIBILITY_TYPES.PRIVATE`

HDVT-90

You can add this code to `VolunteerHomeScreen` to try it out:

```       
<Button
  title="Create Volunteer Group"
  onPress={() =>
    navigation.navigate(ScreenName.VolunteerForm, { query: QUERY_TYPES.VOLUNTEER.GROUP })
  }
/>
```


## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode

## Screenshots:

|group create screen|group create screen|group create screen (visibility - privat)|
|--|--|--|
![Simulator Screen Shot - iPhone 14 Pro Max - 2022-11-03 at 09 14 31](https://user-images.githubusercontent.com/11755668/199673627-a894a4b2-67f2-43e6-bd15-806b359ca962.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2022-11-03 at 09 14 33](https://user-images.githubusercontent.com/11755668/199673641-c28aa287-b63f-43ab-832a-3741882cea8c.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2022-11-03 at 09 14 36](https://user-images.githubusercontent.com/11755668/199673647-73d103ae-e31d-4646-986e-8ef0ec87b12e.png)