### PR TITLE
feat: add floating button

### DIFF
--- a/__tests__/components/FloatingButton.test.js
+++ b/__tests__/components/FloatingButton.test.js
@@ -1,0 +1,150 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import renderer from 'react-test-renderer';
+
+import { FloatingButton } from '../../src/components/FloatingButton';
+
+const renderFloatingButton = (props) => {
+  let testRenderer;
+
+  renderer.act(() => {
+    testRenderer = renderer.create(<FloatingButton publicJsonFile="floatingButton" {...props} />);
+  });
+
+  return testRenderer;
+};
+
+const mockUseStaticContent = jest.fn();
+const mockUseHomeRefresh = jest.fn();
+const mockGetCurrentRoute = jest.fn();
+const mockIsReady = jest.fn();
+const mockNavigate = jest.fn();
+
+jest.mock('../../src/hooks', () => ({
+  useHomeRefresh: (...args) => mockUseHomeRefresh(...args),
+  useStaticContent: (...args) => mockUseStaticContent(...args)
+}));
+
+jest.mock('../../src/navigation/navigationRef', () => ({
+  navigationRef: {
+    getCurrentRoute: (...args) => mockGetCurrentRoute(...args),
+    isReady: (...args) => mockIsReady(...args),
+    navigate: (...args) => mockNavigate(...args)
+  }
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigationState: (selector) => selector({})
+}));
+
+jest.mock('../../src/config', () => ({
+  colors: {
+    primary: '#000000',
+    lightestText: '#ffffff',
+    shadow: '#000000'
+  },
+  normalize: (value) => value,
+  Icon: {
+    NamedIcon: () => null
+  }
+}));
+
+jest.mock('../../src/components/Image', () => ({
+  Image: () => null
+}));
+
+describe('FloatingButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseStaticContent.mockReturnValue({
+      data: [],
+      loading: false,
+      refetch: jest.fn()
+    });
+
+    mockGetCurrentRoute.mockReturnValue({ name: 'Home' });
+    mockIsReady.mockReturnValue(true);
+  });
+
+  it('renders null while loading', () => {
+    mockUseStaticContent.mockReturnValue({
+      data: undefined,
+      loading: true,
+      refetch: jest.fn()
+    });
+
+    const tree = renderFloatingButton({ bottomOffset: 0 }).toJSON();
+
+    expect(tree).toBeNull();
+  });
+
+  it('renders null when data is empty', () => {
+    mockUseStaticContent.mockReturnValue({
+      data: [],
+      loading: false,
+      refetch: jest.fn()
+    });
+
+    const tree = renderFloatingButton({ bottomOffset: 0 }).toJSON();
+
+    expect(tree).toBeNull();
+  });
+
+  it('filters items by active route and keeps global items', () => {
+    mockUseStaticContent.mockReturnValue({
+      data: [
+        {
+          accessibilityLabel: 'Visible on Home',
+          routeName: 'Home',
+          visibleScreens: ['Home']
+        },
+        {
+          accessibilityLabel: 'Hidden on Home',
+          routeName: 'Web',
+          visibleScreens: ['Index']
+        },
+        {
+          accessibilityLabel: 'Visible everywhere',
+          routeName: 'Search'
+        }
+      ],
+      loading: false,
+      refetch: jest.fn()
+    });
+
+    const testRenderer = renderFloatingButton({ bottomOffset: 0 });
+
+    const buttons = testRenderer.root.findAllByType(TouchableOpacity);
+
+    expect(buttons).toHaveLength(2);
+    expect(buttons.map((button) => button.props.accessibilityLabel)).toEqual([
+      'Visible on Home',
+      'Visible everywhere'
+    ]);
+    expect(testRenderer.toJSON()).toMatchSnapshot();
+  });
+
+  it('navigates on press with configured route and params', () => {
+    mockUseStaticContent.mockReturnValue({
+      data: [
+        {
+          accessibilityLabel: 'Open Web',
+          routeName: 'Web',
+          params: { webUrl: 'https://example.com' }
+        }
+      ],
+      loading: false,
+      refetch: jest.fn()
+    });
+
+    const testRenderer = renderFloatingButton({ bottomOffset: 0 });
+
+    const button = testRenderer.root.findByType(TouchableOpacity);
+    renderer.act(() => {
+      button.props.onPress();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('Web', { webUrl: 'https://example.com' });
+  });
+});

--- a/__tests__/components/__snapshots__/FloatingButton.test.js.snap
+++ b/__tests__/components/__snapshots__/FloatingButton.test.js.snap
@@ -1,0 +1,119 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FloatingButton filters items by active route and keeps global items 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "flex-end",
+        "position": "absolute",
+        "right": 16,
+      },
+      {
+        "bottom": 16,
+      },
+    ]
+  }
+>
+  <View
+    accessibilityLabel="Visible on Home"
+    accessibilityRole="button"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "alignItems": "center",
+        "backgroundColor": "#000000",
+        "borderRadius": 28,
+        "height": 56,
+        "justifyContent": "center",
+        "marginTop": 8,
+        "opacity": 1,
+        "shadowColor": "#000000",
+        "shadowOffset": {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.4,
+        "shadowRadius": 4,
+        "width": 56,
+      }
+    }
+  />
+  <View
+    accessibilityLabel="Visible everywhere"
+    accessibilityRole="button"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "alignItems": "center",
+        "backgroundColor": "#000000",
+        "borderRadius": 28,
+        "height": 56,
+        "justifyContent": "center",
+        "marginTop": 8,
+        "opacity": 1,
+        "shadowColor": "#000000",
+        "shadowOffset": {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.4,
+        "shadowRadius": 4,
+        "width": 56,
+      }
+    }
+  />
+</View>
+`;

--- a/docs/FLOATING_BUTTON.md
+++ b/docs/FLOATING_BUTTON.md
@@ -17,12 +17,11 @@ A server-configurable floating action button that appears at a fixed position in
 
 ### Modified Files
 
-| File                                   | Change                                                                                         |
-| -------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `src/navigation/AppStackNavigator.tsx` | Stack navigator wrapped in a `View`; `FloatingButton` added with absolute positioning          |
-| `src/navigation/Navigator.tsx`         | Added `ref={navigationRef}` to `NavigationContainer`                                           |
-| `src/components/SafeAreaViewFlex.tsx`  | `edges` prop made conditional based on navigation type (`tab` → `[]`, `drawer` → `['bottom']`) |
-| `src/components/index.js`              | Added `FloatingButton` export                                                                  |
+| File                                  | Change                                                                                         |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `src/navigation/Navigator.tsx`        | Added `ref={navigationRef}` to `NavigationContainer`; integrated `FloatingButton` rendering    |
+| `src/components/SafeAreaViewFlex.tsx` | `edges` prop made conditional based on navigation type (`tab` → `[]`, `drawer` → `['bottom']`) |
+| `src/components/index.js`             | Added `FloatingButton` export                                                                  |
 
 ## Data Flow
 
@@ -48,14 +47,14 @@ A `publicJsonFile` record named `floatingButton` must be created on the server. 
 ```json
 [
   {
-    "title": "Create Event",
+    "accessibilityLabel": "Create Event",
     "routeName": "EventCreate",
     "params": {},
     "iconName": "calendar-plus",
     "visibleScreens": ["Index"]
   },
   {
-    "title": "Chatbot",
+    "accessibilityLabel": "Open Chatbot",
     "icon": "url",
     "iconName": "",
     "visibleScreens": ["Home"],
@@ -70,14 +69,14 @@ A `publicJsonFile` record named `floatingButton` must be created on the server. 
 
 #### Field Descriptions
 
-| Field            | Type         | Required | Description                                                                                    |
-| ---------------- | ------------ | -------- | ---------------------------------------------------------------------------------------------- |
-| `title`          | `string`     | Yes      | Accessibility label for the button                                                             |
-| `routeName`      | `ScreenName` | Yes      | Target screen name (one of the `ScreenName` enum values in `src/types/Navigation.ts`)          |
-| `params`         | `object`     | No       | Navigation parameters to pass to the target screen                                             |
-| `iconName`       | `string`     | No       | Icon name from the `tabler-icons` set (e.g. `calendar-plus`)                                   |
-| `icon`           | `string`     | No       | Remote icon URL (used instead of `iconName`)                                                   |
-| `visibleScreens` | `string[]`   | No       | Screens on which the button is visible. If omitted or empty, the button appears on all screens |
+| Field                | Type         | Required | Description                                                                                    |
+| -------------------- | ------------ | -------- | ---------------------------------------------------------------------------------------------- |
+| `accessibilityLabel` | `string`     | Yes      | Accessibility label used by screen readers and as the button identifier                        |
+| `routeName`          | `ScreenName` | Yes      | Target screen name (one of the `ScreenName` enum values in `src/types/Navigation.ts`)          |
+| `params`             | `object`     | No       | Navigation parameters to pass to the target screen                                             |
+| `iconName`           | `string`     | No       | Icon name from the `tabler-icons` set (e.g. `calendar-plus`)                                   |
+| `icon`               | `string`     | No       | Remote icon URL (used instead of `iconName`)                                                   |
+| `visibleScreens`     | `string[]`   | No       | Screens on which the button is visible. If omitted or empty, the button appears on all screens |
 
 > **Note:** If both `icon` and `iconName` are provided, `icon` (URL) takes priority.
 
@@ -96,9 +95,11 @@ The changes on this branch add the following integrations to the app:
 
 1. **`navigationRef`** — Created via `createNavigationContainerRef()` and attached to the `NavigationContainer`. This allows accessing the active route via `navigationRef.getCurrentRoute()` from anywhere outside the component tree.
 
-2. **`FloatingButton`** — Rendered as a sibling of `Stack.Navigator` inside `AppStackNavigator`. Positioned in the bottom-right corner using `position: 'absolute'`.
+2. **`FloatingButton` in `Navigator`** — Rendered in `src/navigation/Navigator.tsx` as a sibling of the active navigator (`DrawerNavigator` or `MainTabNavigator`) inside the `NavigationContainer`.
 
-3. **`SafeAreaViewFlex`** — In tab navigation, `edges` is set to an empty array (`[]`) to prevent the FloatingButton from overlapping with the tab bar at the bottom.
+3. **Tab-bar clearance in `Navigator`** — For tab navigation, `Navigator` computes `bottomOffset` using tab bar height + safe-area bottom inset and passes it to `FloatingButton`, so the FAB stays above the tab bar.
+
+4. **`SafeAreaViewFlex` behavior** — In tab navigation, `edges` is set to an empty array (`[]`); in drawer navigation, `edges` remains `['bottom']`. This keeps screen safe-area behavior aligned with the selected navigation type.
 
 ### 3. Visibility Control
 
@@ -111,8 +112,8 @@ The FloatingButton component subscribes to navigation state changes via the `use
 
 The component supports both `drawer` and `tab` navigation types:
 
-- **Tab:** Button is positioned just above the tab bar (`bottom: normalize(16)`)
-- **Drawer:** Button is positioned at the bottom 5% of the screen (`bottom: '5%'`)
+- **Tab:** Button uses `bottom: normalize(16) + bottomOffset`, where `bottomOffset` is computed in `Navigator` from tab bar height + bottom safe area
+- **Drawer:** Button uses `bottom: '5%'`
 
 ## Styling and Appearance
 

--- a/docs/FLOATING_BUTTON.md
+++ b/docs/FLOATING_BUTTON.md
@@ -1,0 +1,138 @@
+# Floating Button (SVASD-537)
+
+A server-configurable floating action button that appears at a fixed position in the bottom-right corner of the screen.
+
+## Overview
+
+`FloatingButton` is a FAB (Floating Action Button) component that can be displayed on any screen and navigates the user to a configured target screen. Button content (icon, target screen, visibility rules) is fetched from the server via a `publicJsonFile` GraphQL query. This allows buttons to be managed dynamically without releasing a new app version.
+
+## Architecture
+
+### New Files
+
+| File                                | Description                                                                                                    |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `src/components/FloatingButton.tsx` | Main component — data fetching, filtering, and rendering                                                       |
+| `src/navigation/navigationRef.ts`   | Global `NavigationContainerRef` — provides access to the active route name from anywhere in the component tree |
+
+### Modified Files
+
+| File                                   | Change                                                                                         |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `src/navigation/AppStackNavigator.tsx` | Stack navigator wrapped in a `View`; `FloatingButton` added with absolute positioning          |
+| `src/navigation/Navigator.tsx`         | Added `ref={navigationRef}` to `NavigationContainer`                                           |
+| `src/components/SafeAreaViewFlex.tsx`  | `edges` prop made conditional based on navigation type (`tab` → `[]`, `drawer` → `['bottom']`) |
+| `src/components/index.js`              | Added `FloatingButton` export                                                                  |
+
+## Data Flow
+
+```
+Server (CMS)
+    │
+    ▼
+publicJsonFile GraphQL query  (name: "floatingButton", type: "json")
+    │
+    ▼
+useStaticContent hook  →  TButton[]
+    │
+    ▼
+FloatingButton component
+    ├── Filter by active screen (visibleScreens)
+    └── Render → TouchableOpacity + Icon/Image
+```
+
+### Server-Side JSON Structure
+
+A `publicJsonFile` record named `floatingButton` must be created on the server. Its content must be a JSON array:
+
+```json
+[
+  {
+    "title": "Create Event",
+    "routeName": "EventCreate",
+    "params": {},
+    "iconName": "calendar-plus",
+    "visibleScreens": ["Index"]
+  },
+  {
+    "title": "Chatbot",
+    "icon": "url",
+    "iconName": "",
+    "visibleScreens": ["Home"],
+    "routeName": "Web",
+    "params": {
+      "webUrl": "url",
+      "title": "Chatbot"
+    }
+  }
+]
+```
+
+#### Field Descriptions
+
+| Field            | Type         | Required | Description                                                                                    |
+| ---------------- | ------------ | -------- | ---------------------------------------------------------------------------------------------- |
+| `title`          | `string`     | Yes      | Accessibility label for the button                                                             |
+| `routeName`      | `ScreenName` | Yes      | Target screen name (one of the `ScreenName` enum values in `src/types/Navigation.ts`)          |
+| `params`         | `object`     | No       | Navigation parameters to pass to the target screen                                             |
+| `iconName`       | `string`     | No       | Icon name from the `tabler-icons` set (e.g. `calendar-plus`)                                   |
+| `icon`           | `string`     | No       | Remote icon URL (used instead of `iconName`)                                                   |
+| `visibleScreens` | `string[]`   | No       | Screens on which the button is visible. If omitted or empty, the button appears on all screens |
+
+> **Note:** If both `icon` and `iconName` are provided, `icon` (URL) takes priority.
+
+## Integration Steps
+
+### 1. Server Configuration
+
+Create a **publicJsonFile** record in the CMS (Main Server):
+
+- **name:** `floatingButton`
+- **content:** A JSON array matching the structure above
+
+### 2. App Side (Already Done)
+
+The changes on this branch add the following integrations to the app:
+
+1. **`navigationRef`** — Created via `createNavigationContainerRef()` and attached to the `NavigationContainer`. This allows accessing the active route via `navigationRef.getCurrentRoute()` from anywhere outside the component tree.
+
+2. **`FloatingButton`** — Rendered as a sibling of `Stack.Navigator` inside `AppStackNavigator`. Positioned in the bottom-right corner using `position: 'absolute'`.
+
+3. **`SafeAreaViewFlex`** — In tab navigation, `edges` is set to an empty array (`[]`) to prevent the FloatingButton from overlapping with the tab bar at the bottom.
+
+### 3. Visibility Control
+
+The FloatingButton component subscribes to navigation state changes via the `useNavigationState` hook, causing a re-render on every screen transition. The active screen name is obtained through `navigationRef.getCurrentRoute()` and compared against the `visibleScreens` array from the server data.
+
+- `visibleScreens` **is defined**: Button appears only on the listed screens
+- `visibleScreens` **is empty or undefined**: Button appears on all screens
+
+### 4. Navigation Type Support
+
+The component supports both `drawer` and `tab` navigation types:
+
+- **Tab:** Button is positioned just above the tab bar (`bottom: normalize(16)`)
+- **Drawer:** Button is positioned at the bottom 5% of the screen (`bottom: '5%'`)
+
+## Styling and Appearance
+
+- Button size: `normalize(56)` × `normalize(56)` (circular)
+- Background color: `colors.primary`
+- Shadow: `shadowColor/shadowOffset/shadowOpacity/shadowRadius` on iOS, `elevation: 6` on Android
+- Multiple buttons are spaced vertically with `normalize(8)` gap
+
+## Testing
+
+### Manual Testing
+
+1. Create a `floatingButton` publicJsonFile record on the server
+2. Start the app: `yarn start`
+3. Verify the button appears in the bottom-right corner on the home screen
+4. Tap the button and confirm navigation to the target screen
+5. Test that buttons restricted via `visibleScreens` only appear on the specified screens
+
+### Unit Test Suggestions
+
+- `FloatingButton` render test: `loading` and `data` states
+- `visibleScreens` filtering logic
+- Navigation triggering via `navigationRef`

--- a/src/components/FloatingButton.tsx
+++ b/src/components/FloatingButton.tsx
@@ -14,11 +14,9 @@ import { Image } from './Image';
 type TButton = {
   icon?: string;
   iconName?: string;
-  iconPosition?: 'left' | 'right';
-  invert?: boolean;
   params?: Record<string, unknown>;
+  accessibilityLabel?: string;
   routeName: ScreenName;
-  title: string;
   visibleScreens?: string[];
 };
 
@@ -60,10 +58,16 @@ export const FloatingButton = ({ publicJsonFile }: { publicJsonFile: string }) =
       {visibleItems.map((item, index) => (
         <TouchableOpacity
           activeOpacity={0.8}
-          accessibilityLabel={item.title}
+          accessibilityLabel={item.accessibilityLabel}
           accessibilityRole="button"
-          key={`${item.title}-${index}`}
-          onPress={() => navigationRef.navigate(item.routeName as never, item.params as never)}
+          key={`${item.accessibilityLabel}-${index}`}
+          onPress={() => {
+            if (!navigationRef.isReady()) {
+              return;
+            }
+
+            navigationRef.navigate(item.routeName as never, item.params as never);
+          }}
           style={styles.button}
         >
           {item.icon ? (

--- a/src/components/FloatingButton.tsx
+++ b/src/components/FloatingButton.tsx
@@ -20,7 +20,13 @@ type TButton = {
   visibleScreens?: string[];
 };
 
-export const FloatingButton = ({ publicJsonFile }: { publicJsonFile: string }) => {
+export const FloatingButton = ({
+  bottomOffset = 0,
+  publicJsonFile
+}: {
+  bottomOffset?: number;
+  publicJsonFile: string;
+}) => {
   const { globalSettings } = useContext(SettingsContext);
   const { navigation: navigationType } = globalSettings;
 
@@ -54,7 +60,7 @@ export const FloatingButton = ({ publicJsonFile }: { publicJsonFile: string }) =
   if (!visibleItems.length) return null;
 
   return (
-    <View style={[styles.container, stylesWithProps({ navigationType }).position]}>
+    <View style={[styles.container, stylesWithProps({ bottomOffset, navigationType }).position]}>
       {visibleItems.map((item, index) => (
         <TouchableOpacity
           activeOpacity={0.8}
@@ -118,10 +124,16 @@ const styles = StyleSheet.create({
 
 /* eslint-disable react-native/no-unused-styles */
 /* this works properly, we do not want that warning */
-const stylesWithProps = ({ navigationType }: { navigationType: string }) => {
+const stylesWithProps = ({
+  bottomOffset,
+  navigationType
+}: {
+  bottomOffset: number;
+  navigationType: string;
+}) => {
   return StyleSheet.create({
     position: {
-      bottom: navigationType === 'drawer' ? '5%' : normalize(16)
+      bottom: navigationType === 'drawer' ? '5%' : normalize(16) + bottomOffset
     }
   });
 };

--- a/src/components/FloatingButton.tsx
+++ b/src/components/FloatingButton.tsx
@@ -1,0 +1,105 @@
+import { NavigationState, PartialState, useNavigationState } from '@react-navigation/native';
+import _filter from 'lodash/filter';
+import React, { useContext } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { Icon, normalize } from '../config';
+import { useHomeRefresh, useStaticContent } from '../hooks';
+import { navigationRef } from '../navigation/navigationRef';
+import { SettingsContext } from '../SettingsProvider';
+import { ScreenName } from '../types';
+
+import { Button } from './Button';
+import { Image } from './Image';
+import { Wrapper } from './Wrapper';
+
+type TButton = {
+  icon?: string;
+  iconName?: string;
+  iconPosition?: 'left' | 'right';
+  invert?: boolean;
+  params?: Record<string, unknown>;
+  routeName: ScreenName;
+  title: string;
+  visibleScreens?: string[];
+};
+
+export const FloatingButton = ({ publicJsonFile }: { publicJsonFile: string }) => {
+  const { globalSettings } = useContext(SettingsContext);
+  const { navigation: navigationType } = globalSettings;
+
+  // Subscribe to navigation state to trigger re-renders on every route change.
+  // We intentionally do NOT use the returned value because on the initial render
+  // the parent navigator's nested stack state is not yet populated, causing a
+  // recursive traversal to resolve to a stack name (e.g. "AppStack") instead of
+  // the actual screen name (e.g. "Home").
+  // `navigationRef.getCurrentRoute()` traverses the full navigation tree via the
+  // root NavigationContainer ref and always returns the focused leaf route.
+  useNavigationState((state: NavigationState | PartialState<NavigationState>) => state);
+  const activeRouteName = navigationRef.getCurrentRoute()?.name ?? '';
+
+  const { data, loading, refetch } = useStaticContent<TButton[]>({
+    refreshTimeKey: `publicJsonFile-${publicJsonFile}`,
+    name: publicJsonFile,
+    type: 'json'
+  });
+
+  useHomeRefresh(refetch);
+
+  if (loading || !data?.length) return null;
+
+  // Filter items whose `visibleScreens` list includes the current screen.
+  // Items without a `visibleScreens` array are shown on every screen.
+  const visibleItems = _filter(
+    data,
+    ({ visibleScreens }) => !visibleScreens?.length || visibleScreens.includes(activeRouteName)
+  );
+
+  if (!visibleItems.length) return null;
+
+  return (
+    <View style={[styles.container, stylesWithProps({ navigationType }).position]}>
+      <Wrapper>
+        {visibleItems.map((item, index) => (
+          <Button
+            icon={
+              item.icon ? (
+                <Image source={{ uri: item.icon }} style={styles.image} />
+              ) : item.iconName ? (
+                <Icon.NamedIcon name={item.iconName} />
+              ) : undefined
+            }
+            iconPosition={item.iconPosition || 'left'}
+            invert={item.invert || false}
+            key={`${item.title}-${index}`}
+            notFullWidth
+            onPress={() => navigationRef.navigate(item.routeName as never, item.params as never)}
+            title={item.title}
+          />
+        ))}
+      </Wrapper>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignSelf: 'center',
+    position: 'absolute'
+  },
+  image: {
+    height: normalize(24),
+    width: normalize(24)
+  }
+});
+
+/* eslint-disable react-native/no-unused-styles */
+/* this works properly, we do not want that warning */
+const stylesWithProps = ({ navigationType }: { navigationType: string }) => {
+  return StyleSheet.create({
+    position: {
+      bottom: navigationType === 'drawer' ? '5%' : 0
+    }
+  });
+};
+/* eslint-enable react-native/no-unused-styles */

--- a/src/components/FloatingButton.tsx
+++ b/src/components/FloatingButton.tsx
@@ -1,17 +1,15 @@
 import { NavigationState, PartialState, useNavigationState } from '@react-navigation/native';
 import _filter from 'lodash/filter';
 import React, { useContext } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, TouchableOpacity, View } from 'react-native';
 
-import { Icon, normalize } from '../config';
+import { colors, Icon, normalize } from '../config';
 import { useHomeRefresh, useStaticContent } from '../hooks';
 import { navigationRef } from '../navigation/navigationRef';
 import { SettingsContext } from '../SettingsProvider';
 import { ScreenName } from '../types';
 
-import { Button } from './Button';
 import { Image } from './Image';
-import { Wrapper } from './Wrapper';
 
 type TButton = {
   icon?: string;
@@ -59,35 +57,56 @@ export const FloatingButton = ({ publicJsonFile }: { publicJsonFile: string }) =
 
   return (
     <View style={[styles.container, stylesWithProps({ navigationType }).position]}>
-      <Wrapper>
-        {visibleItems.map((item, index) => (
-          <Button
-            icon={
-              item.icon ? (
-                <Image source={{ uri: item.icon }} style={styles.image} />
-              ) : item.iconName ? (
-                <Icon.NamedIcon name={item.iconName} />
-              ) : undefined
-            }
-            iconPosition={item.iconPosition || 'left'}
-            invert={item.invert || false}
-            key={`${item.title}-${index}`}
-            notFullWidth
-            onPress={() => navigationRef.navigate(item.routeName as never, item.params as never)}
-            title={item.title}
-          />
-        ))}
-      </Wrapper>
+      {visibleItems.map((item, index) => (
+        <TouchableOpacity
+          activeOpacity={0.8}
+          accessibilityLabel={item.title}
+          accessibilityRole="button"
+          key={`${item.title}-${index}`}
+          onPress={() => navigationRef.navigate(item.routeName as never, item.params as never)}
+          style={styles.button}
+        >
+          {item.icon ? (
+            <Image source={{ uri: item.icon }} style={styles.icon} />
+          ) : item.iconName ? (
+            <Icon.NamedIcon name={item.iconName} color={colors.lightestText} size={normalize(24)} />
+          ) : null}
+        </TouchableOpacity>
+      ))}
     </View>
   );
 };
 
+const BUTTON_SIZE = normalize(56);
+
 const styles = StyleSheet.create({
-  container: {
-    alignSelf: 'center',
-    position: 'absolute'
+  button: {
+    alignItems: 'center',
+    backgroundColor: colors.primary,
+    borderRadius: BUTTON_SIZE / 2,
+    height: BUTTON_SIZE,
+    justifyContent: 'center',
+    marginTop: normalize(8),
+    width: BUTTON_SIZE,
+    ...Platform.select({
+      ios: {
+        shadowColor: colors.shadow,
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.4,
+        shadowRadius: 4
+      },
+      android: {
+        elevation: 6
+      }
+    })
   },
-  image: {
+  container: {
+    alignItems: 'flex-end',
+    position: 'absolute',
+    right: normalize(16)
+  },
+
+  icon: {
     height: normalize(24),
     width: normalize(24)
   }
@@ -98,7 +117,7 @@ const styles = StyleSheet.create({
 const stylesWithProps = ({ navigationType }: { navigationType: string }) => {
   return StyleSheet.create({
     position: {
-      bottom: navigationType === 'drawer' ? '5%' : 0
+      bottom: navigationType === 'drawer' ? '5%' : normalize(16)
     }
   });
 };

--- a/src/components/FloatingButton.tsx
+++ b/src/components/FloatingButton.tsx
@@ -1,11 +1,11 @@
 import { NavigationState, PartialState, useNavigationState } from '@react-navigation/native';
 import _filter from 'lodash/filter';
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 import { Platform, StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { colors, Icon, normalize } from '../config';
 import { useHomeRefresh, useStaticContent } from '../hooks';
-import { navigationRef } from '../navigation/navigationRef';
+import { navigationRef, type RootNavigationParamList } from '../navigation/navigationRef';
 import { SettingsContext } from '../SettingsProvider';
 import { ScreenName } from '../types';
 
@@ -14,7 +14,7 @@ import { Image } from './Image';
 type TButton = {
   icon?: string;
   iconName?: string;
-  params?: Record<string, unknown>;
+  params?: RootNavigationParamList[ScreenName];
   accessibilityLabel?: string;
   routeName: ScreenName;
   visibleScreens?: string[];
@@ -39,6 +39,10 @@ export const FloatingButton = ({
   // root NavigationContainer ref and always returns the focused leaf route.
   useNavigationState((state: NavigationState | PartialState<NavigationState>) => state);
   const activeRouteName = navigationRef.getCurrentRoute()?.name ?? '';
+  const positionStyle = useMemo(
+    () => ({ bottom: navigationType === 'drawer' ? '5%' : normalize(16) + bottomOffset }),
+    [bottomOffset, navigationType]
+  );
 
   const { data, loading, refetch } = useStaticContent<TButton[]>({
     refreshTimeKey: `publicJsonFile-${publicJsonFile}`,
@@ -60,7 +64,7 @@ export const FloatingButton = ({
   if (!visibleItems.length) return null;
 
   return (
-    <View style={[styles.container, stylesWithProps({ bottomOffset, navigationType }).position]}>
+    <View style={[styles.container, positionStyle]}>
       {visibleItems.map((item, index) => (
         <TouchableOpacity
           activeOpacity={0.8}
@@ -72,7 +76,7 @@ export const FloatingButton = ({
               return;
             }
 
-            navigationRef.navigate(item.routeName as never, item.params as never);
+            navigationRef.navigate(item.routeName, item.params);
           }}
           style={styles.button}
         >
@@ -121,20 +125,3 @@ const styles = StyleSheet.create({
     width: normalize(24)
   }
 });
-
-/* eslint-disable react-native/no-unused-styles */
-/* this works properly, we do not want that warning */
-const stylesWithProps = ({
-  bottomOffset,
-  navigationType
-}: {
-  bottomOffset: number;
-  navigationType: string;
-}) => {
-  return StyleSheet.create({
-    position: {
-      bottom: navigationType === 'drawer' ? '5%' : normalize(16) + bottomOffset
-    }
-  });
-};
-/* eslint-enable react-native/no-unused-styles */

--- a/src/components/SafeAreaViewFlex.tsx
+++ b/src/components/SafeAreaViewFlex.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { StyleSheet, ViewStyle } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { SettingsContext } from '../SettingsProvider';
 
 export const SafeAreaViewFlex = ({
   children,
@@ -11,8 +13,15 @@ export const SafeAreaViewFlex = ({
   style?: ViewStyle;
   [key: string]: any;
 }) => {
+  const { globalSettings } = useContext(SettingsContext);
+  const { navigation = 'tab' } = globalSettings;
+
   return (
-    <SafeAreaView style={[styles.flex, style]} edges={['bottom']} {...props}>
+    <SafeAreaView
+      style={[styles.flex, style]}
+      edges={navigation === 'tab' ? [] : ['bottom']}
+      {...props}
+    >
       {children}
     </SafeAreaView>
   );

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -53,6 +53,7 @@ export * from './EditHeader';
 export * from './EmptyMessage';
 export * from './EventSuggestionButton';
 export * from './FavoritesHeader';
+export * from './FloatingButton';
 export * from './GroupedListItem';
 export * from './GroupedSectionHeader';
 export * from './GroupHeader';

--- a/src/navigation/AppStackNavigator.tsx
+++ b/src/navigation/AppStackNavigator.tsx
@@ -1,24 +1,38 @@
 import { createStackNavigator } from '@react-navigation/stack';
 import React from 'react';
+import { StyleSheet, View } from 'react-native';
 
+import { FloatingButton } from '../components/FloatingButton';
 import { StackConfig } from '../types';
 
 const Stack = createStackNavigator<Record<string, { title: string } | undefined>>();
 
 export const getStackNavigator = (stackConfig: StackConfig) => () =>
   (
-    <Stack.Navigator
-      initialRouteName={stackConfig.initialRouteName}
-      screenOptions={stackConfig.screenOptions}
-    >
-      {stackConfig.screenConfigs.map((screenConfig) => (
-        <Stack.Screen
-          key={screenConfig.routeName}
-          name={screenConfig.routeName}
-          component={screenConfig.screenComponent}
-          options={screenConfig.screenOptions}
-          initialParams={screenConfig.initialParams}
-        />
-      ))}
-    </Stack.Navigator>
+    // Wrap in a View so FloatingButton can be absolutely positioned
+    // inside the stack's bounds (above tab bar in tab apps).
+    <View style={styles.flex}>
+      <Stack.Navigator
+        initialRouteName={stackConfig.initialRouteName}
+        screenOptions={stackConfig.screenOptions}
+      >
+        {stackConfig.screenConfigs.map((screenConfig) => (
+          <Stack.Screen
+            key={screenConfig.routeName}
+            name={screenConfig.routeName}
+            component={screenConfig.screenComponent}
+            options={screenConfig.screenOptions}
+            initialParams={screenConfig.initialParams}
+          />
+        ))}
+      </Stack.Navigator>
+
+      <FloatingButton publicJsonFile="floatingButton" />
+    </View>
   );
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1
+  }
+});

--- a/src/navigation/AppStackNavigator.tsx
+++ b/src/navigation/AppStackNavigator.tsx
@@ -1,38 +1,24 @@
 import { createStackNavigator } from '@react-navigation/stack';
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
 
-import { FloatingButton } from '../components/FloatingButton';
 import { StackConfig } from '../types';
 
 const Stack = createStackNavigator<Record<string, { title: string } | undefined>>();
 
 export const getStackNavigator = (stackConfig: StackConfig) => () =>
   (
-    // Wrap in a View so FloatingButton can be absolutely positioned
-    // inside the stack's bounds (above tab bar in tab apps).
-    <View style={styles.flex}>
-      <Stack.Navigator
-        initialRouteName={stackConfig.initialRouteName}
-        screenOptions={stackConfig.screenOptions}
-      >
-        {stackConfig.screenConfigs.map((screenConfig) => (
-          <Stack.Screen
-            key={screenConfig.routeName}
-            name={screenConfig.routeName}
-            component={screenConfig.screenComponent}
-            options={screenConfig.screenOptions}
-            initialParams={screenConfig.initialParams}
-          />
-        ))}
-      </Stack.Navigator>
-
-      <FloatingButton publicJsonFile="floatingButton" />
-    </View>
+    <Stack.Navigator
+      initialRouteName={stackConfig.initialRouteName}
+      screenOptions={stackConfig.screenOptions}
+    >
+      {stackConfig.screenConfigs.map((screenConfig) => (
+        <Stack.Screen
+          key={screenConfig.routeName}
+          name={screenConfig.routeName}
+          component={screenConfig.screenComponent}
+          options={screenConfig.screenOptions}
+          initialParams={screenConfig.initialParams}
+        />
+      ))}
+    </Stack.Navigator>
   );
-
-const styles = StyleSheet.create({
-  flex: {
-    flex: 1
-  }
-});

--- a/src/navigation/Navigator.tsx
+++ b/src/navigation/Navigator.tsx
@@ -1,7 +1,10 @@
 import { DefaultTheme, NavigationContainer } from '@react-navigation/native';
 import { StatusBar } from 'expo-status-bar';
 import React from 'react';
+import { Platform, StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { FloatingButton } from '../components/FloatingButton';
 import { colors } from '../config';
 import { navigationConfig } from '../config/navigation';
 
@@ -9,8 +12,16 @@ import { DrawerNavigator } from './DrawerNavigator';
 import { MainTabNavigator } from './MainTabNavigator';
 import { navigationRef } from './navigationRef';
 
+// Default bottom tab bar heights from React Navigation bottom-tabs.
+const TAB_BAR_HEIGHT = Platform.OS === 'ios' ? 49 : 56;
+
 export const Navigator = ({ navigationType }: { navigationType: 'drawer' | 'tab' }) => {
   const { linkingConfig } = navigationConfig(navigationType);
+  const { bottom: safeAreaBottom } = useSafeAreaInsets();
+
+  // Account for the tab bar height so FloatingButton doesn't overlap it.
+  // Drawer navigation has no tab bar, so no offset is needed there.
+  const tabBottomOffset = navigationType === 'tab' ? TAB_BAR_HEIGHT + safeAreaBottom : 0;
 
   return (
     <NavigationContainer
@@ -22,8 +33,17 @@ export const Navigator = ({ navigationType }: { navigationType: 'drawer' | 'tab'
       }}
       linking={linkingConfig}
     >
-      <StatusBar style="dark" translucent backgroundColor="transparent" />
-      {navigationType === 'drawer' ? <DrawerNavigator /> : <MainTabNavigator />}
+      <View style={styles.flex}>
+        <StatusBar style="dark" translucent backgroundColor="transparent" />
+        {navigationType === 'drawer' ? <DrawerNavigator /> : <MainTabNavigator />}
+        <FloatingButton publicJsonFile="floatingButton" bottomOffset={tabBottomOffset} />
+      </View>
     </NavigationContainer>
   );
 };
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1
+  }
+});

--- a/src/navigation/Navigator.tsx
+++ b/src/navigation/Navigator.tsx
@@ -7,12 +7,14 @@ import { navigationConfig } from '../config/navigation';
 
 import { DrawerNavigator } from './DrawerNavigator';
 import { MainTabNavigator } from './MainTabNavigator';
+import { navigationRef } from './navigationRef';
 
 export const Navigator = ({ navigationType }: { navigationType: 'drawer' | 'tab' }) => {
   const { linkingConfig } = navigationConfig(navigationType);
 
   return (
     <NavigationContainer
+      ref={navigationRef}
       theme={{
         dark: DefaultTheme.dark,
         colors: { ...DefaultTheme.colors, background: colors.surface },

--- a/src/navigation/navigationRef.ts
+++ b/src/navigation/navigationRef.ts
@@ -1,0 +1,8 @@
+import { createNavigationContainerRef } from '@react-navigation/native';
+
+/**
+ * Global navigation ref passed to <NavigationContainer>.
+ * Provides `getCurrentRoute()` which always returns the focused leaf route,
+ * even before nested navigator state is registered in the parent state tree.
+ */
+export const navigationRef = createNavigationContainerRef();

--- a/src/navigation/navigationRef.ts
+++ b/src/navigation/navigationRef.ts
@@ -1,8 +1,14 @@
 import { createNavigationContainerRef } from '@react-navigation/native';
 
 /**
+ * Param list for the global navigation ref.
+ * This broad typing keeps navigation type-safe without restricting route names here.
+ */
+export type RootNavigationParamList = Record<string, object | undefined>;
+
+/**
  * Global navigation ref passed to <NavigationContainer>.
  * Provides `getCurrentRoute()` which always returns the focused leaf route,
  * even before nested navigator state is registered in the parent state tree.
  */
-export const navigationRef = createNavigationContainerRef();
+export const navigationRef = createNavigationContainerRef<RootNavigationParamList>();


### PR DESCRIPTION
With this PR, a floating button feature will be added that can be displayed on the desired screen and controlled via the main server

To make this feature work, create a static content called `floatingButton`. You can create multiple buttons within this content.

An example of static content for the `floatingButton`:
```
[
  {
    "icon": url,
    "iconName": string,
    "visibleScreens": [
      "Home"
    ],
    "routeName": "Web",
    "params": {
      "webUrl": url,
      "title": string
    }
  }
]
```

<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-02 at 11 54 30" src="https://github.com/user-attachments/assets/2f627d3d-9f3e-4b4c-9900-ba254d43fe66" />


SVASD-537