### PR TITLE
feat(price card): show 'kostenlos' instead of nothing

### DIFF
--- a/src/components/screens/PriceCard.js
+++ b/src/components/screens/PriceCard.js
@@ -29,6 +29,8 @@ export const PriceCard = ({ prices }) => (
             maxAdultCount,
             groupPrice
           } = item;
+          const formattedAmount = priceFormat(amount);
+          const formattedGroupPrice = priceFormat(groupPrice);
 
           return (
             <PriceBox key={index}>
@@ -37,14 +39,14 @@ export const PriceCard = ({ prices }) => (
                   {category}
                 </BoldText>
               )}
-              {!!amount && (
+              {!!formattedAmount && (
                 <BoldText small lightest>
-                  {priceFormat(amount)}
+                  {formattedAmount}
                 </BoldText>
               )}
-              {!!groupPrice && (
+              {!!formattedGroupPrice && (
                 <BoldText small lightest>
-                  {priceFormat(groupPrice)}
+                  {formattedGroupPrice}
                 </BoldText>
               )}
               {!!description && (

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -632,6 +632,7 @@ export const texts = {
     location: 'Anfahrt',
     openingTime: 'Öffnungszeiten',
     operatingCompany: 'Anbieter',
+    priceFree: 'kostenlos',
     prices: 'Preise',
     routePlanner: 'Zum Routenplaner bbnavi',
     showLunches: 'Zum aktuellen Gastro-Angebot',

--- a/src/helpers/priceHelper.js
+++ b/src/helpers/priceHelper.js
@@ -8,6 +8,10 @@ import { device } from '../config/device';
  * @return {string} a formatted string in the de-DE locale and with currency code
  */
 export const priceFormat = (price) => {
+  if (price === null || price === undefined) {
+    return;
+  }
+
   if (device.platform === 'ios') {
     return new Intl.NumberFormat('de-DE', {
       style: 'currency',

--- a/src/helpers/priceHelper.js
+++ b/src/helpers/priceHelper.js
@@ -1,4 +1,4 @@
-import { device } from '../config/device';
+import { device, texts } from '../config';
 
 /**
  * Formatting floating-point numbers from data in to prices (1.2 => 1,20 EUR)
@@ -10,6 +10,10 @@ import { device } from '../config/device';
 export const priceFormat = (price) => {
   if (price === null || price === undefined) {
     return;
+  }
+
+  if (price === 0) {
+    return texts.pointOfInterest.priceFree;
   }
 
   if (device.platform === 'ios') {


### PR DESCRIPTION
- there can be free entries, which we were not showing because it resulted in `false`

SVA-822

|before|after|
|---|---|
|![Simulator Screen Shot - iPhone 12 mini - 2022-11-21 at 11 59 39](https://user-images.githubusercontent.com/1942953/203036512-bca16d04-7d05-410b-8136-5b93a641187a.png)|![simulator_screenshot_FE2E8DF8-3BBC-44A8-872C-007904303AB0](https://user-images.githubusercontent.com/1942953/203051075-ffcfcc06-2164-4636-9da5-1f9ec08adb46.png)|
