### PR TITLE
feat(home): support dynamic section configuration in `HomeScreen`

### DIFF
--- a/docs/HOME_SCREEN_SECTION_CONFIGURATION.md
+++ b/docs/HOME_SCREEN_SECTION_CONFIGURATION.md
@@ -15,7 +15,7 @@ This document explains the integration and configuration of the HomeScreen secti
 
 1. **Configuration Source**: Ensure `globalSettings` provides `homeScreenConfig` and `sections` objects. These are typically loaded from remote or local settings.
 2. **Section Structure**: Each section in `homeScreenConfig` should define at minimum:
-   - `query`: One of `QUERY_TYPES.NEWS_ITEMS`, `QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS`, or `QUERY_TYPES.EVENT_RECORDS`.
+   - `query`: One of `newsItems`, `pointsOfInterestAndTours`, or `eventRecords`.
    - `show`: Boolean to toggle visibility.
    - `limit`, `buttonTitle`, `title`, and `queryVariables` as needed.
    - For news: `categoriesNews` array for category-based sections.
@@ -29,8 +29,11 @@ This document explains the integration and configuration of the HomeScreen secti
 ```js
   "homeScreenConfig": [
     {
-      "limit": 5,
+      "limitNews": 15,
       "query": "newsItems",
+      "queryVariables": {
+        "limit": 3
+      },
       "show": true,
       "categoriesNews": [
         {
@@ -51,9 +54,30 @@ This document explains the integration and configuration of the HomeScreen secti
           "rootRouteName": "Meldungen"
         }
       ]
+    },
+    {
+      "limitPointsOfInterestAndTours": 15,
+      "query": "pointsOfInterestAndTours",
+      "queryVariables": {
+        "limit": 10,
+        "orderPoi": "RAND",
+        "orderTour": "RAND",
+        "onlyWithImage": true
+      },
+      "show": true,
+      "headlinePointsOfInterestAndTours": "Sehenswürdigkeiten & Touren",
+      "buttonTitle": "Alle Sehenswürdigkeiten & Touren anzeigen"
+    },
+    {
+      "limitEvents": 15,
+      "query": "eventRecords",
+      "queryVariables": {
+        "limit": 3
+      },
+      "show": true,
+      "buttonTitle": "Alle Veranstaltungen anzeigen"
     }
   ],
-
 ```
 
 ## Testing & Validation

--- a/docs/HOME_SCREEN_SECTION_CONFIGURATION.md
+++ b/docs/HOME_SCREEN_SECTION_CONFIGURATION.md
@@ -1,0 +1,76 @@
+# HomeScreen Section Configuration Integration Guide
+
+## Overview
+
+This document explains the integration and configuration of the HomeScreen sections in the Smart Village App. It summarizes the latest changes in `src/screens/HomeScreen.js` and provides step-by-step instructions for integrating and customizing HomeScreen sections.
+
+## Summary of Changes
+
+- HomeScreen now supports dynamic configuration of sections via `homeScreenConfig` from global settings.
+- Each section (News, Points of Interest, Events) can be customized or extended using configuration objects.
+- Default and custom section logic is unified, supporting flexible layouts and data sources.
+- Category-based news sections and volunteer event toggles are supported.
+
+## Integration Steps
+
+1. **Configuration Source**: Ensure `globalSettings` provides `homeScreenConfig` and `sections` objects. These are typically loaded from remote or local settings.
+2. **Section Structure**: Each section in `homeScreenConfig` should define at minimum:
+   - `query`: One of `QUERY_TYPES.NEWS_ITEMS`, `QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS`, or `QUERY_TYPES.EVENT_RECORDS`.
+   - `show`: Boolean to toggle visibility.
+   - `limit`, `buttonTitle`, `title`, and `queryVariables` as needed.
+   - For news: `categoriesNews` array for category-based sections.
+3. **Default Fallback**: If `homeScreenConfig` is empty, HomeScreen falls back to default sections using `sections` config.
+4. **Widget Integration**: `widgets` and `widgetStyle` are injected from `appDesignSystem` and rendered above the section list.
+5. **Refresh Logic**: Pull-to-refresh and event-based refresh are handled via `DeviceEventEmitter` and the `HOME_REFRESH_EVENT` constant.
+6. **Navigation**: Section navigation is handled via the `NAVIGATION` object, supporting both index and detail navigation for each section type.
+
+## Example Configuration
+
+```js
+  "homeScreenConfig": [
+    {
+      "limit": 5,
+      "query": "newsItems",
+      "show": true,
+      "categoriesNews": [
+        {
+          "categoryId": 1,
+          "categoryTitle": "Nachrichten",
+          "categoryTitleDetail": "Nachricht",
+          "categoryButton": "Alle Nachrichten anzeigen",
+          "indexCategoryIds": [
+            1,
+            78
+          ]
+        },
+        {
+          "categoryId": 2,
+          "categoryTitle": "Meldungen",
+          "categoryTitleDetail": "Meldung",
+          "categoryButton": "Alle Meldungen anzeigen",
+          "rootRouteName": "Meldungen"
+        }
+      ]
+    }
+  ],
+
+```
+
+## Testing & Validation
+
+- Test with both default and custom `homeScreenConfig` values.
+- Validate navigation for each section and category.
+- Check pull-to-refresh and event-based refresh.
+- Ensure widgets and footers render as expected.
+
+## Notes & Warnings
+
+- All user-facing text should be sourced from `src/config/texts.js` for localization.
+- Do not remove or bypass the default fallback logic unless all deployments provide a valid `homeScreenConfig`.
+- When adding new section types, extend the switch-case in HomeScreen accordingly.
+
+## References
+
+- See `src/screens/HomeScreen.js` for implementation details.
+- See `src/config/texts.js` for UI copy and localization.
+- See `src/components/HomeSection.js` for section rendering logic.

--- a/docs/HOME_SCREEN_SECTION_CONFIGURATION.md
+++ b/docs/HOME_SCREEN_SECTION_CONFIGURATION.md
@@ -105,6 +105,7 @@ The following example shows a full `homeScreenConfig` that controls the complete
       "limit": 3
     },
     "show": true,
+    "title": "Veranstaltungen",
     "buttonTitle": "Alle Veranstaltungen anzeigen"
   },
   {
@@ -121,6 +122,21 @@ The following example shows a full `homeScreenConfig` that controls the complete
   }
 ]
 ```
+
+### Default Fallbacks for Query Sections
+
+For data-driven sections (`query`-based entries), the following fields are **optional**. When omitted, they fall back to the defaults defined in the `sections` object of `globalSettings` (or the built-in defaults from `src/config/texts.js`):
+
+| Query                      | Optional field                  | Falls back to                                            |
+| -------------------------- | ------------------------------- | -------------------------------------------------------- |
+| `newsItems`                | `categoriesNews`                | `sections.categoriesNews` (default news categories)      |
+| `newsItems`                | `limitNews`                     | `sections.limitNews` (default: `15`)                     |
+| `pointsOfInterestAndTours` | `title`                         | `sections.headlinePointsOfInterestAndTours`              |
+| `pointsOfInterestAndTours` | `buttonTitle`                   | `sections.buttonPointsOfInterestAndTours`                |
+| `pointsOfInterestAndTours` | `limitPointsOfInterestAndTours` | `sections.limitPointsOfInterestAndTours` (default: `15`) |
+| `eventRecords`             | `title`                         | `sections.headlineEvents`                                |
+| `eventRecords`             | `buttonTitle`                   | `sections.buttonEvents`                                  |
+| `eventRecords`             | `limitEvents`                   | `sections.limitEvents` (default: `15`)                   |
 
 ### Backward Compatibility
 
@@ -145,4 +161,4 @@ Existing configurations that only contain `query`-based entries (without any `ty
 
 - See `src/screens/HomeScreen.js` for implementation details.
 - See `src/config/texts.js` for UI copy and localization.
-- See `src/components/HomeSection.js` for data section rendering logic.
+- See `src/components/HomeSection.tsx` for data section rendering logic.

--- a/docs/HOME_SCREEN_SECTION_CONFIGURATION.md
+++ b/docs/HOME_SCREEN_SECTION_CONFIGURATION.md
@@ -2,99 +2,147 @@
 
 ## Overview
 
-This document explains the integration and configuration of the HomeScreen sections in the Smart Village App. It summarizes the latest changes in `src/screens/HomeScreen.js` and provides step-by-step instructions for integrating and customizing HomeScreen sections.
+This document explains the integration and configuration of the HomeScreen in the Smart Village App. It summarizes the latest changes in `src/screens/HomeScreen.js` and provides step-by-step instructions for integrating and customizing the entire HomeScreen – including static UI components like the carousel, widgets, live ticker, and footer, as well as data-driven sections (news, events, points of interest).
 
 ## Summary of Changes
 
-- HomeScreen now supports dynamic configuration of sections via `homeScreenConfig` from global settings.
-- Each section (News, Points of Interest, Events) can be customized or extended using configuration objects.
-- Default and custom section logic is unified, supporting flexible layouts and data sources.
+- HomeScreen now supports dynamic, full-screen configuration via `homeScreenConfig` from global settings.
+- Every visible element on the HomeScreen – including LiveTicker, ConnectedImagesCarousel, Widgets, Disturber, HomeService, HomeButtons, and About – can be controlled through `homeScreenConfig`.
+- Each entry in `homeScreenConfig` uses either a `type` field (for static UI components) or a `query` field (for data-driven sections).
+- Default and custom section logic is unified. If `homeScreenConfig` is not provided, a default configuration is applied automatically.
 - Category-based news sections and volunteer event toggles are supported.
 
 ## Integration Steps
 
 1. **Configuration Source**: Ensure `globalSettings` provides `homeScreenConfig` and `sections` objects. These are typically loaded from remote or local settings.
-2. **Section Structure**: Each section in `homeScreenConfig` should define at minimum:
-   - `query`: One of `newsItems`, `pointsOfInterestAndTours`, or `eventRecords`.
-   - `show`: Boolean to toggle visibility.
-   - `limit`, `buttonTitle`, `title`, and `queryVariables` as needed.
-   - For news: `categoriesNews` array for category-based sections.
-3. **Default Fallback**: If `homeScreenConfig` is empty, HomeScreen falls back to default sections using `sections` config.
-4. **Widget Integration**: `widgets` and `widgetStyle` are injected from `appDesignSystem` and rendered above the section list.
-5. **Refresh Logic**: Pull-to-refresh and event-based refresh are handled via `DeviceEventEmitter` and the `HOME_REFRESH_EVENT` constant.
-6. **Navigation**: Section navigation is handled via the `NAVIGATION` object, supporting both index and detail navigation for each section type.
+2. **Entry Types**: Each `homeScreenConfig` entry must define either:
+   - `type`: One of `liveTicker`, `carousel`, `widgets`, `disturber`, `homeService`, `homeButtons`, `about` (for static UI components).
+   - `query`: One of `newsItems`, `pointsOfInterestAndTours`, or `eventRecords` (for data-driven sections).
+3. **Visibility**: Use `show: true/false` on every entry to toggle visibility. Omitting `show` defaults to `true` for `type`-based entries.
+4. **Order**: The order of entries in `homeScreenConfig` determines the render order on screen.
+5. **Drawer-only components**: `homeService` and `about` are only rendered when the screen is opened as a drawer (`isDrawer`). The `show` flag alone is not sufficient; the drawer context must match.
+6. **Default Fallback**: If `homeScreenConfig` is empty or not provided, HomeScreen uses a built-in default that mirrors the previous hardcoded layout.
+7. **Refresh Logic**: Pull-to-refresh and event-based refresh are handled via `DeviceEventEmitter` and the `HOME_REFRESH_EVENT` constant.
+
+## Component Types Reference
+
+| `type`        | Component                   | Notes                                                              |
+| ------------- | --------------------------- | ------------------------------------------------------------------ |
+| `liveTicker`  | `<LiveTicker>`              | Defaults to `publicJsonFile: "homeLiveTicker"`                     |
+| `carousel`    | `<ConnectedImagesCarousel>` | Defaults to `publicJsonFile: "homeCarousel"`                       |
+| `widgets`     | `<Widgets>`                 | Uses `widgetConfigs` and `widgetStyle` from `appDesignSystem`      |
+| `disturber`   | `<Disturber>`               | Defaults to `publicJsonFile: "homeDisturber"`                      |
+| `homeService` | `<HomeService>`             | Only rendered in drawer context                                    |
+| `homeButtons` | `<HomeButtons>`             | Defaults to `publicJsonFile: "homeButtons"`                        |
+| `about`       | `<About>`                   | Only rendered in drawer context; always includes `withHomeRefresh` |
+
+All `type`-based entries support an optional `publicJsonFile` field to override the default JSON file name.
 
 ## Example Configuration
 
-```js
-  "homeScreenConfig": [
-    {
-      "limitNews": 15,
-      "query": "newsItems",
-      "queryVariables": {
-        "limit": 3
-      },
-      "show": true,
-      "categoriesNews": [
-        {
-          "categoryId": 1,
-          "categoryTitle": "Nachrichten",
-          "categoryTitleDetail": "Nachricht",
-          "categoryButton": "Alle Nachrichten anzeigen",
-          "indexCategoryIds": [
-            1,
-            78
-          ]
-        },
-        {
-          "categoryId": 2,
-          "categoryTitle": "Meldungen",
-          "categoryTitleDetail": "Meldung",
-          "categoryButton": "Alle Meldungen anzeigen",
-          "rootRouteName": "Meldungen"
-        }
-      ]
+The following example shows a full `homeScreenConfig` that controls the complete HomeScreen layout:
+
+```json
+"homeScreenConfig": [
+  {
+    "type": "liveTicker",
+    "show": true
+  },
+  {
+    "type": "carousel",
+    "show": true,
+    "publicJsonFile": "homeCarousel"
+  },
+  {
+    "type": "widgets",
+    "show": true
+  },
+  {
+    "type": "disturber",
+    "show": true
+  },
+  {
+    "limitNews": 15,
+    "query": "newsItems",
+    "queryVariables": {
+      "limit": 3
     },
-    {
-      "limitPointsOfInterestAndTours": 15,
-      "query": "pointsOfInterestAndTours",
-      "queryVariables": {
-        "limit": 10,
-        "orderPoi": "RAND",
-        "orderTour": "RAND",
-        "onlyWithImage": true
+    "show": true,
+    "categoriesNews": [
+      {
+        "categoryId": 1,
+        "categoryTitle": "Nachrichten",
+        "categoryTitleDetail": "Nachricht",
+        "categoryButton": "Alle Nachrichten anzeigen",
+        "indexCategoryIds": [1, 78]
       },
-      "show": true,
-      "headlinePointsOfInterestAndTours": "Sehenswürdigkeiten & Touren",
-      "buttonTitle": "Alle Sehenswürdigkeiten & Touren anzeigen"
+      {
+        "categoryId": 2,
+        "categoryTitle": "Meldungen",
+        "categoryTitleDetail": "Meldung",
+        "categoryButton": "Alle Meldungen anzeigen",
+        "rootRouteName": "Meldungen"
+      }
+    ]
+  },
+  {
+    "limitPointsOfInterestAndTours": 15,
+    "query": "pointsOfInterestAndTours",
+    "queryVariables": {
+      "limit": 10,
+      "orderPoi": "RAND",
+      "orderTour": "RAND",
+      "onlyWithImage": true
     },
-    {
-      "limitEvents": 15,
-      "query": "eventRecords",
-      "queryVariables": {
-        "limit": 3
-      },
-      "show": true,
-      "buttonTitle": "Alle Veranstaltungen anzeigen"
-    }
-  ],
+    "show": true,
+    "title": "Sehenswürdigkeiten & Touren",
+    "buttonTitle": "Alle Sehenswürdigkeiten & Touren anzeigen"
+  },
+  {
+    "limitEvents": 15,
+    "query": "eventRecords",
+    "queryVariables": {
+      "limit": 3
+    },
+    "show": true,
+    "buttonTitle": "Alle Veranstaltungen anzeigen"
+  },
+  {
+    "type": "homeService",
+    "show": true
+  },
+  {
+    "type": "homeButtons",
+    "show": true
+  },
+  {
+    "type": "about",
+    "show": true
+  }
+]
 ```
+
+### Backward Compatibility
+
+Existing configurations that only contain `query`-based entries (without any `type` entries) continue to work. However, header components (LiveTicker, Carousel, Widgets, Disturber) and footer components (HomeService, HomeButtons, About) **will not be rendered** unless explicitly added as `type` entries. To retain the full layout, add the desired `type` entries to the config.
 
 ## Testing & Validation
 
-- Test with both default and custom `homeScreenConfig` values.
-- Validate navigation for each section and category.
+- Test with both default (no `homeScreenConfig`) and custom configurations.
+- Validate that `show: false` hides the component completely.
+- Test drawer vs. non-drawer context for `homeService` and `about` entries.
+- Validate navigation for each data section and category.
 - Check pull-to-refresh and event-based refresh.
-- Ensure widgets and footers render as expected.
+- Verify that component order in the config matches the visual render order.
 
 ## Notes & Warnings
 
 - All user-facing text should be sourced from `src/config/texts.js` for localization.
 - Do not remove or bypass the default fallback logic unless all deployments provide a valid `homeScreenConfig`.
-- When adding new section types, extend the switch-case in HomeScreen accordingly.
+- When adding new section types, extend the `switch` statement in `renderItem` inside `HomeScreen.js` accordingly.
 
 ## References
 
 - See `src/screens/HomeScreen.js` for implementation details.
 - See `src/config/texts.js` for UI copy and localization.
-- See `src/components/HomeSection.js` for section rendering logic.
+- See `src/components/HomeSection.js` for data section rendering logic.

--- a/src/components/ConnectedImagesCarousel.js
+++ b/src/components/ConnectedImagesCarousel.js
@@ -11,14 +11,9 @@ import { SettingsContext } from '../SettingsProvider';
 import { ImagesCarousel } from './ImagesCarousel';
 import { LoadingContainer } from './LoadingContainer';
 
-export const ConnectedImagesCarousel = ({
-  isImageFullWidth,
-  navigation,
-  publicJsonFile,
-  refreshTimeKey
-}) => {
+export const ConnectedImagesCarousel = ({ isImageFullWidth, navigation, publicJsonFile }) => {
   const { data, loading, refetch } = useStaticContent({
-    refreshTimeKey: refreshTimeKey || `publicJsonFile-${publicJsonFile}`,
+    refreshTimeKey: `publicJsonFile-${publicJsonFile}`,
     name: publicJsonFile,
     type: 'json'
   });
@@ -52,6 +47,5 @@ export const ConnectedImagesCarousel = ({
 ConnectedImagesCarousel.propTypes = {
   isImageFullWidth: PropTypes.bool,
   navigation: PropTypes.object.isRequired,
-  publicJsonFile: PropTypes.string.isRequired,
-  refreshTimeKey: PropTypes.string
+  publicJsonFile: PropTypes.string.isRequired
 };

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -163,11 +163,17 @@ const renderItem = ({ item }) => {
   );
 };
 
+/* eslint-disable complexity */
 export const HomeScreen = ({ navigation, route }) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
   const { globalSettings } = useContext(SettingsContext);
-  const { sections = {}, widgets: widgetConfigs = [], hdvt = {} } = globalSettings;
+  const {
+    hdvt = {},
+    homeScreenConfig = [],
+    sections = {},
+    widgets: widgetConfigs = []
+  } = globalSettings;
   const {
     showNews = true,
     showPointsOfInterestAndTours = true,
@@ -263,7 +269,7 @@ export const HomeScreen = ({ navigation, route }) => {
     }, [])
   );
 
-  const data = [
+  const defaultData = [
     {
       categoriesNews,
       fetchPolicy,
@@ -298,10 +304,71 @@ export const HomeScreen = ({ navigation, route }) => {
     }
   ];
 
+  const configuredData = homeScreenConfig?.length
+    ? homeScreenConfig
+        .map((section) => {
+          switch (section.query) {
+            case QUERY_TYPES.NEWS_ITEMS:
+              return {
+                categoriesNews: section.categoriesNews || categoriesNews,
+                fetchPolicy,
+                limit: section.limit || limitNews,
+                navigation,
+                query: section.query || QUERY_TYPES.NEWS_ITEMS,
+                queryVariables: {
+                  limit: section.limit || limitNews,
+                  excludeDataProviderIds,
+                  excludeMowasRegionalKeys,
+                  ...section.queryVariables
+                },
+                showData: section.show
+              };
+            case QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS:
+              return {
+                buttonTitle: section.buttonTitle || buttonPointsOfInterestAndTours,
+                fetchPolicy,
+                limit: section.limit || limitPointsOfInterestAndTours,
+                navigate: 'CATEGORIES_INDEX',
+                navigation,
+                query: section.query || QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS,
+                queryVariables: {
+                  limit: section.limit || limitPointsOfInterestAndTours,
+                  orderPoi: 'RAND',
+                  orderTour: 'RAND',
+                  onlyWithImage: true,
+                  ...section.queryVariables
+                },
+                showData: section.show,
+                title: section.title || headlinePointsOfInterestAndTours
+              };
+            case QUERY_TYPES.EVENT_RECORDS:
+              return {
+                buttonTitle: section.buttonTitle || buttonEvents,
+                fetchPolicy,
+                limit: section.limit || limitEvents,
+                navigate: 'EVENT_RECORDS_INDEX',
+                navigation,
+                query: section.query || QUERY_TYPES.EVENT_RECORDS,
+                queryVariables: {
+                  limit: section.limit || limitEvents,
+                  order: 'listDate_ASC',
+                  ...section.queryVariables
+                },
+                showData: section.show,
+                showVolunteerEvents,
+                title: section.title || headlineEvents
+              };
+            default:
+              return null;
+          }
+        })
+        .filter((item) => item !== null)
+    : defaultData;
+
   return (
     <SafeAreaViewFlex>
       <FlatList
-        data={data}
+        data={configuredData}
         ListHeaderComponent={
           <>
             <LiveTicker publicJsonFile="homeLiveTicker" />

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -310,13 +310,13 @@ export const HomeScreen = ({ navigation, route }) => {
           switch (section.query) {
             case QUERY_TYPES.NEWS_ITEMS:
               return {
-                categoriesNews: section.categoriesNews || categoriesNews,
+                categoriesNews: section.categoriesNews,
                 fetchPolicy,
-                limit: section.limit || limitNews,
+                limit: section.limitNews,
                 navigation,
-                query: section.query || QUERY_TYPES.NEWS_ITEMS,
+                query: section.query,
                 queryVariables: {
-                  limit: section.limit || limitNews,
+                  limit: 3,
                   excludeDataProviderIds,
                   excludeMowasRegionalKeys,
                   ...section.queryVariables
@@ -325,38 +325,38 @@ export const HomeScreen = ({ navigation, route }) => {
               };
             case QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS:
               return {
-                buttonTitle: section.buttonTitle || buttonPointsOfInterestAndTours,
+                buttonTitle: section.buttonTitle,
                 fetchPolicy,
-                limit: section.limit || limitPointsOfInterestAndTours,
+                limit: section.limitPointsOfInterestAndTours,
                 navigate: 'CATEGORIES_INDEX',
                 navigation,
-                query: section.query || QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS,
+                query: section.query,
                 queryVariables: {
-                  limit: section.limit || limitPointsOfInterestAndTours,
+                  limit: 10,
                   orderPoi: 'RAND',
                   orderTour: 'RAND',
                   onlyWithImage: true,
                   ...section.queryVariables
                 },
                 showData: section.show,
-                title: section.title || headlinePointsOfInterestAndTours
+                title: section.title
               };
             case QUERY_TYPES.EVENT_RECORDS:
               return {
-                buttonTitle: section.buttonTitle || buttonEvents,
+                buttonTitle: section.buttonTitle,
                 fetchPolicy,
-                limit: section.limit || limitEvents,
+                limit: section.limitEvents,
                 navigate: 'EVENT_RECORDS_INDEX',
                 navigation,
-                query: section.query || QUERY_TYPES.EVENT_RECORDS,
+                query: section.query,
                 queryVariables: {
-                  limit: section.limit || limitEvents,
+                  limit: 3,
                   order: 'listDate_ASC',
                   ...section.queryVariables
                 },
                 showData: section.show,
                 showVolunteerEvents,
-                title: section.title || headlineEvents
+                title: section.title
               };
             default:
               return null;

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -38,6 +38,7 @@ import { ScreenName } from '../types';
 
 const { MATOMO_TRACKING, ROOT_ROUTE_NAMES } = consts;
 
+/* eslint-disable complexity */
 const renderItem = ({ item }) => {
   const {
     buttonTitle,
@@ -50,7 +51,6 @@ const renderItem = ({ item }) => {
     publicJsonFile,
     query,
     queryVariables,
-    refreshTimeKey,
     showData,
     showVolunteerEvents,
     title,
@@ -71,7 +71,6 @@ const renderItem = ({ item }) => {
           <ConnectedImagesCarousel
             navigation={navigation}
             publicJsonFile={publicJsonFile || 'homeCarousel'}
-            refreshTimeKey={refreshTimeKey || 'publicJsonFile-homeCarousel'}
           />
         );
       case 'widgets':
@@ -209,7 +208,6 @@ const renderItem = ({ item }) => {
   );
 };
 
-/* eslint-disable complexity */
 export const HomeScreen = ({ navigation, route }) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
@@ -377,9 +375,9 @@ export const HomeScreen = ({ navigation, route }) => {
           switch (section.query) {
             case QUERY_TYPES.NEWS_ITEMS:
               return {
-                categoriesNews: section.categoriesNews,
+                categoriesNews: section.categoriesNews || categoriesNews,
                 fetchPolicy,
-                limit: section.limitNews,
+                limit: section.limitNews ?? limitNews,
                 navigation,
                 query: section.query,
                 queryVariables: {
@@ -392,9 +390,9 @@ export const HomeScreen = ({ navigation, route }) => {
               };
             case QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS:
               return {
-                buttonTitle: section.buttonTitle,
+                buttonTitle: section.buttonTitle || buttonPointsOfInterestAndTours,
                 fetchPolicy,
-                limit: section.limitPointsOfInterestAndTours,
+                limit: section.limitPointsOfInterestAndTours ?? limitPointsOfInterestAndTours,
                 navigate: 'CATEGORIES_INDEX',
                 navigation,
                 query: section.query,
@@ -406,13 +404,13 @@ export const HomeScreen = ({ navigation, route }) => {
                   ...section.queryVariables
                 },
                 showData: section.show !== false,
-                title: section.title
+                title: section.title || headlinePointsOfInterestAndTours
               };
             case QUERY_TYPES.EVENT_RECORDS:
               return {
-                buttonTitle: section.buttonTitle,
+                buttonTitle: section.buttonTitle || buttonEvents,
                 fetchPolicy,
-                limit: section.limitEvents,
+                limit: section.limitEvents ?? limitEvents,
                 navigate: 'EVENT_RECORDS_INDEX',
                 navigation,
                 query: section.query,
@@ -423,7 +421,7 @@ export const HomeScreen = ({ navigation, route }) => {
                 },
                 showData: section.show !== false,
                 showVolunteerEvents,
-                title: section.title
+                title: section.title || headlineEvents
               };
             default:
               return null;

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -38,6 +38,18 @@ import { ScreenName } from '../types';
 
 const { MATOMO_TRACKING, ROOT_ROUTE_NAMES } = consts;
 
+const DEFAULT_HOME_SCREEN_SECTIONS = {
+  LIVE_TICKER: 'liveTicker',
+  CAROUSEL: 'carousel',
+  WIDGETS: 'widgets',
+  DISTURBER: 'disturber',
+  POINTS_OF_INTEREST_AND_TOURS: 'pointsOfInterestAndTours',
+  EVENTS: 'events',
+  HOME_SERVICE: 'homeService',
+  HOME_BUTTONS: 'homeButtons',
+  ABOUT: 'about'
+};
+
 /* eslint-disable complexity */
 const renderItem = ({ item }) => {
   const {
@@ -64,27 +76,27 @@ const renderItem = ({ item }) => {
     if (!item.show) return null;
 
     switch (type) {
-      case 'liveTicker':
+      case DEFAULT_HOME_SCREEN_SECTIONS.LIVE_TICKER:
         return <LiveTicker publicJsonFile={publicJsonFile || 'homeLiveTicker'} />;
-      case 'carousel':
+      case DEFAULT_HOME_SCREEN_SECTIONS.CAROUSEL:
         return (
           <ConnectedImagesCarousel
             navigation={navigation}
             publicJsonFile={publicJsonFile || 'homeCarousel'}
           />
         );
-      case 'widgets':
+      case DEFAULT_HOME_SCREEN_SECTIONS.WIDGETS:
         return <Widgets widgetConfigs={widgetConfigs} widgetStyle={widgetStyle} />;
-      case 'disturber':
+      case DEFAULT_HOME_SCREEN_SECTIONS.DISTURBER:
         return (
           <Disturber navigation={navigation} publicJsonFile={publicJsonFile || 'homeDisturber'} />
         );
-      case 'homeService':
+      case DEFAULT_HOME_SCREEN_SECTIONS.HOME_SERVICE:
         if (!isDrawer) return null;
         return <HomeService publicJsonFile={publicJsonFile || 'homeService'} />;
-      case 'homeButtons':
+      case DEFAULT_HOME_SCREEN_SECTIONS.HOME_BUTTONS:
         return <HomeButtons publicJsonFile={publicJsonFile || 'homeButtons'} />;
-      case 'about':
+      case DEFAULT_HOME_SCREEN_SECTIONS.ABOUT:
         if (!isDrawer) return null;
         return (
           <About
@@ -316,10 +328,10 @@ export const HomeScreen = ({ navigation, route }) => {
   const isDrawer = route.params?.isDrawer;
 
   const defaultData = [
-    { type: 'liveTicker', show: true },
-    { type: 'carousel', show: true, navigation },
-    { type: 'widgets', show: true, widgetConfigs, widgetStyle },
-    { type: 'disturber', show: true, navigation },
+    { type: DEFAULT_HOME_SCREEN_SECTIONS.LIVE_TICKER, show: true },
+    { type: DEFAULT_HOME_SCREEN_SECTIONS.CAROUSEL, show: true, navigation },
+    { type: DEFAULT_HOME_SCREEN_SECTIONS.WIDGETS, show: true, widgetConfigs, widgetStyle },
+    { type: DEFAULT_HOME_SCREEN_SECTIONS.DISTURBER, show: true, navigation },
     {
       categoriesNews,
       fetchPolicy,
@@ -352,9 +364,9 @@ export const HomeScreen = ({ navigation, route }) => {
       showVolunteerEvents,
       title: headlineEvents
     },
-    { type: 'homeService', show: true, isDrawer },
-    { type: 'homeButtons', show: true },
-    { type: 'about', show: true, isDrawer, navigation }
+    { type: DEFAULT_HOME_SCREEN_SECTIONS.HOME_SERVICE, show: true, isDrawer },
+    { type: DEFAULT_HOME_SCREEN_SECTIONS.HOME_BUTTONS, show: true },
+    { type: DEFAULT_HOME_SCREEN_SECTIONS.ABOUT, show: true, isDrawer, navigation }
   ];
 
   const configuredData = homeScreenConfig?.length

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -43,15 +43,61 @@ const renderItem = ({ item }) => {
     buttonTitle,
     categoriesNews,
     fetchPolicy,
+    isDrawer,
     limit,
     navigate,
     navigation,
+    publicJsonFile,
     query,
     queryVariables,
+    refreshTimeKey,
     showData,
     showVolunteerEvents,
-    title
+    title,
+    type,
+    widgetConfigs,
+    widgetStyle
   } = item;
+
+  // Static component types (LiveTicker, Carousel, Widgets, Disturber, HomeService, HomeButtons, About)
+  if (type) {
+    if (!item.show) return null;
+
+    switch (type) {
+      case 'liveTicker':
+        return <LiveTicker publicJsonFile={publicJsonFile || 'homeLiveTicker'} />;
+      case 'carousel':
+        return (
+          <ConnectedImagesCarousel
+            navigation={navigation}
+            publicJsonFile={publicJsonFile || 'homeCarousel'}
+            refreshTimeKey={refreshTimeKey || 'publicJsonFile-homeCarousel'}
+          />
+        );
+      case 'widgets':
+        return <Widgets widgetConfigs={widgetConfigs} widgetStyle={widgetStyle} />;
+      case 'disturber':
+        return (
+          <Disturber navigation={navigation} publicJsonFile={publicJsonFile || 'homeDisturber'} />
+        );
+      case 'homeService':
+        if (!isDrawer) return null;
+        return <HomeService publicJsonFile={publicJsonFile || 'homeService'} />;
+      case 'homeButtons':
+        return <HomeButtons publicJsonFile={publicJsonFile || 'homeButtons'} />;
+      case 'about':
+        if (!isDrawer) return null;
+        return (
+          <About
+            navigation={navigation}
+            publicJsonFile={publicJsonFile || 'homeAbout'}
+            withHomeRefresh
+          />
+        );
+      default:
+        return null;
+    }
+  }
 
   const NAVIGATION = {
     CATEGORIES_INDEX: {
@@ -269,7 +315,13 @@ export const HomeScreen = ({ navigation, route }) => {
     }, [])
   );
 
+  const isDrawer = route.params?.isDrawer;
+
   const defaultData = [
+    { type: 'liveTicker', show: true },
+    { type: 'carousel', show: true, navigation },
+    { type: 'widgets', show: true, widgetConfigs, widgetStyle },
+    { type: 'disturber', show: true, navigation },
     {
       categoriesNews,
       fetchPolicy,
@@ -301,12 +353,27 @@ export const HomeScreen = ({ navigation, route }) => {
       showData: showEvents,
       showVolunteerEvents,
       title: headlineEvents
-    }
+    },
+    { type: 'homeService', show: true, isDrawer },
+    { type: 'homeButtons', show: true },
+    { type: 'about', show: true, isDrawer, navigation }
   ];
 
   const configuredData = homeScreenConfig?.length
     ? homeScreenConfig
         .map((section) => {
+          // Handle static component type entries (liveTicker, carousel, widgets, etc.)
+          if (section.type) {
+            return {
+              ...section,
+              show: section.show !== false,
+              isDrawer,
+              navigation,
+              widgetConfigs,
+              widgetStyle
+            };
+          }
+
           switch (section.query) {
             case QUERY_TYPES.NEWS_ITEMS:
               return {
@@ -321,7 +388,7 @@ export const HomeScreen = ({ navigation, route }) => {
                   excludeMowasRegionalKeys,
                   ...section.queryVariables
                 },
-                showData: section.show
+                showData: section.show !== false
               };
             case QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS:
               return {
@@ -338,7 +405,7 @@ export const HomeScreen = ({ navigation, route }) => {
                   onlyWithImage: true,
                   ...section.queryVariables
                 },
-                showData: section.show,
+                showData: section.show !== false,
                 title: section.title
               };
             case QUERY_TYPES.EVENT_RECORDS:
@@ -354,7 +421,7 @@ export const HomeScreen = ({ navigation, route }) => {
                   order: 'listDate_ASC',
                   ...section.queryVariables
                 },
-                showData: section.show,
+                showData: section.show !== false,
                 showVolunteerEvents,
                 title: section.title
               };
@@ -369,32 +436,6 @@ export const HomeScreen = ({ navigation, route }) => {
     <SafeAreaViewFlex>
       <FlatList
         data={configuredData}
-        ListHeaderComponent={
-          <>
-            <LiveTicker publicJsonFile="homeLiveTicker" />
-
-            <ConnectedImagesCarousel
-              navigation={navigation}
-              publicJsonFile="homeCarousel"
-              refreshTimeKey="publicJsonFile-homeCarousel"
-            />
-
-            <Widgets widgetConfigs={widgetConfigs} widgetStyle={widgetStyle} />
-
-            <Disturber navigation={navigation} publicJsonFile="homeDisturber" />
-          </>
-        }
-        ListFooterComponent={
-          route.params?.isDrawer ? (
-            <>
-              <HomeService publicJsonFile="homeService" />
-              <HomeButtons publicJsonFile="homeButtons" />
-              <About navigation={navigation} publicJsonFile="homeAbout" withHomeRefresh />
-            </>
-          ) : (
-            <HomeButtons publicJsonFile="homeButtons" />
-          )
-        }
         refreshControl={
           <RefreshControl
             refreshing={refreshing}

--- a/src/screens/SUE/SueHomeScreen.tsx
+++ b/src/screens/SUE/SueHomeScreen.tsx
@@ -111,7 +111,6 @@ export const SueHomeScreen = ({ navigation }: HomeScreenProps) => {
           isImageFullWidth
           navigation={navigation}
           publicJsonFile="sueHomeCarousel"
-          refreshTimeKey="publicJsonFile-sueHomeCarousel"
         />
 
         {!!sueReportListNavigationButton &&


### PR DESCRIPTION
This PR adds the ability to remotely configure sections on the `HomeScreen`

An example configuration:

```
"homeScreenConfig": [
    {
      "type": "carousel"
    },
    {
      "type": "liveTicker"
    },
    {
      "type": "widgets"
    },
    {
      "type": "disturber"
    },
    {
      "limitNews": 15,
      "query": "newsItems",
      "queryVariables": {
        "limit": 3
      },
      "categoriesNews": [
        {
          "categoryId": 1,
          "categoryTitle": "Nachrichten",
          "categoryTitleDetail": "Nachricht",
          "categoryButton": "Alle Nachrichten anzeigen",
          "indexCategoryIds": [
            1,
            78
          ]
        },
        {
          "categoryId": 2,
          "categoryTitle": "Meldungen",
          "categoryTitleDetail": "Meldung",
          "categoryButton": "Alle Meldungen anzeigen",
          "rootRouteName": "Meldungen"
        }
      ]
    },
    {
      "limitPointsOfInterestAndTours": 15,
      "query": "pointsOfInterestAndTours",
      "queryVariables": {
        "limit": 10,
        "orderPoi": "RAND",
        "orderTour": "RAND",
        "onlyWithImage": true
      },
      "title": "Sehenswürdigkeiten & Touren",
      "buttonTitle": "Alle Sehenswürdigkeiten & Touren anzeigen"
    },
    {
      "limitEvents": 15,
      "query": "eventRecords",
      "queryVariables": {
        "limit": 3
      },
      "buttonTitle": "Alle Veranstaltungen anzeigen"
    },
    {
      "type": "homeButtons"
    },
    {
      "type": "homeService"
    },
    {
      "type": "about"
    }
  ],
```

Detailed documentation:

https://github.com/smart-village-solutions/smart-village-app-app/blob/2175ce97bb6a425d1e3df007c7cd5ff7f1acbd6b/docs/HOME_SCREEN_SECTION_CONFIGURATION.md

SVASD-353
SVA-1702