### PR TITLE
feat: enhance wallet card functionality

### DIFF
--- a/src/screens/Wallet/WalletCardsListScreen.tsx
+++ b/src/screens/Wallet/WalletCardsListScreen.tsx
@@ -37,29 +37,31 @@ export const WalletCardsListScreen = ({ route }: { route: RouteProp<any, any> })
     return <LoadingSpinner loading />;
   }
 
-  const listItem = (data || []).map((card: TCard) => {
-    const {
-      description = '',
-      iconBackgroundColor = colors.lighterPrimaryRgba,
-      iconColor = colors.primary,
-      iconName = 'credit-card',
-      title = '',
-      type = ''
-    } = card;
+  const listItem = (data || [])
+    .filter((card: TCard) => card.isVisible !== false)
+    .map((card: TCard) => {
+      const {
+        description = '',
+        iconBackgroundColor = colors.lighterPrimaryRgba,
+        iconColor = colors.primary,
+        iconName = 'credit-card',
+        title = '',
+        type = ''
+      } = card;
 
-    return {
-      leftIcon: (
-        <Wrapper style={[styles.iconContainer, { backgroundColor: iconBackgroundColor }]}>
-          <Icon.NamedIcon name={iconName} color={iconColor} />
-        </Wrapper>
-      ),
-      params: { card, title: texts.screenTitles.wallet.cardAdd },
-      routeName: ScreenName.WalletCardAdd,
-      subtitle: description,
-      title,
-      type
-    };
-  });
+      return {
+        leftIcon: (
+          <Wrapper style={[styles.iconContainer, { backgroundColor: iconBackgroundColor }]}>
+            <Icon.NamedIcon name={iconName} color={iconColor} />
+          </Wrapper>
+        ),
+        params: { card, title: texts.screenTitles.wallet.cardAdd },
+        routeName: ScreenName.WalletCardAdd,
+        subtitle: description,
+        title,
+        type
+      };
+    });
 
   return (
     <WalletList

--- a/src/screens/Wallet/WalletHomeScreen.tsx
+++ b/src/screens/Wallet/WalletHomeScreen.tsx
@@ -1,6 +1,6 @@
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import React, { useCallback, useContext, useState } from 'react';
+import React, { useCallback, useContext, useMemo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import {
@@ -16,6 +16,7 @@ import {
 } from '../../components';
 import { colors, Icon, normalize, texts } from '../../config';
 import { getSavedCards } from '../../helpers';
+import { useStaticContent } from '../../hooks';
 import { SettingsContext } from '../../SettingsProvider';
 import { ScreenName, TCard } from '../../types';
 
@@ -71,6 +72,20 @@ export const WalletHomeScreen = () => {
     title = walletHomeTexts.title
   } = wallet;
 
+  const { data: cardTypes } = useStaticContent<TCard[]>({
+    refreshTimeKey: 'publicJsonFile-walletCardTypes',
+    name: 'walletCardTypes',
+    type: 'json'
+  });
+
+  const cardTypeMap = useMemo(() => {
+    const map = new Map<string, TCard>();
+
+    cardTypes?.forEach((ct) => map.set(ct.type, ct));
+
+    return map;
+  }, [cardTypes]);
+
   const [cards, setCards] = useState<TCard[]>([]);
   const [savedCardsLoading, setSavedCardsLoading] = useState<boolean>(true);
 
@@ -113,17 +128,29 @@ export const WalletHomeScreen = () => {
     );
   }
 
-  const listItem = cards.map((card: TCard) => ({
-    leftIcon: (
-      <Wrapper style={[styles.iconContainer, { backgroundColor: card.iconBackgroundColor }]}>
-        <Icon.NamedIcon name={card.iconName} color={card.iconColor} />
-      </Wrapper>
-    ),
-    params: { card, title: texts.screenTitles.wallet.detail },
-    routeName: ScreenName.WalletCardDetail,
-    subtitle: card.description,
-    title: card.cardName || card.title
-  }));
+  const listItem = cards
+    .filter((card: TCard) => {
+      const serverCardType = cardTypeMap.get(card.type);
+
+      return serverCardType?.isVisible !== false;
+    })
+    .map((card: TCard) => {
+      const serverCardType = cardTypeMap.get(card.type);
+      const iconBackgroundColor = serverCardType?.iconBackgroundColor ?? card.iconBackgroundColor;
+      const iconColor = serverCardType?.iconColor ?? card.iconColor;
+
+      return {
+        leftIcon: (
+          <Wrapper style={[styles.iconContainer, { backgroundColor: iconBackgroundColor }]}>
+            <Icon.NamedIcon name={card.iconName} color={iconColor} />
+          </Wrapper>
+        ),
+        params: { card, title: texts.screenTitles.wallet.detail },
+        routeName: ScreenName.WalletCardDetail,
+        subtitle: card.description,
+        title: card.cardName || card.title
+      };
+    });
 
   return (
     <WalletList

--- a/src/types/wallet/Card.ts
+++ b/src/types/wallet/Card.ts
@@ -6,6 +6,7 @@ export type TCard = {
   iconBackgroundColor: string;
   iconColor: string;
   iconName: string;
+  isVisible?: boolean;
   leftIcon: React.ReactNode;
   params?: Record<string, any>;
   pinCode?: string;


### PR DESCRIPTION
With this PR, the card types in the `walletTypes` content can now be visible

To hidden a card type, add the following options to the contents of the object within `walletTypes`
```
[
  {
    ...
    "isVisible": false,
    ...
```

|before|after|
|--|--|
<img width="250" alt="Simulator Screenshot - iPhone 16e - 2026-03-27 at 15 31 44" src="https://github.com/user-attachments/assets/3776724e-b956-46d0-a85b-f10c74ec6168" />|<img width="250" alt="Simulator Screenshot - iPhone 16e - 2026-03-27 at 15 30 57" src="https://github.com/user-attachments/assets/0f07bc1e-8b4f-4b3f-bee4-66d309fdeb27" />



SVAK-167