### PR TITLE
feat(noticeboard): add `noticeboardIndexScreen`

### DIFF
--- a/src/config/navigation/defaultStackConfig.tsx
+++ b/src/config/navigation/defaultStackConfig.tsx
@@ -35,6 +35,7 @@ import {
   MapViewScreen,
   MultiButtonScreen,
   NestedInfoScreen,
+  NoticeboardIndexScreen,
   OParlCalendarScreen,
   OParlDetailScreen,
   OParlOrganizationsScreen,
@@ -266,6 +267,10 @@ export const defaultStackConfig = ({
     {
       routeName: ScreenName.NestedInfo,
       screenComponent: NestedInfoScreen
+    },
+    {
+      routeName: ScreenName.Noticeboard,
+      screenComponent: NoticeboardIndexScreen
     },
     {
       routeName: ScreenName.OParlCalendar,

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -387,6 +387,9 @@ export const texts = {
   navigationTitles: {
     home: 'Übersicht'
   },
+  noticeboard: {
+    emptyTitle: 'Im Moment gibt es nichts zu sehen. Bitte versuchen Sie es später noch einmal.',
+  },
   oparl: {
     agendaItem: {
       agendaItem: 'Tagesordnungspunkt',

--- a/src/screens/NestedInfoScreen.tsx
+++ b/src/screens/NestedInfoScreen.tsx
@@ -141,7 +141,9 @@ export const NestedInfoScreen = ({ navigation, route }: StackScreenProps<any>) =
           />
         }
         sections={sectionData}
-        renderSectionHeader={({ section: { title } }) => <SectionHeader title={title} />}
+        renderSectionHeader={({ section: { title } }) =>
+          title ? <SectionHeader title={title} /> : null
+        }
         renderItem={renderItem}
         keyExtractor={(item) => item.title}
       />

--- a/src/screens/NoticeboardIndexScreen.tsx
+++ b/src/screens/NoticeboardIndexScreen.tsx
@@ -77,10 +77,11 @@ export const NoticeboardIndexScreen = ({ navigation, route }: StackScreenProps<a
         }
         ListHeaderComponent={
           <ListHeaderComponent
-            loading={loadingHtml}
             html={dataHtml}
-            subQuery={subQuery}
+            loading={loadingHtml}
             navigation={navigation}
+            navigationTitle=""
+            subQuery={subQuery}
           />
         }
       />

--- a/src/screens/NoticeboardIndexScreen.tsx
+++ b/src/screens/NoticeboardIndexScreen.tsx
@@ -1,0 +1,99 @@
+import { StackScreenProps } from '@react-navigation/stack';
+import React, { useCallback, useContext, useState } from 'react';
+import { useQuery } from 'react-apollo';
+import { ActivityIndicator, RefreshControl, SectionList } from 'react-native';
+
+import { EmptyMessage, LoadingContainer, SafeAreaViewFlex, SectionHeader } from '../components';
+import { colors, texts } from '../config';
+import { graphqlFetchPolicy, parseListItemsFromQuery } from '../helpers';
+import { useStaticContent } from '../hooks';
+import { useRenderItem } from '../hooks/listHooks';
+import { NetworkContext } from '../NetworkProvider';
+import { getQuery, QUERY_TYPES } from '../queries';
+
+import { ListHeaderComponent } from './NestedInfoScreen';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+/* eslint-disable complexity */
+export const NoticeboardIndexScreen = ({ navigation, route }: StackScreenProps<any>) => {
+  const { isConnected, isMainserverUp } = useContext(NetworkContext);
+  const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
+  const [refreshing, setRefreshing] = useState(false);
+
+  const consentForDataProcessingText = route.params?.consentForDataProcessingText ?? '';
+  const content = route.params?.content ?? '';
+  const query = route.params?.query ?? '';
+  const queryVariables = route.params?.queryVariables ?? {};
+  const subQuery = route.params?.subQuery ?? '';
+  const title = route.params?.title ?? '';
+
+  const { data, loading, refetch } = useQuery(getQuery(query), {
+    fetchPolicy,
+    variables: queryVariables
+  });
+  const listItems = parseListItemsFromQuery(query, data, consentForDataProcessingText, {
+    queryVariables
+  });
+
+  const {
+    data: dataHtml,
+    loading: loadingHtml,
+    refetch: refetchHtml
+  } = useStaticContent<string>({
+    name: content,
+    type: 'html',
+    skip: !content
+  });
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    if (isConnected) {
+      await refetch?.();
+      await refetchHtml?.();
+    }
+    setRefreshing(false);
+  }, [isConnected, refetch]);
+
+  const renderItem = useRenderItem(QUERY_TYPES.PUBLIC_JSON_FILE, navigation);
+
+  if (loading && !data)
+    return (
+      <LoadingContainer>
+        <ActivityIndicator color={colors.accent} />
+      </LoadingContainer>
+    );
+
+  if (!data) {
+    return <EmptyMessage title={texts.noticeboard.emptyTitle} />;
+  }
+
+  const sectionData = [{ title: title, data: listItems }];
+
+  return (
+    <SafeAreaViewFlex>
+      <SectionList
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            colors={[colors.accent]}
+            tintColor={colors.accent}
+          />
+        }
+        ListHeaderComponent={
+          <ListHeaderComponent
+            loading={loadingHtml}
+            html={dataHtml}
+            subQuery={subQuery}
+            navigation={navigation}
+          />
+        }
+        sections={sectionData}
+        renderSectionHeader={({ section: { title } }) => <SectionHeader title={title} />}
+        renderItem={renderItem}
+        keyExtractor={(item) => item.title + item.id}
+      />
+    </SafeAreaViewFlex>
+  );
+};
+/* eslint-enable complexity */

--- a/src/screens/NoticeboardIndexScreen.tsx
+++ b/src/screens/NoticeboardIndexScreen.tsx
@@ -1,20 +1,17 @@
 import { StackScreenProps } from '@react-navigation/stack';
 import React, { useCallback, useContext, useState } from 'react';
 import { useQuery } from 'react-apollo';
-import { ActivityIndicator, RefreshControl, SectionList } from 'react-native';
+import { ActivityIndicator, RefreshControl } from 'react-native';
 
-import { EmptyMessage, LoadingContainer, SafeAreaViewFlex, SectionHeader } from '../components';
+import { EmptyMessage, ListComponent, LoadingContainer, SafeAreaViewFlex } from '../components';
 import { colors, texts } from '../config';
 import { graphqlFetchPolicy, parseListItemsFromQuery } from '../helpers';
 import { useStaticContent } from '../hooks';
-import { useRenderItem } from '../hooks/listHooks';
 import { NetworkContext } from '../NetworkProvider';
-import { getQuery, QUERY_TYPES } from '../queries';
+import { getQuery } from '../queries';
 
 import { ListHeaderComponent } from './NestedInfoScreen';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-/* eslint-disable complexity */
 export const NoticeboardIndexScreen = ({ navigation, route }: StackScreenProps<any>) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
@@ -25,7 +22,6 @@ export const NoticeboardIndexScreen = ({ navigation, route }: StackScreenProps<a
   const query = route.params?.query ?? '';
   const queryVariables = route.params?.queryVariables ?? {};
   const subQuery = route.params?.subQuery ?? '';
-  const title = route.params?.title ?? '';
 
   const { data, loading, refetch } = useQuery(getQuery(query), {
     fetchPolicy,
@@ -54,24 +50,23 @@ export const NoticeboardIndexScreen = ({ navigation, route }: StackScreenProps<a
     setRefreshing(false);
   }, [isConnected, refetch]);
 
-  const renderItem = useRenderItem(QUERY_TYPES.PUBLIC_JSON_FILE, navigation);
-
-  if (loading && !data)
+  if (loading && !listItems)
     return (
       <LoadingContainer>
         <ActivityIndicator color={colors.accent} />
       </LoadingContainer>
     );
 
-  if (!data) {
+  if (!listItems) {
     return <EmptyMessage title={texts.noticeboard.emptyTitle} />;
   }
 
-  const sectionData = [{ title: title, data: listItems }];
-
   return (
     <SafeAreaViewFlex>
-      <SectionList
+      <ListComponent
+        data={listItems}
+        navigation={navigation}
+        query={query}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}
@@ -88,12 +83,7 @@ export const NoticeboardIndexScreen = ({ navigation, route }: StackScreenProps<a
             navigation={navigation}
           />
         }
-        sections={sectionData}
-        renderSectionHeader={({ section: { title } }) => <SectionHeader title={title} />}
-        renderItem={renderItem}
-        keyExtractor={(item) => item.title + item.id}
       />
     </SafeAreaViewFlex>
   );
 };
-/* eslint-enable complexity */

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -24,6 +24,7 @@ export * from './LunchScreen';
 export * from './MapViewScreen';
 export * from './MultiButtonScreen';
 export * from './NestedInfoScreen';
+export * from './NoticeboardIndexScreen';
 export * from './SettingsScreen';
 export * from './SurveyDetailScreen';
 export * from './SurveyOverviewScreen';

--- a/src/types/Navigation.ts
+++ b/src/types/Navigation.ts
@@ -38,6 +38,7 @@ export enum ScreenName {
   MapView = 'MapView',
   MultiButton = 'MultiButton',
   NestedInfo = 'NestedInfo',
+  Noticeboard = 'Noticeboard',
   OParlCalendar = 'OParlCalendar',
   OParlDetail = 'OParlDetail',
   OParlOrganizations = 'OParlOrganizations',


### PR DESCRIPTION
- added index screen for `noticeboard` `genericItem`
  - `noticeboardIndexScreen` differs from `nestedInfoScreen` in that it has a `genericItem` list with query
- added the necessary information for the navigation structure to `defaultStackConfig` and `Navigation`
- added `EmptyMessage` component to show on screen if there is no data in `noticeboardIndexScreen`

SVA-739

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode

## Screenshots:


|Noticeboard Offers Screen|Noticeboard Searches Screen|Noticeboard NeighbourlyHelp Screen|
|--|--|--|
![Simulator Screen Shot - iPhone 8 Plus - 2022-11-18 at 16 05 39](https://user-images.githubusercontent.com/11755668/202735888-aa2016c6-358b-43db-91cd-f598fec9d9ce.png) | ![Simulator Screen Shot - iPhone 8 Plus - 2022-11-18 at 16 05 51](https://user-images.githubusercontent.com/11755668/202735916-4cbf7fbb-3f75-40ea-9897-dc608ccccf55.png) | ![Simulator Screen Shot - iPhone 8 Plus - 2022-11-18 at 16 05 56](https://user-images.githubusercontent.com/11755668/202735926-9f43c676-4a99-4f60-9d03-f000169a35fb.png)
