### PR TITLE
feat(wallet): add live clock to detail screen

### DIFF
--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -1722,6 +1722,7 @@ export const texts = {
       errorTitle: 'Fehler',
       expandCode: 'Code vergrößern',
       lastTransactions: 'Ihre letzten 10 Buchungen',
+      liveIndicator: 'LIVE',
       noCardsAvailable: 'Keine Kartendaten verfügbar.',
       pin: 'PIN',
       shareErrorMessage:

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -1722,7 +1722,6 @@ export const texts = {
       errorTitle: 'Fehler',
       expandCode: 'Code vergrößern',
       lastTransactions: 'Ihre letzten 10 Buchungen',
-      liveIndicator: 'LIVE',
       noCardsAvailable: 'Keine Kartendaten verfügbar.',
       pin: 'PIN',
       shareErrorMessage:

--- a/src/screens/Wallet/WalletCardDetailScreen.tsx
+++ b/src/screens/Wallet/WalletCardDetailScreen.tsx
@@ -37,6 +37,37 @@ import { fetchCardInfo } from '../../queries';
 import { SettingsContext } from '../../SettingsProvider';
 import { CardType, TCard, TCardInfo } from '../../types';
 
+const LiveClock = () => {
+  const [time, setTime] = useState(new Date());
+
+  useEffect(() => {
+    const interval = setInterval(() => setTime(new Date()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const hours = time.getHours().toString().padStart(2, '0');
+  const minutes = time.getMinutes().toString().padStart(2, '0');
+  const seconds = time.getSeconds().toString().padStart(2, '0');
+  // Blinking colon effect: visible on even seconds, hidden on odd
+  const colonVisible = time.getSeconds() % 2 === 0;
+
+  return (
+    <View style={styles.liveClockContainer}>
+      <View style={styles.liveDot} />
+      <BoldText style={styles.liveClockText}>
+        {hours}
+        <BoldText style={[styles.liveClockText, { opacity: colonVisible ? 1 : 0.3 }]}>:</BoldText>
+        {minutes}
+        <BoldText style={[styles.liveClockText, { opacity: colonVisible ? 1 : 0.3 }]}>:</BoldText>
+        {seconds}
+      </BoldText>
+      <RegularText smallest style={styles.liveLabel}>
+        {texts.wallet.detail.liveIndicator}
+      </RegularText>
+    </View>
+  );
+};
+
 const ShareableCard = ({
   apiConnection,
   cardNumber,
@@ -220,6 +251,8 @@ export const WalletCardDetailScreen = ({
                     value={`${apiConnection.qrEndpoint}${cardNumber}`}
                   />
                 </TouchableOpacity>
+
+                <LiveClock />
               </Wrapper>
             )}
 
@@ -390,6 +423,7 @@ export const WalletCardDetailScreen = ({
             cardNumber={cardNumber}
             cardType={cardType}
           />
+          <LiveClock />
         </Wrapper>
       </Modal>
 
@@ -439,6 +473,32 @@ const styles = StyleSheet.create({
     height: '100%',
     justifyContent: 'center',
     width: '100%'
+  },
+  liveClockContainer: {
+    alignItems: 'center',
+    backgroundColor: colors.shadowRgba,
+    borderRadius: normalize(8),
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginTop: normalize(8),
+    paddingHorizontal: normalize(12),
+    paddingVertical: normalize(6)
+  },
+  liveClockText: {
+    color: colors.primary,
+    fontVariant: ['tabular-nums'],
+    fontSize: normalize(16)
+  },
+  liveDot: {
+    backgroundColor: colors.error,
+    borderRadius: normalize(4),
+    height: normalize(8),
+    marginRight: normalize(6),
+    width: normalize(8)
+  },
+  liveLabel: {
+    color: colors.darkText,
+    marginLeft: normalize(6)
   },
   qrOverlayCloseButton: {
     alignItems: 'center',

--- a/src/screens/Wallet/WalletCardDetailScreen.tsx
+++ b/src/screens/Wallet/WalletCardDetailScreen.tsx
@@ -2,10 +2,12 @@ import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import * as FileSystem from 'expo-file-system/legacy';
 import * as Sharing from 'expo-sharing';
-import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
+  Animated,
+  Easing,
   RefreshControl,
   StyleSheet,
   TouchableOpacity,
@@ -34,8 +36,72 @@ import {
 import { colors, device, Icon, normalize, texts } from '../../config';
 import { deleteCardByNumber } from '../../helpers';
 import { fetchCardInfo } from '../../queries';
-import { SettingsContext } from '../../SettingsProvider';
 import { CardType, TCard, TCardInfo } from '../../types';
+
+const SECOND_DIGIT_HEIGHT = normalize(54);
+
+const AnimatedSeconds = ({ seconds }: { seconds: number }) => {
+  const slideAnim = useMemo(() => new Animated.Value(0), []);
+
+  useEffect(() => {
+    slideAnim.setValue(0);
+    Animated.timing(slideAnim, {
+      toValue: -SECOND_DIGIT_HEIGHT,
+      duration: 1000,
+      useNativeDriver: true,
+      easing: Easing.linear
+    }).start();
+  }, [seconds, slideAnim]);
+
+  const prev = ((seconds - 1 + 60) % 60).toString().padStart(2, '0');
+  const current = seconds.toString().padStart(2, '0');
+  const next = ((seconds + 1) % 60).toString().padStart(2, '0');
+  const nextNext = ((seconds + 2) % 60).toString().padStart(2, '0');
+
+  // Opacity transitions: current holds at full opacity for ~60% of the cycle
+  const prevOpacity = slideAnim.interpolate({
+    inputRange: [-SECOND_DIGIT_HEIGHT, -SECOND_DIGIT_HEIGHT * 0.4, 0],
+    outputRange: [0, 0.15, 0.3],
+    extrapolate: 'clamp'
+  });
+
+  const currentOpacity = slideAnim.interpolate({
+    inputRange: [-SECOND_DIGIT_HEIGHT, -SECOND_DIGIT_HEIGHT * 0.4, 0],
+    outputRange: [0.3, 1, 1],
+    extrapolate: 'clamp'
+  });
+
+  const nextOpacity = slideAnim.interpolate({
+    inputRange: [-SECOND_DIGIT_HEIGHT, -SECOND_DIGIT_HEIGHT * 0.4, 0],
+    outputRange: [0.8, 0.2, 0.15],
+    extrapolate: 'clamp'
+  });
+
+  const nextNextOpacity = slideAnim.interpolate({
+    inputRange: [-SECOND_DIGIT_HEIGHT, -SECOND_DIGIT_HEIGHT * 0.4, 0],
+    outputRange: [0.3, 0, 0],
+    extrapolate: 'clamp'
+  });
+
+  return (
+    <View style={styles.secondsSlotContainer}>
+      <Animated.View style={{ transform: [{ translateY: slideAnim }] }}>
+        <Animated.View style={[styles.secondSlot, { opacity: prevOpacity }]}>
+          <BoldText style={styles.liveClockText}>{prev}</BoldText>
+        </Animated.View>
+        <Animated.View style={[styles.secondSlot, { opacity: currentOpacity }]}>
+          <BoldText style={styles.liveClockText}>{current}</BoldText>
+        </Animated.View>
+        <Animated.View style={[styles.secondSlot, { opacity: nextOpacity }]}>
+          <BoldText style={styles.liveClockText}>{next}</BoldText>
+        </Animated.View>
+        <Animated.View style={[styles.secondSlot, { opacity: nextNextOpacity }]}>
+          <BoldText style={styles.liveClockText}>{nextNext}</BoldText>
+        </Animated.View>
+      </Animated.View>
+    </View>
+  );
+};
 
 const LiveClock = () => {
   const [time, setTime] = useState(new Date());
@@ -47,23 +113,26 @@ const LiveClock = () => {
 
   const hours = time.getHours().toString().padStart(2, '0');
   const minutes = time.getMinutes().toString().padStart(2, '0');
-  const seconds = time.getSeconds().toString().padStart(2, '0');
-  // Blinking colon effect: visible on even seconds, hidden on odd
-  const colonVisible = time.getSeconds() % 2 === 0;
+
+  const dateString = time.toLocaleDateString('de-DE', {
+    weekday: 'short',
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric'
+  });
 
   return (
     <View style={styles.liveClockContainer}>
-      <View style={styles.liveDot} />
-      <BoldText style={styles.liveClockText}>
-        {hours}
-        <BoldText style={[styles.liveClockText, { opacity: colonVisible ? 1 : 0.3 }]}>:</BoldText>
-        {minutes}
-        <BoldText style={[styles.liveClockText, { opacity: colonVisible ? 1 : 0.3 }]}>:</BoldText>
-        {seconds}
+      <View style={styles.clockRow}>
+        <BoldText style={styles.liveClockText}>{hours}</BoldText>
+        <BoldText style={styles.liveClockColon}>:</BoldText>
+        <BoldText style={styles.liveClockText}>{minutes}</BoldText>
+        <BoldText style={styles.liveClockColon}>:</BoldText>
+        <AnimatedSeconds seconds={time.getSeconds()} />
+      </View>
+      <BoldText small style={styles.dateText}>
+        {dateString}
       </BoldText>
-      <RegularText smallest style={styles.liveLabel}>
-        {texts.wallet.detail.liveIndicator}
-      </RegularText>
     </View>
   );
 };
@@ -72,20 +141,24 @@ const ShareableCard = ({
   apiConnection,
   cardNumber,
   cardType,
-  pinCode
+  pinCode,
+  serverCardType
 }: {
   apiConnection: { qrEndpoint: string };
   cardNumber: string;
   cardType: CardType;
   pinCode?: string;
+  serverCardType: TCard;
 }) => {
+  const { barcodeFormat = 'QR' } = serverCardType || {};
+
   return (
     <Wrapper itemsCenter style={{ backgroundColor: colors.surface }}>
       <BarcodeCreatorView
         background={colors.surface}
         foregroundColor={colors.darkText}
-        format={cardType === CardType.BONUS ? BarcodeFormat.CODE128 : BarcodeFormat.QR}
-        style={cardType === CardType.BONUS ? styles.barcode : styles.qrCode}
+        style={barcodeFormat === 'CODE128' ? styles.barcode : styles.qrCode}
+        format={BarcodeFormat[barcodeFormat]}
         value={`${apiConnection.qrEndpoint}${cardNumber}`}
       />
 
@@ -119,17 +192,19 @@ export const WalletCardDetailScreen = ({
   route
 }: {
   navigation: StackNavigationProp<Record<string, any>>;
-  route: RouteProp<{ params: { card: TCard } }>;
+  route: RouteProp<{ params: { savedCard: TCard; serverCardType: TCard } }>;
 }) => {
-  const { globalSettings } = useContext(SettingsContext);
-  const { settings = {} } = globalSettings;
-  const { wallet = {} } = settings;
-  const image = wallet?.[CardType.BONUS] || {};
-  const { card } = route.params;
-  const { apiConnection, cardName, cardNumber, pinCode, title, type: cardType } = card;
+  const { savedCard, serverCardType } = route.params;
+  const { apiConnection, cardName, cardNumber, pinCode, title, type: cardType } = savedCard;
+  const {
+    barcodeFormat = 'QR',
+    imageStyle,
+    imageUrl = '',
+    showLiveClock = false
+  } = serverCardType as TCard;
   const [isFirstLoading, setFirstLoading] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
-  const [cardData, setCardData] = useState<TCard | TCardInfo>(card);
+  const [cardData, setCardData] = useState<TCard | TCardInfo>(savedCard);
   const [refreshing, setRefreshing] = useState(false);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [isFullScreenCode, setIsFullScreenCode] = useState(false);
@@ -246,15 +321,15 @@ export const WalletCardDetailScreen = ({
                   <BarcodeCreatorView
                     background={colors.surface}
                     foregroundColor={colors.darkText}
-                    format={cardType === CardType.BONUS ? BarcodeFormat.CODE128 : BarcodeFormat.QR}
-                    style={cardType === CardType.BONUS ? styles.barcode : styles.qrCode}
+                    format={BarcodeFormat[barcodeFormat]}
+                    style={barcodeFormat === 'CODE128' ? styles.barcode : styles.qrCode}
                     value={`${apiConnection.qrEndpoint}${cardNumber}`}
                   />
                 </TouchableOpacity>
-
-                <LiveClock />
               </Wrapper>
             )}
+
+            {cardType === CardType.COUPON && showLiveClock && <LiveClock />}
 
             <Wrapper>
               <Wrapper style={{ backgroundColor: colors.shadowRgba, borderRadius: normalize(8) }}>
@@ -296,7 +371,7 @@ export const WalletCardDetailScreen = ({
                   </WrapperVertical>
                 )}
 
-                {!!cardData?.balanceAsEuro && (
+                {cardData?.balanceAsEuro != null && (
                   <WrapperVertical noPaddingBottom>
                     <WrapperRow spaceBetween itemsCenter>
                       <BoldText small>{texts.wallet.detail.balance}</BoldText>
@@ -307,34 +382,31 @@ export const WalletCardDetailScreen = ({
                   </WrapperVertical>
                 )}
 
-                {cardType === CardType.COUPON && (
-                  <WrapperVertical noPaddingBottom>
-                    <Button
-                      icon={
-                        isLoading ? (
-                          <ActivityIndicator />
-                        ) : (
-                          <Icon.NamedIcon name="refresh" color={colors.surface} />
-                        )
-                      }
-                      iconPosition="left"
-                      onPress={async () => {
-                        setIsLoading(true);
-                        await fetchCardDetails();
-                        setIsLoading(false);
-                      }}
-                      title={texts.wallet.detail.updateBalance}
-                    />
-                  </WrapperVertical>
-                )}
+                <WrapperVertical noPaddingBottom>
+                  <Button
+                    icon={
+                      isLoading ? (
+                        <ActivityIndicator />
+                      ) : (
+                        <Icon.NamedIcon name="refresh" color={colors.surface} />
+                      )
+                    }
+                    iconPosition="left"
+                    onPress={async () => {
+                      setIsLoading(true);
+                      await fetchCardDetails();
+                      setIsLoading(false);
+                    }}
+                    title={texts.wallet.detail.updateBalance}
+                  />
+                </WrapperVertical>
               </Wrapper>
 
-              {cardType === CardType.BONUS && !!image?.imageUrl && (
+              {cardType === CardType.BONUS && showLiveClock && <LiveClock />}
+
+              {!!imageUrl && (
                 <WrapperVertical noPaddingBottom>
-                  <Image
-                    source={{ uri: image.imageUrl }}
-                    style={[styles.image, image.imageStyle]}
-                  />
+                  <Image source={{ uri: imageUrl }} style={[styles.image, imageStyle]} />
                 </WrapperVertical>
               )}
 
@@ -375,7 +447,7 @@ export const WalletCardDetailScreen = ({
 
         <Wrapper itemsCenter>
           <BoldText>{texts.wallet.detail.deleteConfirmationTitle}</BoldText>
-          {cardType === CardType.COUPON && cardData?.balanceAsEuro && (
+          {cardType === CardType.COUPON && cardData?.balanceAsEuro != null && (
             <WrapperVertical>
               <RegularText center>
                 {texts.wallet.detail.deleteConfirmationMessage(cardData?.balanceAsEuro)}
@@ -422,8 +494,10 @@ export const WalletCardDetailScreen = ({
             apiConnection={apiConnection}
             cardNumber={cardNumber}
             cardType={cardType}
+            serverCardType={serverCardType}
           />
-          <LiveClock />
+
+          {showLiveClock && <LiveClock />}
         </Wrapper>
       </Modal>
 
@@ -435,6 +509,7 @@ export const WalletCardDetailScreen = ({
               cardNumber={cardNumber}
               cardType={cardType}
               pinCode={pinCode}
+              serverCardType={serverCardType}
             />
           </ViewShot>
         </View>
@@ -476,29 +551,41 @@ const styles = StyleSheet.create({
   },
   liveClockContainer: {
     alignItems: 'center',
-    backgroundColor: colors.shadowRgba,
-    borderRadius: normalize(8),
-    flexDirection: 'row',
-    justifyContent: 'center',
-    marginTop: normalize(8),
-    paddingHorizontal: normalize(12),
-    paddingVertical: normalize(6)
+    marginTop: normalize(4),
+    paddingVertical: normalize(4)
   },
   liveClockText: {
     color: colors.primary,
+    fontSize: normalize(48),
     fontVariant: ['tabular-nums'],
-    fontSize: normalize(16)
+    lineHeight: SECOND_DIGIT_HEIGHT,
+    textAlign: 'center'
   },
-  liveDot: {
-    backgroundColor: colors.error,
-    borderRadius: normalize(4),
-    height: normalize(8),
-    marginRight: normalize(6),
-    width: normalize(8)
+  liveClockColon: {
+    color: colors.primary,
+    fontSize: normalize(48),
+    lineHeight: SECOND_DIGIT_HEIGHT,
+    marginHorizontal: normalize(2)
   },
-  liveLabel: {
-    color: colors.darkText,
-    marginLeft: normalize(6)
+  clockRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'center'
+  },
+  secondsSlotContainer: {
+    height: SECOND_DIGIT_HEIGHT * 2,
+    overflow: 'hidden',
+    width: normalize(72)
+  },
+  secondSlot: {
+    alignItems: 'center',
+    height: SECOND_DIGIT_HEIGHT,
+    justifyContent: 'center'
+  },
+  dateText: {
+    bottom: normalize(20),
+    color: colors.placeholder,
+    position: 'absolute'
   },
   qrOverlayCloseButton: {
     alignItems: 'center',

--- a/src/screens/Wallet/WalletCardDetailScreen.tsx
+++ b/src/screens/Wallet/WalletCardDetailScreen.tsx
@@ -1,6 +1,6 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 import * as Sharing from 'expo-sharing';
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import {
@@ -136,7 +136,7 @@ export const WalletCardDetailScreen = ({
   const [isCapturing, setIsCapturing] = useState(false);
   const [isPinVisible, setIsPinVisible] = useState(false);
 
-  const viewShotRef = useRef();
+  const viewShotRef = useRef(null);
 
   const fetchCardDetails = useCallback(async () => {
     try {
@@ -162,16 +162,16 @@ export const WalletCardDetailScreen = ({
       setIsCapturing(true);
 
       // Wait for ViewShot to mount
-      setTimeout(async () => {
-        const base64 = await viewShotRef?.current?.capture();
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
-        // as URL sharing is not possible on Android, we need to save the file. On iOS, direct sharing of base64 data is supported
-        await FileSystem.writeAsStringAsync(fileUri, base64, {
-          encoding: FileSystem.EncodingType.Base64
-        });
+      const base64 = await viewShotRef?.current?.capture();
 
-        await Sharing.shareAsync(fileUri);
-      }, 50);
+      // as URL sharing is not possible on Android, we need to save the file. On iOS, direct sharing of base64 data is supported
+      await FileSystem.writeAsStringAsync(fileUri, base64, {
+        encoding: FileSystem.EncodingType.Base64
+      });
+
+      await Sharing.shareAsync(fileUri);
     } catch (e) {
       console.error(e);
       Alert.alert(texts.wallet.detail.errorTitle, texts.wallet.detail.shareErrorMessage);

--- a/src/screens/Wallet/WalletCardDetailScreen.tsx
+++ b/src/screens/Wallet/WalletCardDetailScreen.tsx
@@ -148,9 +148,9 @@ const ShareableCard = ({
   cardNumber: string;
   cardType: CardType;
   pinCode?: string;
-  serverCardType: TCard;
+  serverCardType?: TCard;
 }) => {
-  const { barcodeFormat = 'QR' } = serverCardType || {};
+  const { barcodeFormat = 'QR' } = serverCardType ?? {};
 
   return (
     <Wrapper itemsCenter style={{ backgroundColor: colors.surface }}>
@@ -192,7 +192,7 @@ export const WalletCardDetailScreen = ({
   route
 }: {
   navigation: StackNavigationProp<Record<string, any>>;
-  route: RouteProp<{ params: { savedCard: TCard; serverCardType: TCard } }>;
+  route: RouteProp<{ params: { savedCard: TCard; serverCardType?: TCard } }>;
 }) => {
   const { savedCard, serverCardType } = route.params;
   const { apiConnection, cardName, cardNumber, pinCode, title, type: cardType } = savedCard;
@@ -201,7 +201,7 @@ export const WalletCardDetailScreen = ({
     imageStyle,
     imageUrl = '',
     showLiveClock = false
-  } = serverCardType as TCard;
+  } = serverCardType ?? {};
   const [isFirstLoading, setFirstLoading] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [cardData, setCardData] = useState<TCard | TCardInfo>(savedCard);
@@ -240,6 +240,10 @@ export const WalletCardDetailScreen = ({
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       const base64 = await viewShotRef?.current?.capture();
+
+      if (!base64) {
+        throw new Error('Failed to capture wallet card image');
+      }
 
       // as URL sharing is not possible on Android, we need to save the file. On iOS, direct sharing of base64 data is supported
       await FileSystem.writeAsStringAsync(fileUri, base64, {
@@ -382,24 +386,26 @@ export const WalletCardDetailScreen = ({
                   </WrapperVertical>
                 )}
 
-                <WrapperVertical noPaddingBottom>
-                  <Button
-                    icon={
-                      isLoading ? (
-                        <ActivityIndicator />
-                      ) : (
-                        <Icon.NamedIcon name="refresh" color={colors.surface} />
-                      )
-                    }
-                    iconPosition="left"
-                    onPress={async () => {
-                      setIsLoading(true);
-                      await fetchCardDetails();
-                      setIsLoading(false);
-                    }}
-                    title={texts.wallet.detail.updateBalance}
-                  />
-                </WrapperVertical>
+                {cardType === CardType.COUPON && (
+                  <WrapperVertical noPaddingBottom>
+                    <Button
+                      icon={
+                        isLoading ? (
+                          <ActivityIndicator />
+                        ) : (
+                          <Icon.NamedIcon name="refresh" color={colors.surface} />
+                        )
+                      }
+                      iconPosition="left"
+                      onPress={async () => {
+                        setIsLoading(true);
+                        await fetchCardDetails();
+                        setIsLoading(false);
+                      }}
+                      title={texts.wallet.detail.updateBalance}
+                    />
+                  </WrapperVertical>
+                )}
               </Wrapper>
 
               {cardType === CardType.BONUS && showLiveClock && <LiveClock />}

--- a/src/screens/Wallet/WalletHomeScreen.tsx
+++ b/src/screens/Wallet/WalletHomeScreen.tsx
@@ -86,16 +86,16 @@ export const WalletHomeScreen = () => {
     return map;
   }, [cardTypes]);
 
-  const [cards, setCards] = useState<TCard[]>([]);
+  const [savedCards, setSavedCards] = useState<TCard[]>([]);
   const [savedCardsLoading, setSavedCardsLoading] = useState<boolean>(true);
 
   const fetchCards = useCallback(async () => {
     const savedCards = await getSavedCards();
 
     if (savedCards?.length) {
-      setCards(savedCards);
+      setSavedCards(savedCards);
     } else {
-      setCards([]);
+      setSavedCards([]);
     }
   }, []);
 
@@ -110,7 +110,7 @@ export const WalletHomeScreen = () => {
     return <LoadingSpinner loading />;
   }
 
-  if (!cards?.length) {
+  if (!savedCards?.length) {
     return (
       <SafeAreaViewFlex>
         <WrapperVertical>
@@ -128,27 +128,28 @@ export const WalletHomeScreen = () => {
     );
   }
 
-  const listItem = cards
-    .filter((card: TCard) => {
-      const serverCardType = cardTypeMap.get(card.type);
+  const listItem = savedCards
+    .filter((savedCard: TCard) => {
+      const serverCardType = cardTypeMap.get(savedCard.type);
 
       return serverCardType?.isVisible !== false;
     })
-    .map((card: TCard) => {
-      const serverCardType = cardTypeMap.get(card.type);
-      const iconBackgroundColor = serverCardType?.iconBackgroundColor ?? card.iconBackgroundColor;
-      const iconColor = serverCardType?.iconColor ?? card.iconColor;
+    .map((savedCard: TCard) => {
+      const serverCardType = cardTypeMap.get(savedCard.type);
+      const iconBackgroundColor =
+        serverCardType?.iconBackgroundColor ?? savedCard.iconBackgroundColor;
+      const iconColor = serverCardType?.iconColor ?? savedCard.iconColor;
 
       return {
         leftIcon: (
           <Wrapper style={[styles.iconContainer, { backgroundColor: iconBackgroundColor }]}>
-            <Icon.NamedIcon name={card.iconName} color={iconColor} />
+            <Icon.NamedIcon name={savedCard.iconName} color={iconColor} />
           </Wrapper>
         ),
-        params: { card, title: texts.screenTitles.wallet.detail },
+        params: { savedCard, serverCardType, title: texts.screenTitles.wallet.detail },
         routeName: ScreenName.WalletCardDetail,
-        subtitle: card.description,
-        title: card.cardName || card.title
+        subtitle: savedCard.description,
+        title: savedCard.cardName || savedCard.title
       };
     });
 

--- a/src/types/wallet/Card.ts
+++ b/src/types/wallet/Card.ts
@@ -1,16 +1,24 @@
+import type { ImageStyle } from 'react-native';
+import type { BarcodeFormat } from 'react-native-barcode-creator';
+
 export type TCard = {
   apiConnection: TApiConnection;
+  balanceAsEuro?: number;
+  barcodeFormat?: keyof typeof BarcodeFormat;
   cardName?: string;
   cardNumber: string;
   description?: string;
   iconBackgroundColor: string;
   iconColor: string;
   iconName: string;
+  imageStyle?: ImageStyle;
+  imageUrl?: string;
   isVisible?: boolean;
   leftIcon: React.ReactNode;
   params?: Record<string, any>;
   pinCode?: string;
   routeName?: string;
+  showLiveClock?: boolean;
   subtitle: string;
   title: string;
   type: CardType;


### PR DESCRIPTION
This PR adds a clock component to the wallet module for validity checks. Additionally, the image display feature and the `barcodeFormat` property on the detail screen have been updated to allow for the management of different card types via staticContent.

|bonus card type detail screen|bonus card type scanner modal|coupon card type detail screen|coupon card type scanner|
|--|--|--|--|
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-04-09 at 15 25 11" src="https://github.com/user-attachments/assets/c8bc7115-55ec-4ef1-8673-0fc5a18228bd" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-04-09 at 15 25 15" src="https://github.com/user-attachments/assets/f078f8e4-1564-4ea0-9d38-6f70bef27116" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-04-09 at 15 25 21" src="https://github.com/user-attachments/assets/79c0bbc7-0e7d-43c2-96d7-461de7663c36" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-04-09 at 15 25 24" src="https://github.com/user-attachments/assets/87838aad-d508-4b7a-8ae6-61c188c927d8" />

SVAK-167