### PR TITLE
feat(deadlines): show category in list

### DIFF
--- a/src/helpers/genericTypeHelper.ts
+++ b/src/helpers/genericTypeHelper.ts
@@ -62,3 +62,18 @@ export const getGenericItemMatomoName = (genericType: GenericType): string => {
       return '';
   }
 };
+
+export const getGenericItemSubtitle = (genericItem: {
+  genericType: GenericType;
+  categories: [{ name: string }];
+  dataProvider: { name: string };
+}): string => {
+  switch (genericItem.genericType) {
+    case GenericType.Deadline:
+      return genericItem.categories?.[0]?.name;
+    case GenericType.Noticeboard:
+      return '';
+    default:
+      return genericItem.dataProvider?.name;
+  }
+};

--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -8,7 +8,11 @@ import { colors, consts, Icon, normalize, texts } from '../../config';
 import { QUERY_TYPES } from '../../queries';
 import { GenericType, ScreenName } from '../../types';
 import { eventDate, isBeforeEndOfToday, isTodayOrLater } from '../dateTimeHelper';
-import { getGenericItemDetailTitle, getGenericItemRootRouteName } from '../genericTypeHelper';
+import {
+  getGenericItemDetailTitle,
+  getGenericItemRootRouteName,
+  getGenericItemSubtitle
+} from '../genericTypeHelper';
 import { mainImageOfMediaContents } from '../imageHelper';
 import { momentFormatUtcToLocal } from '../momentHelper';
 import { getTitleForQuery } from '../queryHelper';
@@ -74,7 +78,7 @@ const parseGenericItems = (data, skipLastDivider, titleDetail, consentForDataPro
     id: genericItem.id,
     subtitle: subtitle(
       momentFormatUtcToLocal(genericItem.publicationDate ?? genericItem.createdAt),
-      genericItem.genericType !== GenericType.Noticeboard && genericItem.dataProvider?.name
+      getGenericItemSubtitle(genericItem)
     ),
     title: genericItem.title,
     picture: {


### PR DESCRIPTION
- created helper that returns different values for different generic types respecting the current state for noticeboard entries (empty string) and the fallback of the data provider name

SVA-710

![Simulator Screen Shot - iPhone 13 Pro Max - 2022-12-19 at 16 40 19](https://user-images.githubusercontent.com/1942953/208464425-e05d7ed7-ff3b-4f44-9bb1-ad6c406d7a38.png)
