### PR TITLE
fix(ar): add height to modal

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -10,6 +10,7 @@ import { Touchable } from './Touchable';
 
 export const Modal = ({
   children,
+  height,
   isBackdropPress,
   isListView,
   isVisible,
@@ -24,7 +25,7 @@ export const Modal = ({
       windowBackgroundColor={colors.overlayRgba}
       overlayStyle={!isListView && styles.overlay}
       width="80%"
-      height="auto"
+      height={height}
       borderRadius={8}
       supportedOrientations={['portrait', 'landscape']}
     >
@@ -49,6 +50,7 @@ const styles = StyleSheet.create({
 
 Modal.propTypes = {
   children: PropTypes.node.isRequired,
+  height: PropTypes.string,
   isBackdropPress: PropTypes.bool,
   isListView: PropTypes.bool,
   isVisible: PropTypes.bool.isRequired,
@@ -57,5 +59,6 @@ Modal.propTypes = {
 };
 
 Modal.defaultProps = {
+  height: 'auto',
   modalHiddenButtonName: texts.settingsTitles.arListLayouts.hide
 };

--- a/src/components/augmentedReality/ARModal.js
+++ b/src/components/augmentedReality/ARModal.js
@@ -47,6 +47,7 @@ export const ARModal = ({
   return (
     <Modal
       isListView={isListView}
+      height={isListView && '85%'}
       onModalVisible={() => {
         if (onModalVisible) {
           onModalVisible();


### PR DESCRIPTION
- added height to modal because modal cannot be switched off on small screen phones if there are too many models

SVA-565

## Screenshots:

|before|after|
|--|--|
![IMG_0098](https://user-images.githubusercontent.com/11755668/208725753-48e194aa-0838-4e23-a172-336749584ea3.PNG) | ![IMG_0100](https://user-images.githubusercontent.com/11755668/208725765-d5fefc87-71d3-4393-95db-4d6295a384db.PNG)

