### PR TITLE
fix(volunteer): fix avatar not appearing in event attendee list

### DIFF
--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -236,7 +236,7 @@ const parseVolunteers = (data, query, skipLastDivider, withDate, isSectioned, cu
         };
       }
 
-      leftIcon = <VolunteerAvatar item={volunteer} />;
+      leftIcon = <VolunteerAvatar item={volunteer.user ? volunteer : { user: volunteer }} />;
     }
 
     if (query === QUERY_TYPES.VOLUNTEER.GROUP && !!volunteer.role) {


### PR DESCRIPTION
- solved the problem by taking the `user` object into the user object if there is no `volunteer.user` object in the data coming from the server because there is no user object that `VolunteerAvatar` needs

HDVT-87

## Screenshots:

|before|after|
|--|--|
![Simulator Screen Shot - iPhone 14 Pro Max - 2022-11-04 at 11 31 52](https://user-images.githubusercontent.com/11755668/199952377-c9f162ca-2f27-4d38-832d-4a65136546d5.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2022-11-04 at 11 31 25](https://user-images.githubusercontent.com/11755668/199952398-67f76f94-9e94-479d-a30a-a9767bc377bd.png)
