### PR TITLE
feat: enhance navigation handling in `Navigator` and `MapLibre`

### DIFF
--- a/src/components/map/MapLibre.tsx
+++ b/src/components/map/MapLibre.tsx
@@ -38,6 +38,7 @@ import { SettingsContext } from '../../SettingsProvider';
 import { MapMarker } from '../../types';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { BoldText, RegularText } from '../Text';
+import { NavigationType } from '../../navigation/Navigator';
 
 const { a11yLabel, MAP } = consts;
 
@@ -149,7 +150,7 @@ export const MapLibre = ({
   ...otherProps
 }: Props) => {
   const { globalSettings } = useContext(SettingsContext);
-  const { settings = {} } = globalSettings;
+  const { settings = {}, navigation = NavigationType.TAB } = globalSettings;
   const { locationService = {} } = settings;
   const {
     clusterCircleColor,
@@ -200,7 +201,8 @@ export const MapLibre = ({
   const mapPressTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const hasInitialFitRef = useRef(false);
   const { bottom: safeAreaBottom } = useSafeAreaInsets();
-  const bottomTabBarHeight = useBottomTabBarHeight();
+  const tabBarHeight = useSafeBottomTabBarHeight();
+  const bottomTabBarHeight = navigation === NavigationType.TAB ? tabBarHeight : 0;
 
   let initialRegion: Partial<LocationObjectCoords> = {
     latitude: 51.1657,

--- a/src/config/navigation/config.ts
+++ b/src/config/navigation/config.ts
@@ -3,10 +3,11 @@ import * as Linking from 'expo-linking';
 
 import { NavigatorConfig, ScreenName } from '../../types';
 import { consts } from '../consts';
+import { NavigationType } from '../../navigation/Navigator';
 
 const { HOST_NAMES } = consts;
 
-export const navigationConfig = (navigationType: 'drawer' | 'tab') => {
+export const navigationConfig = (navigationType: NavigationType) => {
   let navigatorConfig: NavigatorConfig;
   const linkingConfig: LinkingOptions<{}> = {
     prefixes: [Linking.createURL('/')]
@@ -17,12 +18,12 @@ export const navigationConfig = (navigationType: 'drawer' | 'tab') => {
     [ScreenName.Home]: '*'
   };
 
-  if (navigationType != 'drawer') {
+  if (navigationType != NavigationType.DRAWER) {
     // TODO: needs to be the index of the tab config where in-app links should navigate in
     const index = 0;
 
     navigatorConfig = {
-      type: 'tab'
+      type: NavigationType.TAB
     };
 
     linkingConfig.config = {
@@ -38,7 +39,7 @@ export const navigationConfig = (navigationType: 'drawer' | 'tab') => {
     };
   } else {
     navigatorConfig = {
-      type: 'drawer'
+      type: NavigationType.DRAWER
     };
 
     linkingConfig.config = {

--- a/src/navigation/Navigator.tsx
+++ b/src/navigation/Navigator.tsx
@@ -8,7 +8,12 @@ import { navigationConfig } from '../config/navigation';
 import { DrawerNavigator } from './DrawerNavigator';
 import { MainTabNavigator } from './MainTabNavigator';
 
-export const Navigator = ({ navigationType }: { navigationType: 'drawer' | 'tab' }) => {
+export enum NavigationType {
+  DRAWER = 'drawer',
+  TAB = 'tab'
+}
+
+export const Navigator = ({ navigationType }: { navigationType: NavigationType }) => {
   const { linkingConfig } = navigationConfig(navigationType);
 
   return (
@@ -21,7 +26,7 @@ export const Navigator = ({ navigationType }: { navigationType: 'drawer' | 'tab'
       linking={linkingConfig}
     >
       <StatusBar style="dark" translucent backgroundColor="transparent" />
-      {navigationType === 'drawer' ? <DrawerNavigator /> : <MainTabNavigator />}
+      {navigationType === NavigationType.DRAWER ? <DrawerNavigator /> : <MainTabNavigator />}
     </NavigationContainer>
   );
 };


### PR DESCRIPTION
With this PR, the issue of the app crashing when redirecting to a screen containing the Maplibre component in apps using drawer navigation has been resolved, as the height of the tab bar could not be calculated.

SVA-1365