### PR TITLE
refactor: adjust `normalize` import

### DIFF
--- a/src/components/CommentSection.tsx
+++ b/src/components/CommentSection.tsx
@@ -3,9 +3,8 @@ import { RefObject } from 'react';
 import { useRef } from 'react';
 import { useMutation } from 'react-apollo';
 import { Alert, Keyboard, ScrollView, StyleSheet, TextInput, View } from 'react-native';
-import { normalize } from 'react-native-elements';
 
-import { colors, device, texts } from '../config';
+import { colors, device, normalize, texts } from '../config';
 import { momentFormat } from '../helpers';
 import { useSurveyLanguages } from '../hooks';
 import { COMMENT_ON_SURVEY } from '../queries/survey';

--- a/src/components/Radiobutton.js
+++ b/src/components/Radiobutton.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { StyleSheet } from 'react-native';
-import { CheckBox as RNECheckbox, normalize } from 'react-native-elements';
+import { CheckBox as RNECheckbox } from 'react-native-elements';
 
-import { colors, Icon } from '../config';
+import { colors, Icon, normalize } from '../config';
 import { baseFontStyle } from '../config/styles/baseFontStyle';
 
 export const Radiobutton = ({ title, disabled, selected, onPress, containerStyle }) => (

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -1,10 +1,9 @@
 import React, { useContext, useRef } from 'react';
 import { StyleProp, StyleSheet, TouchableOpacity, View, ViewStyle } from 'react-native';
-import { normalize } from 'react-native-elements';
 import MapView, { LatLng, MAP_TYPES, Marker, Polyline, Region, UrlTile } from 'react-native-maps';
 import { SvgXml } from 'react-native-svg';
 
-import { colors, device, Icon } from '../../config';
+import { colors, device, Icon, normalize } from '../../config';
 import { imageHeight, imageWidth } from '../../helpers';
 import { SettingsContext } from '../../SettingsProvider';
 import { MapMarker } from '../../types';

--- a/src/components/screens/ServiceTile.tsx
+++ b/src/components/screens/ServiceTile.tsx
@@ -1,10 +1,9 @@
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { useContext } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
-import { normalize } from 'react-native-elements';
 import { EdgeInsets, useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { colors, consts, device, Icon } from '../../config';
+import { colors, consts, device, Icon, normalize } from '../../config';
 import { OrientationContext } from '../../OrientationProvider';
 import { Image } from '../Image';
 import { ServiceBox } from '../ServiceBox';

--- a/src/components/screens/ServiceTiles.js
+++ b/src/components/screens/ServiceTiles.js
@@ -1,9 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { useCallback, useContext, useState } from 'react';
 import { RefreshControl, ScrollView, StyleSheet, View } from 'react-native';
-import { normalize } from 'react-native-elements';
 
-import { colors, consts, device } from '../../config';
+import { colors, consts, device, normalize } from '../../config';
 import { useStaticContent, useVolunteerRefresh } from '../../hooks';
 import { NetworkContext } from '../../NetworkProvider';
 import { HtmlView } from '../HtmlView';

--- a/src/components/survey/SurveyAnswer.tsx
+++ b/src/components/survey/SurveyAnswer.tsx
@@ -1,8 +1,7 @@
 import React, { SetStateAction, useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { normalize } from 'react-native-elements';
 
-import { colors } from '../../config';
+import { colors, normalize } from '../../config';
 import { getAnswerLabel, imageWidth } from '../../helpers';
 import { useSurveyLanguages } from '../../hooks';
 import { ResponseOption } from '../../types';

--- a/src/components/volunteer/VolunteerHomeSection.tsx
+++ b/src/components/volunteer/VolunteerHomeSection.tsx
@@ -2,9 +2,8 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import _isNumber from 'lodash/isNumber';
 import React, { useState } from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
-import { normalize } from 'react-native-elements';
 
-import { colors, Icon, texts } from '../../config';
+import { colors, Icon, normalize, texts } from '../../config';
 import { isUpcomingDate } from '../../helpers';
 import { useVolunteerData, useVolunteerRefresh } from '../../hooks';
 import { QUERY_TYPES } from '../../queries';

--- a/src/components/wasteCalendar/WasteReminderSettings.tsx
+++ b/src/components/wasteCalendar/WasteReminderSettings.tsx
@@ -11,7 +11,7 @@ import {
   View
 } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
-import { ListItem, normalize } from 'react-native-elements';
+import { ListItem } from 'react-native-elements';
 
 import {
   deleteReminderSetting,
@@ -23,7 +23,7 @@ import { BoldText, RegularText } from '../Text';
 import { Touchable } from '../Touchable';
 import { Radiobutton } from '../Radiobutton';
 import { Wrapper, WrapperHorizontal, WrapperRow } from '../Wrapper';
-import { colors, consts, device, texts } from '../../config';
+import { colors, consts, device, normalize, texts } from '../../config';
 import { ReminderSettings, WasteTypeData } from '../../types';
 import { Button } from '../Button';
 import { areValidReminderSettings, parseReminderSettings } from '../../jsonValidation';

--- a/src/screens/EncounterDataScreen.tsx
+++ b/src/screens/EncounterDataScreen.tsx
@@ -10,7 +10,6 @@ import {
   TouchableOpacity,
   View
 } from 'react-native';
-import { normalize } from 'react-native-elements';
 
 import {
   Button,
@@ -27,7 +26,7 @@ import {
   WrapperRow,
   WrapperWithOrientation
 } from '../components';
-import { colors, consts, Icon, texts } from '../config';
+import { colors, consts, Icon, normalize, texts } from '../config';
 import { updateUserAsync } from '../encounterApi';
 import { momentFormat } from '../helpers';
 import { useEncounterUser, useSelectImage, useEncounterSupportId } from '../hooks';

--- a/src/screens/EncounterRegistrationScreen.tsx
+++ b/src/screens/EncounterRegistrationScreen.tsx
@@ -11,7 +11,7 @@ import {
   TouchableOpacity,
   View
 } from 'react-native';
-import { CheckBox, normalize } from 'react-native-elements';
+import { CheckBox } from 'react-native-elements';
 
 import {
   BoldText,
@@ -30,7 +30,7 @@ import {
   WrapperRow,
   WrapperWithOrientation
 } from '../components';
-import { colors, consts, device, Icon, texts } from '../config';
+import { colors, consts, device, Icon, normalize, texts } from '../config';
 import { createUserAsync } from '../encounterApi';
 import { momentFormat, storeEncounterUserId } from '../helpers';
 import { useSelectImage } from '../hooks';


### PR DESCRIPTION
moved `normalize` imports from `react-native-elements` to our configs as it seems to be happened mistakenly before.
please also check around with different simulators and systems, if anything seems to break or be misaligned now.