### PR TITLE
fix(ar): android error due to `ViroAmbientLight`

### DIFF
--- a/src/components/augmentedReality/AugmentedRealityView.js
+++ b/src/components/augmentedReality/AugmentedRealityView.js
@@ -64,7 +64,6 @@ export const AugmentedRealityView = ({ sceneNavigator }) => {
         color={object?.light?.color || colors.surface}
         temperature={object?.light?.temperature || 6500}
         intensity={object?.light?.intensity || 1000}
-        rotation={object?.light?.rotation || [0, 0, 0]}
       />
 
       {object?.target ? (


### PR DESCRIPTION
- removed rotation prop in `ViroAmbientLight` to prevent application crashes

SVA-565
