### PR TITLE
fix(static contents): add error if not an object

### DIFF
--- a/src/components/screens/Service.tsx
+++ b/src/components/screens/Service.tsx
@@ -87,7 +87,7 @@ export const Service = ({
   ) : (
     <>
       <WrapperWrap spaceBetween>{tiles?.map(renderItem)}</WrapperWrap>
-      {toggler}
+      {!!tiles?.length && toggler}
     </>
   );
 };

--- a/src/components/screens/ServiceTiles.js
+++ b/src/components/screens/ServiceTiles.js
@@ -26,7 +26,7 @@ export const ServiceTiles = ({
   const { isConnected } = useContext(NetworkContext);
   const [refreshing, setRefreshing] = useState(false);
 
-  const { data, loading, refetch } = useStaticContent({
+  const { data, loading, refetch, error } = useStaticContent({
     refreshTimeKey: `publicJsonFile-${staticJsonName}`,
     name: staticJsonName,
     type: 'json'
@@ -83,7 +83,7 @@ export const ServiceTiles = ({
             )}
 
             <View style={styles.padding}>
-              <Service data={data} staticJsonName={staticJsonName} />
+              {!error && <Service data={data} staticJsonName={staticJsonName} />}
             </View>
           </ScrollView>
         </>

--- a/src/hooks/staticContent.ts
+++ b/src/hooks/staticContent.ts
@@ -1,4 +1,5 @@
 import _isEmpty from 'lodash/isEmpty';
+import _isObjectLike from 'lodash/isObjectLike';
 import { useCallback, useContext, useMemo, useState } from 'react';
 import { useQuery } from 'react-apollo';
 
@@ -81,7 +82,7 @@ export const useStaticContent = <T>({
     try {
       const json = data?.publicJsonFile?.content;
 
-      if (!_isEmpty(json)) {
+      if (!_isEmpty(json) && _isObjectLike(json)) {
         return parseFromJson ? parseFromJson(json) : json;
       } else if (!loading && data) {
         // set error true if there is bad data without `publicJsonFile.content`


### PR DESCRIPTION
static contents can be corrupt if they are not valid jsons after editing on the main server. this could lead to crashes of the application without a proper solution.

- added a json validation with checking of proper object, which results in an error if there is something bad
- added error condition in `ServiceTiles` to not render `Service` if there is an error
- removed rendering of tiles toggler if there are no tiles

SVA-844