### PR TITLE
feat: add optional pdfUrl to SubQuery and navigation parameters

### DIFF
--- a/src/components/MultiButtonWithSubQuery.tsx
+++ b/src/components/MultiButtonWithSubQuery.tsx
@@ -19,9 +19,11 @@ export const navigateWithSubQuery = ({
   params?:
     | {
         isExternal?: boolean;
+        pdfUrl?: string;
         routeName: string;
         webUrl: string;
         paramsForButton?: {
+          pdfUrl?: string;
           query: string;
           queryVariables: { name: string };
           rootRouteName: string;
@@ -58,6 +60,7 @@ export const navigateWithSubQuery = ({
     // it contains a `routeName` and a `webUrl`
     return navigation.push(params.routeName, {
       isExternal: params.isExternal,
+      pdfUrl: params.pdfUrl,
       rootRouteName,
       title,
       webUrl: params.webUrl
@@ -72,6 +75,7 @@ export const navigateWithSubQuery = ({
   return navigation.push(subQuery.routeName, {
     ...subParams,
     isExternal: subQuery.isExternal,
+    pdfUrl: subQuery.pdfUrl,
     rootRouteName,
     title,
     webUrl: subQuery.webUrl

--- a/src/types/SubQuery.ts
+++ b/src/types/SubQuery.ts
@@ -13,7 +13,8 @@ export type SubQuery = {
   ];
   buttonTitle: string;
   isExternal?: boolean;
-  params: { rootRouteName: string; routeName: string; title: string; webUrl: string };
+  params?: { rootRouteName: string; routeName: string; title: string; webUrl: string };
+  pdfUrl?: string;
   routeName: string;
   title?: string;
   webUrl?: string;


### PR DESCRIPTION
This PR resolves the issue where the `pdfUrl` parameter is not being sent when transitioning from `HtmlScreen` to `pdfScreen`.

SVA-1610