### PR TITLE
refactor(noticeboard): add `consentForDataProcessingText` to `listItem`

### DIFF
--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -66,7 +66,7 @@ const parseEventRecords = (data, skipLastDivider, withDate) => {
   }));
 };
 
-const parseGenericItems = (data, skipLastDivider, titleDetail) => {
+const parseGenericItems = (data, skipLastDivider, titleDetail, consentForDataProcessingText) => {
   // this likely needs a rework in the future, but for now this is the place to filter items.
   const filteredData = data?.filter(filterGenericItems);
 
@@ -92,7 +92,7 @@ const parseGenericItems = (data, skipLastDivider, titleDetail) => {
         : ScreenName.Detail,
     params: {
       title: getGenericItemDetailTitle(genericItem.genericType),
-      consentForDataProcessingText: titleDetail || '',
+      consentForDataProcessingText,
       suffix: genericItem.genericType,
       query: QUERY_TYPES.GENERIC_ITEM,
       queryVariables: { id: `${genericItem.id}` },
@@ -372,6 +372,7 @@ const parseConsulData = (data, query, skipLastDivider) => {
  * @param {string | undefined} titleDetail
  * @param {{
  *    bookmarkable?: boolean;
+ *    consentForDataProcessingText?: string;
  *    skipLastDivider?: boolean;
  *    withDate?: boolean,
  *    isSectioned?: boolean,
@@ -385,6 +386,7 @@ export const parseListItemsFromQuery = (query, data, titleDetail, options = {}) 
 
   const {
     bookmarkable = true,
+    consentForDataProcessingText,
     skipLastDivider = false,
     withDate = true,
     isSectioned = false,
@@ -395,7 +397,12 @@ export const parseListItemsFromQuery = (query, data, titleDetail, options = {}) 
     case QUERY_TYPES.EVENT_RECORDS:
       return parseEventRecords(data[query], skipLastDivider, withDate);
     case QUERY_TYPES.GENERIC_ITEMS:
-      return parseGenericItems(data[query], skipLastDivider, titleDetail);
+      return parseGenericItems(
+        data[query],
+        skipLastDivider,
+        titleDetail,
+        consentForDataProcessingText
+      );
     case QUERY_TYPES.NEWS_ITEMS:
       return parseNewsItems(data[query], skipLastDivider, titleDetail, bookmarkable);
     case QUERY_TYPES.POINTS_OF_INTEREST:

--- a/src/screens/Noticeboard/NoticeboardIndexScreen.tsx
+++ b/src/screens/Noticeboard/NoticeboardIndexScreen.tsx
@@ -26,7 +26,8 @@ export const NoticeboardIndexScreen = ({ navigation, route }: StackScreenProps<a
     fetchPolicy,
     variables: queryVariables
   });
-  const listItems = parseListItemsFromQuery(query, data, consentForDataProcessingText, {
+  const listItems = parseListItemsFromQuery(query, data, '', {
+    consentForDataProcessingText,
     queryVariables
   });
 


### PR DESCRIPTION
- added `consentForDataProcessingText` information required for `noticeboard` to options instead of `titleDetail`

SVA-739
