### PR TITLE
feat(profile): sync member state on home refresh

### DIFF
--- a/src/ProfileProvider.tsx
+++ b/src/ProfileProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { useQuery } from 'react-query';
 
 import {
@@ -8,6 +8,7 @@ import {
   storeProfileUserData
 } from './helpers';
 import { useHomeRefresh } from './hooks';
+import { NetworkContext } from './NetworkProvider';
 import { QUERY_TYPES } from './queries';
 import { member } from './queries/profile';
 import { ProfileMember } from './types';
@@ -17,67 +18,182 @@ const defaultProfile = {
   isError: false,
   isLoading: true,
   isLoggedIn: false,
-  refresh: () => {}
+  refresh: async () => {}
 };
 
 export const ProfileContext = createContext(defaultProfile);
 
 export const ProfileProvider = ({ children }: { children?: React.ReactNode }) => {
+  const { isConnected } = useContext(NetworkContext);
   const [currentUserData, setCurrentUserData] = useState<ProfileMember | null>(null);
   const [isError, setIsError] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const hasInitialized = useRef(false);
+  const activeOperation = useRef<Promise<void> | null>(null);
+  const pendingMemberSync = useRef(false);
 
-  const { isLoading: isLoadingMember } = useQuery(QUERY_TYPES.PROFILE.MEMBER, member, {
-    enabled: isLoggedIn,
-    onSuccess: (responseData: ProfileMember) => {
+  const clearProfileSession = useCallback(() => {
+    storeProfileAuthToken();
+    storeProfileUserData();
+    setIsLoggedIn(false);
+    setCurrentUserData(null);
+    pendingMemberSync.current = false;
+  }, []);
+
+  const handleMemberResponse = useCallback(
+    (responseData: ProfileMember) => {
       if (!responseData?.member || !responseData?.member?.keycloak_refresh_token) {
-        storeProfileAuthToken();
-        setIsLoggedIn(false);
-        setCurrentUserData(null);
+        clearProfileSession();
 
         return;
       }
 
       storeProfileUserData(responseData);
-    }
+      setCurrentUserData(responseData);
+      setIsError(false);
+      setIsLoggedIn(true);
+      pendingMemberSync.current = false;
+    },
+    [clearProfileSession]
+  );
+
+  const { refetch: refetchMember } = useQuery(QUERY_TYPES.PROFILE.MEMBER, member, {
+    enabled: false
   });
 
-  const logInCallback = useCallback(async () => {
-    setIsLoading(true);
-    setIsError(false);
+  const refetchMemberWithRetryState = useCallback(async () => {
+    const result = await refetchMember();
 
-    try {
-      const storedProfileAuthToken = await profileAuthToken();
-      const { currentUserData: userData } = await profileUserData();
-
-      setIsLoggedIn(!!storedProfileAuthToken);
-      setCurrentUserData(userData);
-    } catch (e) {
-      console.warn(e);
+    if (result.isError) {
+      pendingMemberSync.current = true;
       setIsError(true);
+      throw result.error ?? new Error('Member refetch failed');
     }
 
-    setIsLoading(false);
+    handleMemberResponse(result.data as ProfileMember);
+
+    return result;
+  }, [handleMemberResponse, refetchMember]);
+
+  const runSerializedTask = useCallback((task: () => Promise<void>) => {
+    const operation = (activeOperation.current ?? Promise.resolve())
+      .catch((error) => {
+        console.warn(error);
+      })
+      .then(task)
+      .finally(() => {
+        if (activeOperation.current === operation) {
+          activeOperation.current = null;
+        }
+      });
+
+    activeOperation.current = operation;
+
+    return operation;
   }, []);
 
-  useHomeRefresh(logInCallback);
+  const loadProfileState = useCallback(
+    async ({
+      scheduleMemberSync = false,
+      syncMemberNow = false
+    }: {
+      scheduleMemberSync?: boolean;
+      syncMemberNow?: boolean;
+    } = {}) => {
+      await runSerializedTask(async () => {
+        setIsLoading(true);
+        setIsError(false);
+
+        try {
+          const storedProfileAuthToken = await profileAuthToken();
+          if (!storedProfileAuthToken) {
+            clearProfileSession();
+
+            return;
+          }
+
+          const { currentUserData: userData } = await profileUserData();
+
+          setIsLoggedIn(true);
+          setCurrentUserData(userData);
+
+          pendingMemberSync.current =
+            scheduleMemberSync && !syncMemberNow;
+
+          if (syncMemberNow) {
+            await refetchMemberWithRetryState();
+          }
+        } catch (e) {
+          console.warn(e);
+          setIsError(true);
+        } finally {
+          hasInitialized.current = true;
+          setIsLoading(false);
+        }
+      });
+    },
+    [clearProfileSession, refetchMemberWithRetryState, runSerializedTask]
+  );
+
+  const logInCallback = useCallback(async () => {
+    await loadProfileState({
+      scheduleMemberSync: true,
+      syncMemberNow: isConnected
+    });
+  }, [isConnected, loadProfileState]);
+
+  const syncMemberCallback = useCallback(async ({ requirePendingSync = false } = {}) => {
+    await runSerializedTask(async () => {
+      try {
+        if (requirePendingSync && !pendingMemberSync.current) {
+          return;
+        }
+
+        const storedProfileAuthToken = await profileAuthToken();
+
+        if (!storedProfileAuthToken) {
+          clearProfileSession();
+
+          return;
+        }
+
+        if (isConnected) {
+          // Keep reconnect and home-triggered member syncs silent so background
+          // authorization refreshes do not re-enter the global profile loading state.
+          setIsError(false);
+          await refetchMemberWithRetryState();
+        } else {
+          pendingMemberSync.current = true;
+        }
+      } catch (e) {
+        console.warn(e);
+        pendingMemberSync.current = true;
+        setIsError(true);
+      }
+    });
+  }, [clearProfileSession, isConnected, refetchMemberWithRetryState, runSerializedTask]);
+
+  useHomeRefresh(syncMemberCallback);
 
   useEffect(() => {
-    if (!isLoggedIn) {
-      logInCallback();
-    } else {
-      setIsError(true);
-      setIsLoading(false);
+    loadProfileState({ scheduleMemberSync: true });
+  }, [loadProfileState]);
+
+  useEffect(() => {
+    if (!hasInitialized.current || !isConnected || !isLoggedIn) {
+      return;
     }
-  }, [isLoggedIn]);
+
+    syncMemberCallback({ requirePendingSync: true });
+  }, [isConnected, isLoggedIn, syncMemberCallback]);
 
   return (
     <ProfileContext.Provider
       value={{
         currentUserData,
         isError,
-        isLoading: isLoading || isLoadingMember,
+        isLoading,
         isLoggedIn,
         refresh: logInCallback
       }}


### PR DESCRIPTION
This PR hardens the profile sync flow in the mobile app so Keycloak-driven member and role updates can be applied reliably after app start, on reconnect, and on home-triggered refreshes without requiring a logout/login cycle.

_Why_

- Keycloak roles and permissions may change while a user is still logged in.
- The app needed to pick those changes up through /member without forcing a new login.
- The previous flow was vulnerable to loading flicker, duplicate sync triggers, stale connectivity timing, and async races between bootstrap and background refresh paths.

_Result_

- Existing sessions can pick up server-side role changes more reliably.
- Reconnects no longer re-run the full profile bootstrap loading flow.
- Background profile syncs are less noisy for the UI.
- Profile state updates are serialized and more deterministic.

MQGB-208