### PR TITLE
feat(ar): make the sound infinite loop

### DIFF
--- a/src/components/augmentedReality/AugmentedRealityView.js
+++ b/src/components/augmentedReality/AugmentedRealityView.js
@@ -87,13 +87,7 @@ export const AugmentedRealityView = ({ sceneNavigator }) => {
 
 // eslint-disable-next-line complexity
 const ViroSoundAnd3DObject = (item) => {
-  const {
-    isObjectLoading,
-    setIsObjectLoading,
-    isStartAnimationAndSound,
-    setIsStartAnimationAndSound,
-    object
-  } = item;
+  const { isObjectLoading, setIsObjectLoading, isStartAnimationAndSound, object } = item;
 
   if (object?.mp4) {
     // if the `chromaKeyFilteredVideo` prop is undefined, the default color of a green screen is set
@@ -113,7 +107,7 @@ const ViroSoundAnd3DObject = (item) => {
               <ViroSpatialSound
                 source={{ uri: object?.mp3?.uri }}
                 paused={!isStartAnimationAndSound}
-                onFinish={() => setIsStartAnimationAndSound(false)}
+                loop
                 maxDistance={object?.mp3?.maxDistance}
                 minDistance={object?.mp3?.minDistance}
                 position={object?.mp3?.position}
@@ -123,7 +117,7 @@ const ViroSoundAnd3DObject = (item) => {
               <ViroSound
                 source={{ uri: object?.mp3?.uri }}
                 paused={!isStartAnimationAndSound}
-                onFinish={() => setIsStartAnimationAndSound(false)}
+                loop
               />
             ))}
 


### PR DESCRIPTION
- added `loop` prop to `ViroSound` and `ViroSpatialSound` component for unlimited looping
- deleted the `onFinish` function in the `ViroSound` and `ViroSpatialSound` component to prevent the audio file from being stopped after finishing

SVA-565