### PR TITLE
fix: refresh home section for points of interest and tours

### DIFF
--- a/src/components/DataListSection.tsx
+++ b/src/components/DataListSection.tsx
@@ -16,6 +16,23 @@ import { BoldText } from './Text';
 import { Touchable } from './Touchable';
 import { Wrapper } from './Wrapper';
 
+const pointsOfInterestAndToursListCache = new Map<number, unknown[]>();
+
+// Keep exactly one shuffled snapshot per fetched data version so tab switches reuse the same order.
+const cachePointsOfInterestAndToursListData = (cacheKey: number, listData: unknown[]) => {
+  pointsOfInterestAndToursListCache.set(cacheKey, listData);
+
+  if (pointsOfInterestAndToursListCache.size > 1) {
+    const oldestKey = pointsOfInterestAndToursListCache.keys().next().value;
+
+    if (oldestKey !== undefined) {
+      pointsOfInterestAndToursListCache.delete(oldestKey);
+    }
+  }
+
+  return listData;
+};
+
 type Props = {
   additionalData?: unknown[];
   buttonTitle?: string;
@@ -28,10 +45,11 @@ type Props = {
   navigate?: () => void;
   navigateButton?: () => void;
   navigateLink?: () => void;
-  navigation: StackNavigationProp<any>;
+  navigation: StackNavigationProp<Record<string, object | undefined>>;
   listType?: string;
   placeholder?: React.ReactElement;
   query: string;
+  queryUpdatedAt?: number;
   queryVariables?: Record<string, unknown>;
   sectionData?: unknown[];
   sectionTitle?: string;
@@ -57,6 +75,7 @@ export const DataListSection = ({
   listType,
   placeholder,
   query,
+  queryUpdatedAt,
   queryVariables,
   sectionData,
   sectionTitle = getTitleForQuery(query),
@@ -82,7 +101,8 @@ export const DataListSection = ({
     );
   }
 
-  let listData = parseListItemsFromQuery(query, sectionData, sectionTitleDetail, {
+  const isPointsOfInterestAndTours = query === QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS;
+  const queryOptions = {
     withDate:
       (query === QUERY_TYPES.EVENT_RECORDS && !queryVariables?.onlyUniqEvents) ||
       query === QUERY_TYPES.VOLUNTEER.CALENDAR_ALL ||
@@ -90,7 +110,21 @@ export const DataListSection = ({
       query === QUERY_TYPES.VOLUNTEER.CONVERSATIONS,
     withTime: query === QUERY_TYPES.EVENT_RECORDS && !queryVariables?.onlyUniqEvents,
     queryKey: query === QUERY_TYPES.VOUCHERS ? QUERY_TYPES.GENERIC_ITEMS : query
-  });
+  };
+
+  let listData =
+    isPointsOfInterestAndTours && queryUpdatedAt
+      ? pointsOfInterestAndToursListCache.get(queryUpdatedAt)
+      : undefined;
+
+  if (!listData) {
+    listData = parseListItemsFromQuery(query, sectionData, sectionTitleDetail, queryOptions);
+
+    if (isPointsOfInterestAndTours && queryUpdatedAt && listData?.length) {
+      // Cache the already shuffled output so the same query result keeps the same order.
+      listData = cachePointsOfInterestAndToursListData(queryUpdatedAt, listData);
+    }
+  }
 
   if (listData?.length && additionalData?.length) {
     listData.push(...additionalData);

--- a/src/components/HomeSection.tsx
+++ b/src/components/HomeSection.tsx
@@ -2,7 +2,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import React from 'react';
 import { useQuery } from 'react-query';
 
-import { useHomeRefresh, useVolunteerData } from '../hooks';
+import { useHomePointsOfInterestAndToursRefresh, useHomeRefresh, useVolunteerData } from '../hooks';
 import { getQuery, QUERY_TYPES } from '../queries';
 import { ReactQueryClient } from '../ReactQueryClient';
 
@@ -19,7 +19,7 @@ type Props = {
     | 'cache-and-network';
   isIndexStartingAt1: boolean;
   navigate: () => void;
-  navigation: StackNavigationProp<any>;
+  navigation: StackNavigationProp<Record<string, object | undefined>>;
   placeholder?: React.ReactElement;
   query: string;
   queryVariables: { limit?: number; take?: number };
@@ -40,11 +40,24 @@ export const HomeSection = ({
   title,
   titleDetail
 }: Props) => {
-  const { data, isLoading, refetch } = useQuery([query, queryVariables], async () => {
-    const client = await ReactQueryClient();
+  const isPointsOfInterestAndTours = query === QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS;
+  // `dataUpdatedAt` is provided by react-query and changes whenever a successful fetch updates data.
+  const { data, dataUpdatedAt, isLoading, refetch } = useQuery(
+    [query, queryVariables],
+    async () => {
+      const client = await ReactQueryClient();
 
-    return await client.request(getQuery(query), queryVariables);
-  });
+      return await client.request(getQuery(query), queryVariables);
+    },
+    isPointsOfInterestAndTours
+      ? {
+          // Keep one random selection stable across tab switches; manual refresh uses a separate event.
+          staleTime: 60 * 60 * 1000,
+          refetchOnWindowFocus: false,
+          refetchOnReconnect: false
+        }
+      : undefined
+  );
 
   const isCalendarWithVolunteerEvents = query === QUERY_TYPES.EVENT_RECORDS && showVolunteerEvents;
 
@@ -59,14 +72,27 @@ export const HomeSection = ({
     isSectioned: false
   });
 
-  useHomeRefresh(() => {
-    refetch();
-    isCalendarWithVolunteerEvents && refetchVolunteerEvents();
-  });
+  useHomeRefresh(
+    isPointsOfInterestAndTours
+      ? undefined
+      : () => {
+          refetch();
+          isCalendarWithVolunteerEvents && refetchVolunteerEvents();
+        }
+  );
+
+  useHomePointsOfInterestAndToursRefresh(
+    isPointsOfInterestAndTours
+      ? () => {
+          // Pull-to-refresh must always fetch a new random result, even inside the cache window.
+          refetch();
+        }
+      : undefined
+  );
 
   let showButton = !!data?.[query]?.length;
 
-  if (query === QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS) {
+  if (isPointsOfInterestAndTours) {
     showButton =
       !!data?.[QUERY_TYPES.POINTS_OF_INTEREST]?.length || !!data?.[QUERY_TYPES.TOURS]?.length;
   }
@@ -86,6 +112,7 @@ export const HomeSection = ({
       navigation={navigation}
       placeholder={placeholder}
       query={query}
+      queryUpdatedAt={dataUpdatedAt}
       sectionData={data}
       sectionTitle={title}
       sectionTitleDetail={titleDetail}

--- a/src/components/HorizontalList.js
+++ b/src/components/HorizontalList.js
@@ -4,7 +4,7 @@ import { FlatList } from 'react-native';
 
 import { useRenderItem } from '../hooks';
 
-const keyExtractor = (item, index) => `index${index}-id${item.id}`;
+const keyExtractor = (item) => `${item.params?.query || 'item'}-${item.id}`;
 
 export const HorizontalList = ({ navigation, data, query }) => {
   const renderItem = useRenderItem(query, navigation, { horizontal: true });

--- a/src/hooks/HomeRefresh.ts
+++ b/src/hooks/HomeRefresh.ts
@@ -4,6 +4,8 @@ import { DeviceEventEmitter } from 'react-native';
 import { QUERY_TYPES } from '../queries';
 
 export const HOME_REFRESH_EVENT = 'SVA_HOME_REFRESH';
+export const HOME_FORCE_REFRESH_POINTS_OF_INTEREST_AND_TOURS_EVENT =
+  'SVA_HOME_FORCE_REFRESH_POINTS_OF_INTEREST_AND_TOURS';
 export const VOLUNTEER_HOME_REFRESH_EVENT = 'SVA_VOLUNTEER_HOME_REFRESH';
 export const VOLUNTEER_PERSONAL_REFRESH_EVENT = 'SVA_VOLUNTEER_PERSONAL_REFRESH';
 export const VOLUNTEER_GROUP_REFRESH_EVENT = 'SVA_VOLUNTEER_GROUP_REFRESH';
@@ -15,6 +17,20 @@ export const useHomeRefresh = (onRefresh?: () => void) => {
     if (!onRefresh) return;
 
     const subscription = DeviceEventEmitter.addListener(HOME_REFRESH_EVENT, onRefresh);
+
+    return () => subscription.remove();
+  }, [onRefresh]);
+};
+
+export const useHomePointsOfInterestAndToursRefresh = (onRefresh?: () => void) => {
+  useEffect(() => {
+    if (!onRefresh) return;
+
+    // This event is only emitted by manual pull-to-refresh to bypass stale time.
+    const subscription = DeviceEventEmitter.addListener(
+      HOME_FORCE_REFRESH_POINTS_OF_INTEREST_AND_TOURS_EVENT,
+      onRefresh
+    );
 
     return () => subscription.remove();
   }, [onRefresh]);

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -32,7 +32,10 @@ import {
   useRedeemLocalVouchers,
   useVersionCheck
 } from '../hooks';
-import { HOME_REFRESH_EVENT } from '../hooks/HomeRefresh';
+import {
+  HOME_FORCE_REFRESH_POINTS_OF_INTEREST_AND_TOURS_EVENT,
+  HOME_REFRESH_EVENT
+} from '../hooks/HomeRefresh';
 import { QUERY_TYPES, getQueryType } from '../queries';
 import { ScreenName } from '../types';
 
@@ -237,6 +240,7 @@ export const HomeScreen = ({ navigation, route }) => {
     // this will trigger the onRefresh functions provided to the `useHomeRefresh` hook in other
     // components.
     DeviceEventEmitter.emit(HOME_REFRESH_EVENT);
+    DeviceEventEmitter.emit(HOME_FORCE_REFRESH_POINTS_OF_INTEREST_AND_TOURS_EVENT);
 
     // we simulate state change of `refreshing` with setting it to `true` first and after
     // a timeout to `false` again, which will result in a re-rendering of the screen.


### PR DESCRIPTION
This change stabilized the Home screen's Points of Interest and Tours slider when switching away from and back to the Home tab. The section kept using random server results and client-side shuffling, but it now reused the same shuffled output for the same cached `react-query` data snapshot instead of reshuffling on every remount. Pull-to-refresh still explicitly bypassed the cache and fetched a new random result, so users still got fresh content on manual refresh without the cards visibly jumping during normal tab navigation.