### PR TITLE
fix(map): adjust callout position for Android

### DIFF
--- a/src/components/map/MapLibre.tsx
+++ b/src/components/map/MapLibre.tsx
@@ -16,7 +16,7 @@ import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { featureCollection, point } from '@turf/helpers';
 import { LocationObject, LocationObjectCoords } from 'expo-location';
 import React, { useContext, useEffect, useRef, useState } from 'react';
-import { StyleProp, StyleSheet, TouchableOpacity, View, ViewStyle } from 'react-native';
+import { Platform, StyleProp, StyleSheet, TouchableOpacity, View, ViewStyle } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -553,7 +553,12 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     marginBottom: normalize(150),
     width: 'auto',
-    zIndex: 9999999
+    zIndex: 9999999,
+    ...Platform.select({
+      android: {
+        position: 'absolute'
+      }
+    })
   },
   calloutContent: {
     backgroundColor: colors.surface,


### PR DESCRIPTION
This PR fixes the issue where callout text does not appear on the SUE report screen on the Android platform.

|before|after|
|--|--|
<img width="285" height="640" alt="Screenshot_1759330812" src="https://github.com/user-attachments/assets/072c2e5b-1d09-44ae-83ea-4fcace0e843b" />|<img width="285" height="640" alt="Screenshot_1759330802" src="https://github.com/user-attachments/assets/4e67bd00-f245-4f91-a95b-c5aadf99d948" />


SVA-1365