### PR TITLE
feat(push notifications): exclude data providers

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "Smart Village App",
     "slug": "smart-village-app",
+    "owner": "ikusei",
     "privacy": "public",
     "description": "An open source React Native app for smart villages merging regional offers and services in one place - in your pocket.",
     "githubUrl": "https://github.com/ikuseiGmbH/smart-village-app-app",

--- a/src/config/secrets.temp
+++ b/src/config/secrets.temp
@@ -34,7 +34,8 @@ module.exports.secrets = {
 
     rest: {
       pushDevicesRegister: '',
-      pushDevicesDelete: ''
+      pushDevicesDelete: '',
+      pushDevicesDataProviders: ''
     },
 
     // you need to provide your Sentry credentials to connect your instance

--- a/src/pushNotifications/PermissionHandling.ts
+++ b/src/pushNotifications/PermissionHandling.ts
@@ -55,7 +55,9 @@ export const initializePushPermissions = async () => {
 };
 
 const registerForPushNotificationsAsync = async () => {
-  const { data: token } = await Notifications.getExpoPushTokenAsync();
+  const { data: token } = await Notifications.getExpoPushTokenAsync({
+    experienceId: `${Constants.manifest?.owner}/${Constants.manifest?.slug}`
+  });
 
   if (device.platform === 'android') {
     Notifications.setNotificationChannelAsync('default', {

--- a/src/pushNotifications/TokenHandling.ts
+++ b/src/pushNotifications/TokenHandling.ts
@@ -89,3 +89,28 @@ const storeTokenSecurely = (token?: string) => {
 
 export const getPushTokenFromStorage = () =>
   SecureStore.getItemAsync(PushNotificationStorageKeys.PUSH_TOKEN);
+
+export const addDataProvidersToTokenOnServer = async (excludeDataProviderIds: number[]) => {
+  const storedToken = await getPushTokenFromStorage();
+  const accessToken = await SecureStore.getItemAsync('ACCESS_TOKEN');
+  const requestPath =
+    secrets[namespace].serverUrl + secrets[namespace].rest.pushDevicesDataProviders;
+
+  const fetchObj = {
+    method: 'PUT',
+    headers: {
+      Accept: 'application/json',
+      Authorization: 'Bearer ' + accessToken,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      notification_device: { token: storedToken, exclude_data_provider_ids: excludeDataProviderIds }
+    })
+  };
+
+  if (storedToken && accessToken) {
+    return fetch(requestPath, fetchObj).then((response) => response.status === 200);
+  }
+
+  return false;
+};


### PR DESCRIPTION
- added request to call a new endpoint on switching data provider settings with passing excluded data provider ids that will be respected for push notifications
- added `experienceId` needed to properly create expo push tokens
  - therefore added `owner` in app.json, which is the account name registered at expo.dev

SVA-710

|switches|passed object|
|---|---|
![SCR-20221108-q2j](https://user-images.githubusercontent.com/1942953/200645991-0072596b-4916-4835-8591-5f0423b4833a.png)|<img width="68" alt="image" src="https://user-images.githubusercontent.com/1942953/201331807-a74484bf-1a42-413c-89e4-0cae9c220ed8.png">|