### PR TITLE
feat: add list view property to tiles

### DIFF
--- a/src/components/screens/DraggableList.tsx
+++ b/src/components/screens/DraggableList.tsx
@@ -1,0 +1,60 @@
+import React, { ReactElement } from 'react';
+import Animated, {
+  useAnimatedRef,
+  useAnimatedScrollHandler,
+  useSharedValue
+} from 'react-native-reanimated';
+
+import { normalize } from '../../config';
+
+import { Positions } from './DraggableItem';
+import { DraggableListItem } from './DraggableListItem';
+
+type Props = {
+  children: ReactElement<{ draggableId: string; draggableKey: string }>[];
+  onDragEnd: (diff: Positions) => void;
+};
+
+export const DraggableList = ({ children, onDragEnd }: Props) => {
+  const scrollY = useSharedValue(0);
+  const scrollView = useAnimatedRef<Animated.ScrollView>();
+  const positions = useSharedValue<Positions>(
+    Object.assign(
+      {},
+      ...children.map((child, index) => ({ [child.props.draggableId?.replace('​', '')]: index }))
+    )
+  );
+  const onScroll = useAnimatedScrollHandler({
+    onScroll: ({ contentOffset: { y } }) => {
+      scrollY.value = y;
+    }
+  });
+
+  return (
+    <Animated.ScrollView
+      onScroll={onScroll}
+      ref={scrollView}
+      contentContainerStyle={{
+        height: normalize(80) * children.length,
+        marginHorizontal: normalize(14)
+      }}
+      showsVerticalScrollIndicator={false}
+      showsHorizontalScrollIndicator={false}
+    >
+      {children.map((child) => (
+        <DraggableListItem
+          key={child.props.draggableKey}
+          positions={positions}
+          id={child.props.draggableId}
+          onDragEnd={onDragEnd}
+          scrollView={scrollView}
+          scrollY={scrollY}
+          numberOfTiles={1}
+          tileSize={normalize(80)}
+        >
+          {child}
+        </DraggableListItem>
+      ))}
+    </Animated.ScrollView>
+  );
+};

--- a/src/components/screens/DraggableListItem.tsx
+++ b/src/components/screens/DraggableListItem.tsx
@@ -1,0 +1,195 @@
+import React, { ReactNode, RefObject, useCallback, useContext } from 'react';
+import { StyleSheet } from 'react-native';
+import { PanGestureHandler, PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
+import Animated, {
+  Easing,
+  runOnJS,
+  scrollTo,
+  useAnimatedGestureHandler,
+  useAnimatedReaction,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming
+} from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { colors, device, Icon, normalize } from '../../config';
+import { getHeaderHeight, statusBarHeight } from '../../helpers';
+import { OrientationContext } from '../../OrientationProvider';
+
+export type Positions = {
+  [id: string]: number;
+};
+
+type Props = {
+  children: ReactNode;
+  positions: Animated.SharedValue<Positions>;
+  id: string;
+  onDragEnd: (diffs: Positions) => void;
+  scrollView: RefObject<Animated.ScrollView>;
+  scrollY: Animated.SharedValue<number>;
+  tileSize: number;
+};
+
+const animationConfig = {
+  easing: Easing.inOut(Easing.ease),
+  duration: 350
+};
+
+export const DraggableListItem = ({
+  children,
+  positions,
+  id,
+  onDragEnd,
+  scrollView,
+  scrollY,
+  tileSize
+}: Props) => {
+  const { orientation } = useContext(OrientationContext);
+  const safeAreaInsets = useSafeAreaInsets();
+  const containerHeight =
+    device.height -
+    safeAreaInsets.top -
+    safeAreaInsets.bottom -
+    getHeaderHeight(orientation) -
+    statusBarHeight(orientation);
+
+  const isGestureActive = useSharedValue(false);
+  const contentHeight = Object.keys(positions.value).length * tileSize;
+
+  const getPosition = useCallback(
+    (position: number) => {
+      'worklet';
+      return {
+        x: 0,
+        y: position * tileSize
+      };
+    },
+    [tileSize]
+  );
+
+  const getOrder = useCallback(
+    (ty: number, max: number) => {
+      'worklet';
+      const y = Math.round(ty / tileSize) * tileSize;
+      const row = Math.max(y, 0) / tileSize;
+      return Math.min(row, max);
+    },
+    [tileSize]
+  );
+
+  const position = getPosition(positions.value[id]);
+  const translateY = useSharedValue(position.y);
+
+  useAnimatedReaction(
+    () => positions.value[id],
+    (newOrder) => {
+      if (!isGestureActive.value) {
+        const pos = getPosition(newOrder);
+        translateY.value = withTiming(pos.y, animationConfig);
+      }
+    }
+  );
+
+  const onGestureEvent = useAnimatedGestureHandler<PanGestureHandlerGestureEvent, { y: number }>({
+    onStart: (_, ctx) => {
+      ctx.y = translateY.value;
+    },
+    onActive: ({ translationY }, ctx) => {
+      isGestureActive.value = true;
+      translateY.value = ctx.y + translationY;
+
+      // 1. We calculate where the tile should be
+      const newOrder = getOrder(translateY.value, Object.keys(positions.value).length - 1);
+
+      // 2. We swap the positions
+      const oldOrder = positions.value[id];
+
+      if (newOrder !== oldOrder) {
+        const idToSwap = Object.keys(positions.value).find(
+          (key) => positions.value[key] === newOrder
+        );
+
+        if (idToSwap) {
+          // Spread operator is not supported in worklets
+          // And Object.assign doesn't seem to be working on alpha.6
+          const newPositions = JSON.parse(JSON.stringify(positions.value));
+          newPositions[id] = newOrder;
+          newPositions[idToSwap] = oldOrder;
+          positions.value = newPositions;
+        }
+      }
+
+      // 3. Scroll up and down if necessary
+      const lowerBound = scrollY.value;
+      const upperBound = lowerBound + containerHeight - tileSize;
+      const maxScroll = contentHeight - containerHeight;
+      const leftToScrollDown = maxScroll - scrollY.value;
+
+      if (translateY.value < lowerBound) {
+        const diff = Math.min(lowerBound - translateY.value, lowerBound);
+        scrollY.value -= diff;
+        scrollTo(scrollView, 0, scrollY.value, false);
+        ctx.y -= diff;
+        translateY.value = ctx.y + translationY;
+      }
+
+      if (translateY.value > upperBound) {
+        const diff = Math.min(translateY.value - upperBound, leftToScrollDown);
+        scrollY.value += diff;
+        scrollTo(scrollView, 0, scrollY.value, false);
+        ctx.y += diff;
+        translateY.value = ctx.y + translationY;
+      }
+    },
+    onEnd: () => {
+      const newPosition = getPosition(positions.value[id]);
+
+      translateY.value = withTiming(newPosition.y, animationConfig, () => {
+        isGestureActive.value = false;
+        runOnJS(onDragEnd)(positions.value);
+      });
+    }
+  });
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const zIndex = isGestureActive.value ? 100 : 0;
+    const scale = withSpring(isGestureActive.value ? 1.05 : 1);
+
+    return {
+      height: tileSize,
+      justifyContent: 'center',
+      transform: [{ translateY: translateY.value }, { scale }],
+      width: '100%',
+      zIndex
+    };
+  });
+
+  return (
+    <Animated.View style={[StyleSheet.absoluteFillObject, animatedStyle]}>
+      <Animated.View style={[StyleSheet.absoluteFillObject, styles.draggableItem]}>
+        {children}
+      </Animated.View>
+      <PanGestureHandler enabled onGestureEvent={onGestureEvent}>
+        <Animated.View style={styles.animatedView}>
+          <Icon.About />
+        </Animated.View>
+      </PanGestureHandler>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  animatedView: {
+    alignSelf: 'flex-end',
+    backgroundColor: colors.surface,
+    margin: normalize(10),
+    padding: normalize(5)
+  },
+  draggableItem: {
+    borderColor: colors.borderRgba,
+    borderWidth: 1,
+    margin: normalize(3)
+  }
+});

--- a/src/components/screens/ServiceTile.tsx
+++ b/src/components/screens/ServiceTile.tsx
@@ -2,6 +2,7 @@ import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { ComponentProps, useCallback, useContext, useState } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Divider } from 'react-native-elements';
 import { EdgeInsets, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { colors, consts, device, Icon, IconSet, normalize } from '../../config';
@@ -9,6 +10,8 @@ import { OrientationContext } from '../../OrientationProvider';
 import { Image } from '../Image';
 import { ServiceBox } from '../ServiceBox';
 import { BoldText } from '../Text';
+
+import { LIST_TYPES } from './ServiceTiles';
 
 export type TServiceTile = {
   accessibilityLabel: string;
@@ -29,6 +32,7 @@ export const ServiceTile = ({
   hasDiagonalGradientBackground = false,
   isEditMode = false,
   item,
+  listType,
   onToggleVisibility,
   tileSizeFactor = 1
 }: {
@@ -36,6 +40,7 @@ export const ServiceTile = ({
   hasDiagonalGradientBackground?: boolean;
   isEditMode?: boolean;
   item: TServiceTile;
+  listType?: string;
   onToggleVisibility: (
     toggleableId: string,
     isVisible: boolean,
@@ -57,65 +62,95 @@ export const ServiceTile = ({
   const ToggleVisibilityIcon = isVisible ? Icon.Visible : Icon.Unvisible;
 
   return (
-    <ServiceBox orientation={orientation} dimensions={dimensions} bigTile={!!item.tile}>
-      <TouchableOpacity
-        onPress={onPress}
-        accessibilityLabel={
-          item.accessibilityLabel
-            ? `(${item.accessibilityLabel}) ${consts.a11yLabel.button}`
-            : undefined
-        }
-      >
-        {isEditMode && (
-          <ToggleVisibilityIcon
-            color={colors.placeholder}
-            size={normalize(20)}
-            style={[styles.toggleVisibilityIcon, !!item.tile && styles.toggleVisibilityIconBigTile]}
-          />
-        )}
-        <View style={!isVisible && styles.invisible}>
-          {item.iconName ? (
-            <Icon.NamedIcon
-              color={hasDiagonalGradientBackground ? colors.lightestText : undefined}
-              name={item.iconName}
-              size={normalize(30)}
-              style={styles.serviceIcon}
-            />
-          ) : (
-            <Image
-              source={{ uri: item.icon || item.tile }}
-              childrenContainerStyle={[
-                styles.serviceImage,
-                !!item.tile &&
-                  stylesWithProps({
-                    tileSizeFactor,
-                    orientation,
-                    safeAreaInsets
-                  }).bigTile
+    <>
+      <ServiceBox orientation={orientation} dimensions={dimensions} bigTile={!!item.tile}>
+        <TouchableOpacity
+          onPress={onPress}
+          accessibilityLabel={
+            item.accessibilityLabel
+              ? `(${item.accessibilityLabel}) ${consts.a11yLabel.button}`
+              : undefined
+          }
+        >
+          {isEditMode && listType === LIST_TYPES.grid && (
+            <ToggleVisibilityIcon
+              color={colors.placeholder}
+              size={normalize(20)}
+              style={[
+                styles.toggleVisibilityIcon,
+                !!item.tile && styles.toggleVisibilityIconBigTile
               ]}
-              PlaceholderContent={null}
-              resizeMode="contain"
             />
           )}
-          {!!item.title && (
-            <BoldText
-              small
-              lightest={hasDiagonalGradientBackground}
-              primary={!hasDiagonalGradientBackground}
-              center
-              accessibilityLabel={`(${item.title}) ${consts.a11yLabel.button}`}
-            >
-              {item.title}
-            </BoldText>
-          )}
-        </View>
-      </TouchableOpacity>
-    </ServiceBox>
+          <View
+            style={[
+              !isVisible && styles.invisible,
+              listType === LIST_TYPES.list && [styles.listContainer, styles.margin]
+            ]}
+          >
+            <View style={[listType === LIST_TYPES.list && styles.listContainer]}>
+              {isEditMode && listType === LIST_TYPES.list && (
+                <ToggleVisibilityIcon color={colors.placeholder} size={normalize(20)} />
+              )}
+
+              {item.iconName ? (
+                <Icon.NamedIcon
+                  color={hasDiagonalGradientBackground ? colors.lightestText : undefined}
+                  name={item.iconName}
+                  size={normalize(30)}
+                  style={[
+                    styles.serviceIcon,
+                    listType === LIST_TYPES.list && isEditMode && styles.margin
+                  ]}
+                />
+              ) : (
+                <Image
+                  source={{ uri: item.icon || item.tile }}
+                  childrenContainerStyle={[
+                    styles.serviceImage,
+                    !!item.tile &&
+                      stylesWithProps({
+                        tileSizeFactor,
+                        orientation,
+                        safeAreaInsets
+                      }).bigTile
+                  ]}
+                  PlaceholderContent={null}
+                  resizeMode="contain"
+                />
+              )}
+              {!!item.title && (
+                <BoldText
+                  small
+                  lightest={hasDiagonalGradientBackground}
+                  primary={!hasDiagonalGradientBackground}
+                  center={listType === LIST_TYPES.grid}
+                  accessibilityLabel={`(${item.title}) ${consts.a11yLabel.button}`}
+                  style={listType === LIST_TYPES.list && [styles.margin]}
+                >
+                  {item.title}
+                </BoldText>
+              )}
+            </View>
+            {listType === LIST_TYPES.list && !isEditMode && <Icon.ArrowRight />}
+          </View>
+        </TouchableOpacity>
+      </ServiceBox>
+      {listType === LIST_TYPES.list && !isEditMode && <Divider />}
+    </>
   );
 };
 /* eslint-enable complexity */
 
 const styles = StyleSheet.create({
+  listContainer: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between'
+  },
+  margin: {
+    marginLeft: normalize(14)
+  },
   serviceIcon: {
     alignSelf: 'center',
     paddingVertical: normalize(7.5)

--- a/src/config/Icon.tsx
+++ b/src/config/Icon.tsx
@@ -168,6 +168,7 @@ export const Icon = {
   ExpandMap: (props: IconProps) => <NamedIcon name="maximize" {...props} />,
   Filter: (props: IconProps) => <SvgIcon xml={filter} {...props} />,
   GPS: (props: IconProps) => <SvgIcon xml={gps} {...props} />,
+  Grid: (props: IconProps) => <NamedIcon name="grid-dots" {...props} />,
   Home: (props: IconProps) => <SvgIcon xml={home} {...props} />,
   HeartEmpty: (props: IconProps) => <SvgIcon xml={heartEmpty} {...props} />,
   HeartFilled: (props: IconProps) => <SvgIcon xml={heartFilled} {...props} />,

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -866,6 +866,7 @@ export const texts = {
     weather: 'Wetter'
   },
   serviceTiles: {
+    listEdit: 'Liste bearbeiten',
     done: 'Fertig',
     edit: 'Kacheln bearbeiten'
   },

--- a/src/screens/TilesScreen.js
+++ b/src/screens/TilesScreen.js
@@ -6,13 +6,14 @@ import { useMatomoTrackScreenView } from '../hooks';
 import { SettingsContext } from '../SettingsProvider';
 
 export const getTilesScreen = ({
+  hasDiagonalGradientBackground,
+  imageKey,
+  isEditMode,
+  listType,
   matomoString,
   staticJsonName,
   titleFallback,
-  titleKey,
-  imageKey,
-  hasDiagonalGradientBackground,
-  isEditMode
+  titleKey
 }) => {
   const TilesScreen = () => {
     const { globalSettings } = useContext(SettingsContext);
@@ -23,11 +24,12 @@ export const getTilesScreen = ({
 
     return (
       <ServiceTiles
+        hasDiagonalGradientBackground={hasDiagonalGradientBackground}
+        image={image}
+        isEditMode={isEditMode}
+        listTypeProp={listType}
         staticJsonName={staticJsonName}
         title={title}
-        image={image}
-        hasDiagonalGradientBackground={hasDiagonalGradientBackground}
-        isEditMode={isEditMode}
       />
     );
   };


### PR DESCRIPTION
- added list view feature for tile screen
- added `listType` state to `ServiceTiles` to specify the listing type
- added `Divider` to add a line between rows in list view
- added `DraggableList` and `DraggableListItem` so that the list can be personalized while in list view
- used `staticJsonName` to set the list view separately according to different tile contents
- saved the selected list type on the device so that the user is in the selected list view after closing and reopening the app after setting the list type

|tile view|list view|personalized tile view|personalized list view|big tile view (no list view option)|
|--|--|--|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2024-11-26 at 09 34 11](https://github.com/user-attachments/assets/c1adbdfb-7d80-4aaa-a609-17ecdddd41b6)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-11-26 at 09 34 14](https://github.com/user-attachments/assets/1f6964c8-ac22-447f-85a0-00637534720c)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-11-26 at 09 34 22](https://github.com/user-attachments/assets/02e801da-a002-4e18-9fbc-3e78cebdb592)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-11-26 at 09 34 31](https://github.com/user-attachments/assets/05da7bb5-b2a4-43a0-b5f2-4cdc35086c20)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-11-26 at 09 34 38](https://github.com/user-attachments/assets/3173fb62-b77d-499b-a45e-0528884efbfb)
