### PR TITLE
fix(onboarding): screen reader not working for buttons

### DIFF
--- a/src/screens/AppIntroScreen.tsx
+++ b/src/screens/AppIntroScreen.tsx
@@ -447,18 +447,16 @@ const styles = StyleSheet.create({
   skipButton: {
     backgroundColor: colors.transparent,
     borderColor: colors.borderRgba,
-    borderWidth: normalize(1),
-    bottom: normalize(72)
+    borderWidth: normalize(1)
   },
   sliderButtonContainer: {
     alignItems: 'center',
     alignSelf: 'center',
     backgroundColor: colors.primary,
     borderRadius: normalize(8),
-    bottom: normalize(128),
     height: normalize(32),
     justifyContent: 'center',
-    position: 'absolute',
+    marginBottom: normalize(16),
     width: normalize(144)
   },
   sliderButtonDisabled: {


### PR DESCRIPTION
With this PR, it fixes the problem that the screen reader feature of the Android OS cannot recognize the buttons on the `OnboardingScreen`.

|before|after|
|--|--|
<img width="295" height="640" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-08 at 09 52 03" src="https://github.com/user-attachments/assets/66e5dc5f-f492-4e65-a9a6-c849e9c0b0c5" />|<img width="295" height="640" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-08 at 09 51 57" src="https://github.com/user-attachments/assets/70dadf20-3238-44b2-a856-e25d79acf59d" />

SVA-1457