### PR TITLE
feat(ar): multiple scene logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "markdown-it": "^12.3.2",
     "matomo-tracker-react-native": "^0.3.0",
     "moment": "~2.29.4",
+    "moment-range": "^4.0.2",
     "qs": "^6.10.3",
     "react": "17.0.2",
     "react-apollo": "~3.1.5",

--- a/src/components/augmentedReality/AugmentedRealityView.js
+++ b/src/components/augmentedReality/AugmentedRealityView.js
@@ -151,7 +151,7 @@ const ViroSoundAnd3DObject = (item) => {
 
       <Viro3DObject
         source={{ uri: object?.vrx?.uri }}
-        resources={object?.texture}
+        resources={object?.textures}
         type="VRX"
         position={object?.vrx?.position}
         rotation={object?.vrx?.rotation}

--- a/src/helpers/augmentedReality/downloadObject.js
+++ b/src/helpers/augmentedReality/downloadObject.js
@@ -25,6 +25,7 @@ export const downloadObject = async ({ index, data, setData }) => {
         rolloffModel,
         rotation,
         scale,
+        stable,
         temperature,
         title,
         type,
@@ -81,6 +82,7 @@ export const downloadObject = async ({ index, data, setData }) => {
           rotation, // Array [x,y,z]
           scale, // Array [x,y,z]
           size,
+          stable,
           temperature, // Number
           title,
           type,

--- a/src/helpers/augmentedReality/index.js
+++ b/src/helpers/augmentedReality/index.js
@@ -3,6 +3,8 @@ export * from './deleteObject';
 export * from './downloadAndDeleteAllData';
 export * from './downloadObject';
 export * from './downloadType';
+export * from './multipleSceneIndexGenerator';
 export * from './navigationToArtworkDetailScreen';
+export * from './objectParser';
 export * from './progressSizeGenerator';
 export * from './storageNameCreator';

--- a/src/helpers/augmentedReality/multipleSceneIndexGenerator.ts
+++ b/src/helpers/augmentedReality/multipleSceneIndexGenerator.ts
@@ -3,6 +3,9 @@ import { extendMoment } from 'moment-range';
 
 const extendedMoment = extendMoment(moment);
 
+type TGenerator = { startDate: Date; timePeriodInDays: number; scenes: Array<TScenes> };
+type TScenes = { localUris: Array<{ type: string; stable: boolean }> };
+
 /**
  * index creation function for model and texture
  *
@@ -12,25 +15,28 @@ const extendedMoment = extendMoment(moment);
  *
  * @return {object} both parsed values as an object, like { modalIndex: 1, textureIndex: 1 }
  */
-const multipleSceneIndexGenerator = async ({ startDate, timePeriodInDays, scenes }) =>
-  new Promise((resolve) => {
-    let modalIndex, textureIndex;
+export const multipleSceneIndexGenerator = ({
+  startDate,
+  timePeriodInDays,
+  scenes
+}: TGenerator) => {
+  let modalIndex, textureIndex;
 
-    /* all models must have the same number of variable textures. Therefore, in order to obtain the 
-       number of textures, the textures of the first model were calculated. */
-    if (scenes.length > 1) {
-      const today = new Date(),
-        differenceDate = extendedMoment.range(startDate, today).diff('days'),
-        textureCount = scenes[0]?.localUris?.filter(
-          ({ type, stable }) => !stable && type === 'texture'
-        )?.length,
-        texture = Math.floor(differenceDate / timePeriodInDays),
-        modalCount = scenes.length,
-        modal = Math.floor(texture / textureCount);
+  /* all models must have the same number of variable textures. Therefore, in order to obtain the 
+      number of textures, the textures of the first model were calculated. */
+  if (scenes.length > 1) {
+    const today = new Date(),
+      differenceDate = extendedMoment.range(startDate, today).diff('days'),
+      textureCount = scenes[0]?.localUris?.filter(
+        ({ type, stable }) => !stable && type === 'texture'
+      )?.length,
+      texture = Math.floor(differenceDate / timePeriodInDays),
+      modalCount = scenes.length,
+      modal = Math.floor(texture / textureCount);
 
-      modalIndex = modal % modalCount;
-      textureIndex = texture % textureCount;
-    }
+    modalIndex = modal % modalCount;
+    textureIndex = texture % textureCount;
+  }
 
-    resolve({ modalIndex, textureIndex });
-  });
+  return { modalIndex, textureIndex };
+};

--- a/src/helpers/augmentedReality/multipleSceneIndexGenerator.ts
+++ b/src/helpers/augmentedReality/multipleSceneIndexGenerator.ts
@@ -1,10 +1,11 @@
+import _remove from 'lodash/remove';
 import moment from 'moment';
 import { extendMoment } from 'moment-range';
 
 const extendedMoment = extendMoment(moment);
 
 type TScenes = { localUris: Array<{ type: string; stable: boolean }> };
-type TGenerator = { startDate: Date; timePeriodInDays: number; scenes: Array<TScenes> };
+type TGenerator = { startDate?: Date; timePeriodInDays?: number; scenes: Array<TScenes> };
 
 /**
  * index creation function for model and texture
@@ -22,27 +23,36 @@ export const multipleSceneIndexGenerator = ({
 }: TGenerator) => {
   let modelIndex = 0;
   const scenesCount = scenes?.length;
-  let localUris = scenes?.[modelIndex]?.localUris;
+  const localUris = scenes?.[modelIndex]?.localUris;
 
   // if we have multiple scenes, we want to calculate the model and texture based on the current day
   // compared to the `startDate`
   if (scenesCount > 1 && startDate && timePeriodInDays) {
-    const today = new Date();
-
-    // the current day number is the number of running days since the given start date
-    const currentDayNumber = extendedMoment.range(startDate, today).diff('days');
-
     // all models must have the same number of variable textures. therefore, in order to obtain the
     // number of textures, the textures of the first model were calculated.
-    const textureCount = scenes[0]?.localUris?.filter(
-      ({ type, stable }) => !stable && type === 'texture'
-    )?.length;
+    const variableTextures = scenes[0]?.localUris?.filter(
+      ({ type, stable }) => type === 'texture' && !stable
+    );
+    const variableTexturesCount = variableTextures?.length;
 
+    if (!variableTexturesCount) {
+      // nothing to do if there are no unstable textures
+      // keep original localUris with modelIndex = 0
+      return { localUris };
+    }
+
+    const today = new Date();
+    // the current day number is the number of running days since the given start date
+    const currentDayNumber = extendedMoment.range(startDate, today).diff('days');
     const texture = Math.floor(currentDayNumber / timePeriodInDays);
-    const model = Math.floor(texture / textureCount);
+    const model = Math.floor(texture / variableTexturesCount);
     modelIndex = model % scenesCount;
-    const textureIndex = texture % textureCount;
-    localUris = [scenes[modelIndex]?.localUris[textureIndex]];
+    const textureIndex = texture % variableTexturesCount;
+    const variableTexture = variableTextures?.[textureIndex];
+
+    _remove(localUris, ({ type, stable }) => type === 'texture' && !stable);
+
+    !!variableTexture && localUris.push(variableTexture);
   }
 
   return { localUris };

--- a/src/helpers/augmentedReality/multipleSceneIndexGenerator.ts
+++ b/src/helpers/augmentedReality/multipleSceneIndexGenerator.ts
@@ -13,14 +13,14 @@ type TScenes = { localUris: Array<{ type: string; stable: boolean }> };
  * @param {number} timePeriodInDays    time period in days of the model
  * @param {array}  scenes              array of models
  *
- * @return {object} both parsed values as an object, like { modalIndex: 1, textureIndex: 1 }
+ * @return {object} both parsed values as an object, like { modelIndex: 1, textureIndex: 1 }
  */
 export const multipleSceneIndexGenerator = ({
   startDate,
   timePeriodInDays,
   scenes
 }: TGenerator) => {
-  let modalIndex, textureIndex;
+  let modelIndex, textureIndex;
 
   /* all models must have the same number of variable textures. Therefore, in order to obtain the 
       number of textures, the textures of the first model were calculated. */
@@ -31,12 +31,12 @@ export const multipleSceneIndexGenerator = ({
         ({ type, stable }) => !stable && type === 'texture'
       )?.length,
       texture = Math.floor(differenceDate / timePeriodInDays),
-      modalCount = scenes.length,
-      modal = Math.floor(texture / textureCount);
+      modelCount = scenes.length,
+      model = Math.floor(texture / textureCount);
 
-    modalIndex = modal % modalCount;
+    modelIndex = model % modelCount;
     textureIndex = texture % textureCount;
   }
 
-  return { modalIndex, textureIndex };
+  return { modelIndex, textureIndex };
 };

--- a/src/helpers/augmentedReality/multipleSceneIndexGenerator.ts
+++ b/src/helpers/augmentedReality/multipleSceneIndexGenerator.ts
@@ -1,0 +1,36 @@
+import moment from 'moment';
+import { extendMoment } from 'moment-range';
+
+const extendedMoment = extendMoment(moment);
+
+/**
+ * index creation function for model and texture
+ *
+ * @param {string} startDate           start date of the model
+ * @param {number} timePeriodInDays    time period in days of the model
+ * @param {array}  scenes              array of models
+ *
+ * @return {object} both parsed values as an object, like { modalIndex: 1, textureIndex: 1 }
+ */
+const multipleSceneIndexGenerator = async ({ startDate, timePeriodInDays, scenes }) =>
+  new Promise((resolve) => {
+    let modalIndex, textureIndex;
+
+    /* all models must have the same number of variable textures. Therefore, in order to obtain the 
+       number of textures, the textures of the first model were calculated. */
+    if (scenes.length > 1) {
+      const today = new Date(),
+        differenceDate = extendedMoment.range(startDate, today).diff('days'),
+        textureCount = scenes[0]?.localUris?.filter(
+          ({ type, stable }) => !stable && type === 'texture'
+        )?.length,
+        texture = Math.floor(differenceDate / timePeriodInDays),
+        modalCount = scenes.length,
+        modal = Math.floor(texture / textureCount);
+
+      modalIndex = modal % modalCount;
+      textureIndex = texture % textureCount;
+    }
+
+    resolve({ modalIndex, textureIndex });
+  });

--- a/src/helpers/augmentedReality/objectParser.js
+++ b/src/helpers/augmentedReality/objectParser.js
@@ -1,10 +1,14 @@
+import { Alert } from 'react-native';
+
+import { texts } from '../../config';
+
 import { multipleSceneIndexGenerator } from './multipleSceneIndexGenerator';
 
 export const objectParser = async ({ item, setObject, setIsLoading, onPress }) => {
   const parsedObject = { textures: [] };
   const variableTextures = [];
 
-  const { modalIndex, textureIndex } = await multipleSceneIndexGenerator({
+  const { modalIndex, textureIndex } = multipleSceneIndexGenerator({
     startDate: item?.payload?.startDate,
     timePeriodInDays: item?.payload?.timePeriodInDays,
     scenes: item?.payload?.scenes
@@ -13,16 +17,16 @@ export const objectParser = async ({ item, setObject, setIsLoading, onPress }) =
   const localUris =
     item?.payload?.scenes?.[modalIndex]?.localUris || item?.payload?.scenes?.[0]?.localUris;
 
-  localUris.filter(
-    ({ stable, uri, type }) => stable && type === 'texture' && parsedObject.textures.push({ uri })
-  );
+  localUris.filter(({ stable, uri, type }) => {
+    if (type === 'texture') {
+      stable && parsedObject.textures.push({ uri });
+      !stable && variableTextures.push({ uri });
+    }
+  });
 
-  // combine stable textures with variable textures
-  if (typeof modalIndex === 'number' && typeof textureIndex === 'number') {
-    localUris.filter(
-      ({ stable, uri, type }) => !stable && type === 'texture' && variableTextures.push({ uri })
-    );
-    parsedObject.textures.push(variableTextures[textureIndex || 0] || []);
+  if (variableTextures.length > 0) {
+    const variableTexture = variableTextures[textureIndex || 0] || [];
+    parsedObject.textures.push(variableTexture);
   }
 
   if (localUris?.animationName) {

--- a/src/helpers/augmentedReality/objectParser.js
+++ b/src/helpers/augmentedReality/objectParser.js
@@ -6,16 +6,12 @@ import { multipleSceneIndexGenerator } from './multipleSceneIndexGenerator';
 
 export const objectParser = async ({ item, setObject, setIsLoading, onPress }) => {
   const parsedObject = { textures: [] };
-  const variableTextures = [];
 
-  const { modelIndex, textureIndex } = multipleSceneIndexGenerator({
+  const { localUris } = multipleSceneIndexGenerator({
+    scenes: item?.payload?.scenes,
     startDate: item?.payload?.startDate,
-    timePeriodInDays: item?.payload?.timePeriodInDays,
-    scenes: item?.payload?.scenes
+    timePeriodInDays: item?.payload?.timePeriodInDays
   });
-
-  const localUris =
-    item?.payload?.scenes?.[modelIndex]?.localUris || item?.payload?.scenes?.[0]?.localUris;
 
   if (localUris?.animationName) {
     parsedObject.animationName = localUris?.animationName;
@@ -23,8 +19,7 @@ export const objectParser = async ({ item, setObject, setIsLoading, onPress }) =
 
   localUris?.forEach((item) => {
     if (item.type === 'texture') {
-      item.stable && parsedObject.textures.push({ uri: item.uri });
-      !item.stable && variableTextures.push({ uri: item.uri });
+      parsedObject.textures.push({ uri: item.uri });
     } else {
       parsedObject[item.type] = {
         chromaKeyFilteredVideo: item?.chromaKeyFilteredVideo,
@@ -43,11 +38,6 @@ export const objectParser = async ({ item, setObject, setIsLoading, onPress }) =
       };
     }
   });
-
-  if (variableTextures.length > 0) {
-    const variableTexture = variableTextures[textureIndex || 0] || [];
-    parsedObject.textures.push(variableTexture);
-  }
 
   if (!parsedObject?.textures?.length || !parsedObject?.vrx) {
     return Alert.alert(

--- a/src/helpers/augmentedReality/objectParser.js
+++ b/src/helpers/augmentedReality/objectParser.js
@@ -17,24 +17,15 @@ export const objectParser = async ({ item, setObject, setIsLoading, onPress }) =
   const localUris =
     item?.payload?.scenes?.[modelIndex]?.localUris || item?.payload?.scenes?.[0]?.localUris;
 
-  localUris.filter(({ stable, uri, type }) => {
-    if (type === 'texture') {
-      stable && parsedObject.textures.push({ uri });
-      !stable && variableTextures.push({ uri });
-    }
-  });
-
-  if (variableTextures.length > 0) {
-    const variableTexture = variableTextures[textureIndex || 0] || [];
-    parsedObject.textures.push(variableTexture);
-  }
-
   if (localUris?.animationName) {
     parsedObject.animationName = localUris?.animationName;
   }
 
   localUris?.forEach((item) => {
-    if (item.type !== 'texture') {
+    if (item.type === 'texture') {
+      item.stable && parsedObject.textures.push({ uri: item.uri });
+      !item.stable && variableTextures.push({ uri: item.uri });
+    } else {
       parsedObject[item.type] = {
         chromaKeyFilteredVideo: item?.chromaKeyFilteredVideo,
         color: item?.color,
@@ -52,6 +43,11 @@ export const objectParser = async ({ item, setObject, setIsLoading, onPress }) =
       };
     }
   });
+
+  if (variableTextures.length > 0) {
+    const variableTexture = variableTextures[textureIndex || 0] || [];
+    parsedObject.textures.push(variableTexture);
+  }
 
   if (!parsedObject?.textures?.length || !parsedObject?.vrx) {
     return Alert.alert(

--- a/src/helpers/augmentedReality/objectParser.js
+++ b/src/helpers/augmentedReality/objectParser.js
@@ -4,14 +4,10 @@ import { texts } from '../../config';
 
 import { multipleSceneIndexGenerator } from './multipleSceneIndexGenerator';
 
-export const objectParser = async ({ item, setObject, setIsLoading, onPress }) => {
+export const objectParser = async ({ payload, setObject, setIsLoading, onPress }) => {
   const parsedObject = { textures: [] };
 
-  const { localUris } = multipleSceneIndexGenerator({
-    scenes: item?.payload?.scenes,
-    startDate: item?.payload?.startDate,
-    timePeriodInDays: item?.payload?.timePeriodInDays
-  });
+  const { localUris } = multipleSceneIndexGenerator(payload);
 
   if (localUris?.animationName) {
     parsedObject.animationName = localUris?.animationName;

--- a/src/helpers/augmentedReality/objectParser.js
+++ b/src/helpers/augmentedReality/objectParser.js
@@ -8,14 +8,14 @@ export const objectParser = async ({ item, setObject, setIsLoading, onPress }) =
   const parsedObject = { textures: [] };
   const variableTextures = [];
 
-  const { modalIndex, textureIndex } = multipleSceneIndexGenerator({
+  const { modelIndex, textureIndex } = multipleSceneIndexGenerator({
     startDate: item?.payload?.startDate,
     timePeriodInDays: item?.payload?.timePeriodInDays,
     scenes: item?.payload?.scenes
   });
 
   const localUris =
-    item?.payload?.scenes?.[modalIndex]?.localUris || item?.payload?.scenes?.[0]?.localUris;
+    item?.payload?.scenes?.[modelIndex]?.localUris || item?.payload?.scenes?.[0]?.localUris;
 
   localUris.filter(({ stable, uri, type }) => {
     if (type === 'texture') {

--- a/src/helpers/augmentedReality/objectParser.js
+++ b/src/helpers/augmentedReality/objectParser.js
@@ -1,0 +1,62 @@
+import { multipleSceneIndexGenerator } from './multipleSceneIndexGenerator';
+
+export const objectParser = async ({ item, setObject, setIsLoading, onPress }) => {
+  const parsedObject = { textures: [] };
+  const variableTextures = [];
+
+  const { modalIndex, textureIndex } = await multipleSceneIndexGenerator({
+    startDate: item?.payload?.startDate,
+    timePeriodInDays: item?.payload?.timePeriodInDays,
+    scenes: item?.payload?.scenes
+  });
+
+  const localUris =
+    item?.payload?.scenes?.[modalIndex]?.localUris || item?.payload?.scenes?.[0]?.localUris;
+
+  localUris.filter(
+    ({ stable, uri, type }) => stable && type === 'texture' && parsedObject.textures.push({ uri })
+  );
+
+  // combine stable textures with variable textures
+  if (typeof modalIndex === 'number' && typeof textureIndex === 'number') {
+    localUris.filter(
+      ({ stable, uri, type }) => !stable && type === 'texture' && variableTextures.push({ uri })
+    );
+    parsedObject.textures.push(variableTextures[textureIndex || 0] || []);
+  }
+
+  if (localUris?.animationName) {
+    parsedObject.animationName = localUris?.animationName;
+  }
+
+  localUris?.forEach((item) => {
+    if (item.type !== 'texture') {
+      parsedObject[item.type] = {
+        chromaKeyFilteredVideo: item?.chromaKeyFilteredVideo,
+        color: item?.color,
+        intensity: item?.intensity,
+        isSpatialSound: item?.isSpatialSound,
+        maxDistance: item?.maxDistance,
+        minDistance: item?.minDistance,
+        physicalWidth: item?.physicalWidth,
+        position: item?.position,
+        rolloffModel: item?.rolloffModel,
+        rotation: item?.rotation,
+        scale: item?.scale,
+        temperature: item?.temperature,
+        uri: item?.uri
+      };
+    }
+  });
+
+  if (!parsedObject?.textures?.length || !parsedObject?.vrx) {
+    return Alert.alert(
+      texts.augmentedReality.modalHiddenAlertTitle,
+      texts.augmentedReality.invalidModelError,
+      [{ text: texts.augmentedReality.ok, onPress }]
+    );
+  }
+
+  setObject(JSON.parse(JSON.stringify(parsedObject)));
+  setIsLoading(false);
+};

--- a/src/screens/augmentedReality/ARShowScreen.js
+++ b/src/screens/augmentedReality/ARShowScreen.js
@@ -1,10 +1,14 @@
 import { ViroARSceneNavigator } from '@viro-community/react-viro';
+import moment from 'moment';
+import { extendMoment } from 'moment-range';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Alert, Animated, StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { AugmentedRealityView, LoadingSpinner } from '../../components';
 import { colors, Icon, normalize, texts } from '../../config';
+
+const extendedMoment = extendMoment(moment);
 
 export const ARShowScreen = ({ navigation, route }) => {
   const [isLoading, setIsLoading] = useState(true);
@@ -111,6 +115,38 @@ export const ARShowScreen = ({ navigation, route }) => {
     </>
   );
 };
+
+/**
+ * index creation function for model and texture
+ *
+ * @param {string} startDate           start date of the model
+ * @param {number} timePeriodInDays    time period in days of the model
+ * @param {array}  scenes              array of models
+ *
+ * @return {object} both parsed values as an object, like { modalIndex: 1, textureIndex: 1 }
+ */
+const multipleSceneIndexGenerator = async ({ startDate, timePeriodInDays, scenes }) =>
+  new Promise((resolve) => {
+    let modalIndex, textureIndex;
+
+    /* all models must have the same number of variable textures. Therefore, in order to obtain the 
+       number of textures, the textures of the first model were calculated. */
+    if (scenes.length > 1) {
+      const today = new Date(),
+        differenceDate = extendedMoment.range(startDate, today).diff('days'),
+        textureCount = scenes[0]?.localUris?.filter(
+          ({ type, stable }) => !stable && type === 'texture'
+        )?.length,
+        texture = Math.floor(differenceDate / timePeriodInDays),
+        modalCount = scenes.length,
+        modal = Math.floor(texture / textureCount);
+
+      modalIndex = modal % modalCount;
+      textureIndex = texture % textureCount;
+    }
+
+    resolve({ modalIndex, textureIndex });
+  });
 
 const objectParser = async ({ item, setObject, setIsLoading, onPress }) => {
   const parsedObject = { texture: [] };

--- a/src/screens/augmentedReality/ARShowScreen.js
+++ b/src/screens/augmentedReality/ARShowScreen.js
@@ -42,7 +42,7 @@ export const ARShowScreen = ({ navigation, route }) => {
 
   useEffect(() => {
     objectParser({
-      item: data?.[index],
+      payload: data?.[index]?.payload,
       setObject,
       setIsLoading,
       onPress: () => navigation.goBack()


### PR DESCRIPTION
- added `multipleSceneIndexGenerator` to calculate texture and model indexes for a model containing more than one scene
- added moment-range package to measure day difference
- added stable key to `downloadObject` helper to save stable textures coming from server
- added selecting the required model from the scenes array with the index information from the `multipleSceneIndexGenerator` function
- added the required texture data to the newly created `variableTextures` array after the `modalIndex` and `textureIndex` data have the number type and added to the `parsedObject.textures` array
- renamed the `texture` array to `textures` for clarity
- changed the `multipleSceneIndexGenerator` function to `void` format as there is no need for `async/await` function
- filtering the texture files in a single loop because two different loops are too many
- added to `parsedObject.textures` in case there is an item in the `variableTextures` array

SVA-565


⚠️ use the following procedure to test the function ⚠️



- download the [dummyData.js](https://github.com/ikuseiGmbH/smart-village-app-app/files/10115149/dummyData.js.zip) file to test.
- add `tourStops: dummyData` as a prop inside the `AugmentedReality` component in `Tour.js`
-  add the following code blog inside the `parsedObject` inside `ARShowScreen`
```
console.warn({
    modelIndex,
    textureIndex,
    variableTextures: variableTextures[textureIndex || 0] || [],
    parsedObject: JSON.parse(JSON.stringify(parsedObject))
  });
```
- this code blog will only give you an idea whether the function is working correctly or not. Since there is no `vrx` file inside the `dummyData`, the `AugmentedReality` object will not be visible.

