### PR TITLE
feature(ar): show multiple models in one scene

### DIFF
--- a/src/components/augmentedReality/AugmentedRealityView.js
+++ b/src/components/augmentedReality/AugmentedRealityView.js
@@ -93,7 +93,7 @@ const ViroSoundAnd3DObject = (item) => {
     // if the `chromaKeyFilteredVideo` prop is undefined, the default color of a green screen is set
     ViroMaterials.createMaterials({
       chromaKeyFilteredVideo: {
-        chromaKeyFilteringColor: object?.mp4?.chromaKeyFilteredVideo || '#00FF00'
+        chromaKeyFilteringColor: object.mp4?.chromaKeyFilteredVideo || '#00FF00'
       }
     });
   }
@@ -103,19 +103,19 @@ const ViroSoundAnd3DObject = (item) => {
       {!isObjectLoading && (
         <>
           {!!object?.mp3 &&
-            (object?.mp3?.isSpatialSound ? (
+            (object.mp3?.isSpatialSound ? (
               <ViroSpatialSound
-                source={{ uri: object?.mp3?.uri }}
+                source={{ uri: object.mp3?.uri }}
                 paused={!isStartAnimationAndSound}
                 loop
-                maxDistance={object?.mp3?.maxDistance}
-                minDistance={object?.mp3?.minDistance}
-                position={object?.mp3?.position}
-                rolloffModel={object?.mp3?.rolloffModel}
+                maxDistance={object.mp3?.maxDistance}
+                minDistance={object.mp3?.minDistance}
+                position={object.mp3?.position}
+                rolloffModel={object.mp3?.rolloffModel}
               />
             ) : (
               <ViroSound
-                source={{ uri: object?.mp3?.uri }}
+                source={{ uri: object.mp3?.uri }}
                 paused={!isStartAnimationAndSound}
                 loop
               />
@@ -125,26 +125,26 @@ const ViroSoundAnd3DObject = (item) => {
             <ViroVideo
               loop
               materials={['chromaKeyFilteredVideo']}
-              position={object?.mp4?.position}
-              rotation={object?.mp4?.rotation}
-              scale={object?.mp4?.scale}
-              source={{ uri: object?.mp4?.uri }}
+              position={object.mp4?.position}
+              rotation={object.mp4?.rotation}
+              scale={object.mp4?.scale}
+              source={{ uri: object.mp4?.uri }}
             />
           )}
 
           {!!object?.image && (
             <ViroImage
-              position={object?.image?.position}
-              rotation={object?.image?.rotation}
-              scale={object?.image?.scale}
-              source={{ uri: object?.image?.uri }}
+              position={object.image?.position}
+              rotation={object.image?.rotation}
+              scale={object.image?.scale}
+              source={{ uri: object.image?.uri }}
             />
           )}
         </>
       )}
 
-      {!!object?.models &&
-        !!object?.textures &&
+      {!!object?.models?.length &&
+        !!object?.textures?.length &&
         object.models.map((model, index) => (
           <Viro3DObject
             key={index}

--- a/src/components/augmentedReality/AugmentedRealityView.js
+++ b/src/components/augmentedReality/AugmentedRealityView.js
@@ -143,22 +143,27 @@ const ViroSoundAnd3DObject = (item) => {
         </>
       )}
 
-      <Viro3DObject
-        source={{ uri: object?.vrx?.uri }}
-        resources={object?.textures}
-        type="VRX"
-        position={object?.vrx?.position}
-        rotation={object?.vrx?.rotation}
-        scale={object?.vrx?.scale}
-        onLoadStart={() => setIsObjectLoading(true)}
-        onLoadEnd={() => setIsObjectLoading(false)}
-        onError={() => alert(texts.augmentedReality.arShowScreen.objectLoadErrorAlert)}
-        animation={{
-          loop: true,
-          name: object?.animationName,
-          run: isStartAnimationAndSound
-        }}
-      />
+      {!!object?.models &&
+        !!object?.textures &&
+        object.models.map((model, index) => (
+          <Viro3DObject
+            key={index}
+            source={{ uri: model.uri }}
+            resources={object.textures}
+            type="VRX"
+            position={model.position}
+            rotation={model.rotation}
+            scale={model.scale}
+            onLoadStart={() => setIsObjectLoading(true)}
+            onLoadEnd={() => setIsObjectLoading(false)}
+            onError={() => alert(texts.augmentedReality.arShowScreen.objectLoadErrorAlert)}
+            animation={{
+              loop: true,
+              name: object?.animationName,
+              run: isStartAnimationAndSound
+            }}
+          />
+        ))}
     </>
   );
 };

--- a/src/helpers/augmentedReality/multipleSceneIndexGenerator.ts
+++ b/src/helpers/augmentedReality/multipleSceneIndexGenerator.ts
@@ -4,7 +4,25 @@ import { extendMoment } from 'moment-range';
 
 const extendedMoment = extendMoment(moment);
 
-type TScenes = { localUris: Array<{ type: string; stable: boolean }> };
+type TTextures = Array<{ size: number; stable: boolean; title: string; type: string; uri: string }>;
+type TModels = Array<{
+  position?: number[];
+  rotation?: number[];
+  scale?: number[];
+  size?: number;
+  title?: string;
+  type: string;
+  uri: string;
+}>;
+type TScenes = {
+  localUris: Array<{
+    models?: TModels;
+    stable?: boolean;
+    textures?: TTextures;
+    type?: string;
+    uri?: string;
+  }>;
+};
 type TGenerator = { startDate?: Date; timePeriodInDays?: number; scenes: Array<TScenes> };
 
 /**
@@ -24,22 +42,18 @@ export const multipleSceneIndexGenerator = ({
   let modelIndex = 0;
   const scenesCount = scenes?.length;
   let localUris = scenes?.[modelIndex]?.localUris;
+  const models: TModels = [];
+  const textures: TTextures = [];
 
   // if we have multiple scenes, we want to calculate the model and texture based on the current day
   // compared to the `startDate`
   if (scenesCount > 1 && startDate && timePeriodInDays) {
     // all models must have the same number of variable textures. therefore, in order to obtain the
     // number of textures, the textures of the first model were calculated.
-    const variableTextures = scenes[0]?.localUris?.filter(
+    let variableTextures = scenes[0]?.localUris?.filter(
       ({ type, stable }) => type === 'texture' && !stable
     );
     const variableTexturesCount = variableTextures?.length;
-
-    if (!variableTexturesCount) {
-      // nothing to do if there are no unstable textures
-      // keep original localUris with modelIndex = 0
-      return { localUris };
-    }
 
     const today = new Date();
     // the current day number is the number of running days since the given start date
@@ -47,13 +61,54 @@ export const multipleSceneIndexGenerator = ({
     const texture = Math.floor(currentDayNumber / timePeriodInDays);
     const model = Math.floor(texture / variableTexturesCount);
     modelIndex = model % scenesCount;
-    const textureIndex = texture % variableTexturesCount;
-    const variableTexture = variableTextures?.[textureIndex];
+
+    // When VariableTextures are created, they are created according to index 0 of the scene array.
+    // Once the modelIndex is found, it must be updated to select the correct texture file.
+    variableTextures = scenes[modelIndex]?.localUris?.filter(
+      ({ type, stable }) => type === 'texture' && !stable
+    );
     localUris = scenes?.[modelIndex]?.localUris;
+    const textureIndex = texture % variableTexturesCount;
+    const variableTexture = variableTextures[textureIndex];
 
-    _remove(localUris, ({ type, stable }) => type === 'texture' && !stable);
+    localUris.forEach((item) => {
+      switch (item.type) {
+        case 'vrx':
+          models.push(item as TModels[0]);
+          break;
+        case 'texture':
+          if (item.stable) {
+            textures.push(item as TTextures[0]);
+            !!variableTexture && textures.push(variableTexture as TTextures[0]);
+          }
+          break;
+        default:
+          break;
+      }
+    });
 
-    !!variableTexture && localUris.push(variableTexture);
+    _remove(localUris, ({ type }) => type === 'texture' || type === 'vrx');
+
+    localUris.push({ models, textures });
+  } else {
+    scenes.forEach(({ localUris: multiModelLocalUris }) => {
+      multiModelLocalUris.forEach((item) => {
+        switch (item.type) {
+          case 'vrx':
+            models.push(item as TModels[0]);
+            break;
+          case 'texture':
+            textures.push(item as TTextures[0]);
+            break;
+          default:
+            break;
+        }
+      });
+    });
+
+    _remove(localUris, ({ type }) => type === 'texture' || type === 'vrx');
+
+    localUris.push({ models, textures });
   }
 
   return { localUris };

--- a/src/helpers/augmentedReality/multipleSceneIndexGenerator.ts
+++ b/src/helpers/augmentedReality/multipleSceneIndexGenerator.ts
@@ -50,7 +50,7 @@ export const multipleSceneIndexGenerator = ({
   if (scenesCount > 1 && startDate && timePeriodInDays) {
     // all models must have the same number of variable textures. therefore, in order to obtain the
     // number of textures, the textures of the first model were calculated.
-    let variableTextures = scenes[0]?.localUris?.filter(
+    let variableTextures = scenes[modelIndex]?.localUris?.filter(
       ({ type, stable }) => type === 'texture' && !stable
     );
     const variableTexturesCount = variableTextures?.length;
@@ -64,9 +64,12 @@ export const multipleSceneIndexGenerator = ({
 
     // When VariableTextures are created, they are created according to index 0 of the scene array.
     // Once the modelIndex is found, it must be updated to select the correct texture file.
-    variableTextures = scenes[modelIndex]?.localUris?.filter(
-      ({ type, stable }) => type === 'texture' && !stable
-    );
+    if (modelIndex > 0) {
+      variableTextures = scenes[modelIndex]?.localUris?.filter(
+        ({ type, stable }) => type === 'texture' && !stable
+      );
+    }
+
     localUris = scenes?.[modelIndex]?.localUris;
     const textureIndex = texture % variableTexturesCount;
     const variableTexture = variableTextures[textureIndex];

--- a/src/helpers/augmentedReality/objectParser.js
+++ b/src/helpers/augmentedReality/objectParser.js
@@ -5,7 +5,7 @@ import { texts } from '../../config';
 import { multipleSceneIndexGenerator } from './multipleSceneIndexGenerator';
 
 export const objectParser = async ({ payload, setObject, setIsLoading, onPress }) => {
-  const parsedObject = { textures: [] };
+  const parsedObject = { textures: [], models: [] };
 
   const { localUris } = multipleSceneIndexGenerator(payload);
 
@@ -14,28 +14,26 @@ export const objectParser = async ({ payload, setObject, setIsLoading, onPress }
   }
 
   localUris?.forEach((item) => {
-    if (item.type === 'texture') {
-      parsedObject.textures.push({ uri: item.uri });
-    } else {
-      parsedObject[item.type] = {
-        chromaKeyFilteredVideo: item?.chromaKeyFilteredVideo,
-        color: item?.color,
-        intensity: item?.intensity,
-        isSpatialSound: item?.isSpatialSound,
-        maxDistance: item?.maxDistance,
-        minDistance: item?.minDistance,
-        physicalWidth: item?.physicalWidth,
-        position: item?.position,
-        rolloffModel: item?.rolloffModel,
-        rotation: item?.rotation,
-        scale: item?.scale,
-        temperature: item?.temperature,
-        uri: item?.uri
-      };
-    }
+    parsedObject.models = item?.models;
+    parsedObject.textures = item?.textures;
+    parsedObject[item.type] = {
+      chromaKeyFilteredVideo: item?.chromaKeyFilteredVideo,
+      color: item?.color,
+      intensity: item?.intensity,
+      isSpatialSound: item?.isSpatialSound,
+      maxDistance: item?.maxDistance,
+      minDistance: item?.minDistance,
+      physicalWidth: item?.physicalWidth,
+      position: item?.position,
+      rolloffModel: item?.rolloffModel,
+      rotation: item?.rotation,
+      scale: item?.scale,
+      temperature: item?.temperature,
+      uri: item?.uri
+    };
   });
 
-  if (!parsedObject?.textures?.length || !parsedObject?.vrx) {
+  if (!parsedObject?.textures?.length || !parsedObject?.models?.length) {
     return Alert.alert(
       texts.augmentedReality.modalHiddenAlertTitle,
       texts.augmentedReality.invalidModelError,

--- a/src/helpers/augmentedReality/objectParser.js
+++ b/src/helpers/augmentedReality/objectParser.js
@@ -7,15 +7,18 @@ import { multipleSceneIndexGenerator } from './multipleSceneIndexGenerator';
 export const objectParser = async ({ payload, setObject, setIsLoading, onPress }) => {
   const parsedObject = { textures: [], models: [] };
 
-  const { localUris } = multipleSceneIndexGenerator(payload);
+  const { localUris, models, textures } = multipleSceneIndexGenerator(payload);
 
   if (payload?.animationName) {
     parsedObject.animationName = payload.animationName;
   }
 
+  if (models.length && textures.length) {
+    parsedObject.models = models;
+    parsedObject.textures = textures;
+  }
+
   localUris?.forEach((item) => {
-    parsedObject.models = item?.models;
-    parsedObject.textures = item?.textures;
     parsedObject[item.type] = {
       chromaKeyFilteredVideo: item?.chromaKeyFilteredVideo,
       color: item?.color,

--- a/src/helpers/augmentedReality/objectParser.js
+++ b/src/helpers/augmentedReality/objectParser.js
@@ -9,8 +9,8 @@ export const objectParser = async ({ payload, setObject, setIsLoading, onPress }
 
   const { localUris } = multipleSceneIndexGenerator(payload);
 
-  if (localUris?.animationName) {
-    parsedObject.animationName = localUris?.animationName;
+  if (payload?.animationName) {
+    parsedObject.animationName = payload.animationName;
   }
 
   localUris?.forEach((item) => {


### PR DESCRIPTION
- added multiple models and textures from the `scene` array to the `models` and `textures` arrays in order to show the models using the map function on the `AugmentedRealityView` screen
- deleted objects according to their types with `_remove` method to prevent unnecessary texture and model information
- creating `variableTextures` based on index 0 of the scene and we were constantly getting variable textures of the model at index 0. To avoid this, `variableTextures` has been updated with `modelIndex`
- deleted the direct return of `localUris` in case `variableTexturesCount` is `false` because we need `models` and `textures` arrays inside `localUris`
- added `models` array in `parsedObject` to parse one or more models
- changed `parsedObject?.vrx` control to `parsedObject?.models?.length` as it can no longer be done
- added to arrays in `parsedObject` since all `models` and `textures` are contained in an array
- added `Viro3DObject` to the map function in `AugmentedRealityView` to show all models inside the models array
- removed extra controls on `AugmentedRealityView` page to improve performance and because they have already been checked

SVA-565

📝 note: with this code, one or more models can be displayed in a scene at the same time. 

‼️ attention! displaying more than one model at the same time may cause RAM problems. ‼️

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode

⚠️ use the following procedure to test the function ⚠️

- download the [dummyData.js](https://github.com/ikuseiGmbH/smart-village-app-app/files/10166934/dummyData.js.zip) file to test.
- extract `dummyData` from zip
- add dummyData into a folder of your choice
- add `tourStops: dummyData` as a prop inside the `AugmentedReality` component in `Tour.js`
- go to any `InternationalerKunstwanderweg` screen from the App
- you can download the model you want from a list of all possible `scenes` in different situations and try it out