### PR TITLE
fix(HtmlView): resolve YouTube iframe error 153 and 152-4 via Referer header

### DIFF
--- a/src/components/HtmlView.js
+++ b/src/components/HtmlView.js
@@ -72,6 +72,40 @@ const htmlConfig = {
   }
 };
 
+const isYouTubeUri = (uri) => {
+  if (!uri) {
+    return false;
+  }
+  try {
+    const { hostname } = new URL(uri);
+    const normalizedHostname = hostname.toLowerCase();
+    return (
+      normalizedHostname === 'youtu.be' ||
+      normalizedHostname === 'youtube.com' ||
+      normalizedHostname.endsWith('.youtube.com')
+    );
+  } catch {
+    // Invalid URLs must not break HTML rendering.
+    return false;
+  }
+};
+
+// YouTube embeds require a Referer header, otherwise YouTube returns error 153
+// ("The request contains no HTTP Referer or equivalent client identity").
+// provideEmbeddedHeaders is called by @native-html/iframe-plugin for each iframe src
+// and the returned headers are passed to the underlying WebView source.
+// Note: using 'https://www.youtube.com' as Referer causes error 152-4 because YouTube
+// applies stricter embed rules when the Referer matches its own domain. Using a neutral
+// origin like 'https://example.com' (RFC 2606 reserved placeholder) satisfies the
+// presence check without triggering those domain-specific restrictions.
+const provideEmbeddedHeaders = (uri) => {
+  if (isYouTubeUri(uri)) {
+    return { Referer: 'https://example.com' };
+  }
+
+  return undefined;
+};
+
 export const HtmlView = memo(
   ({
     big = true,
@@ -108,6 +142,7 @@ export const HtmlView = memo(
       <HTML
         source={{ html }}
         {...htmlConfig}
+        provideEmbeddedHeaders={provideEmbeddedHeaders}
         renderersProps={{
           a: { onPress: (evt, href) => openLink(href, openWebScreen) },
           iframe: {

--- a/src/components/HtmlView.js
+++ b/src/components/HtmlView.js
@@ -95,12 +95,12 @@ const isYouTubeUri = (uri) => {
 // provideEmbeddedHeaders is called by @native-html/iframe-plugin for each iframe src
 // and the returned headers are passed to the underlying WebView source.
 // Note: using 'https://www.youtube.com' as Referer causes error 152-4 because YouTube
-// applies stricter embed rules when the Referer matches its own domain. Using a neutral
-// origin like 'https://example.com' (RFC 2606 reserved placeholder) satisfies the
-// presence check without triggering those domain-specific restrictions.
+// applies stricter embed rules when the Referer matches its own domain. Using the
+// app's own domain 'https://smart-village.app' satisfies the presence check without
+// triggering those domain-specific restrictions.
 const provideEmbeddedHeaders = (uri) => {
   if (isYouTubeUri(uri)) {
-    return { Referer: 'https://example.com' };
+    return { Referer: 'https://smart-village.app' };
   }
 
   return undefined;


### PR DESCRIPTION
With this PR, the issue where YouTube content embedded via iframes could not be displayed due to an error has been resolved.

|before|after|
|--|--|
<img width="200" alt="Simulator Screenshot - iPhone 13 mini - 2026-04-21 at 14 26 31" src="https://github.com/user-attachments/assets/3f963a13-6e35-4dab-9f12-6aabe0da1868" />|<img width="200" alt="Simulator Screenshot - iPhone 13 mini - 2026-04-21 at 14 27 11" src="https://github.com/user-attachments/assets/536d7402-4b86-4595-8541-3791f47ead6c" />


SVASD-548