### PR TITLE
fix: hide bookmark icon in header

### DIFF
--- a/src/screens/SUE/SueDetailScreen.tsx
+++ b/src/screens/SUE/SueDetailScreen.tsx
@@ -192,6 +192,7 @@ export const SueDetailScreen = ({ navigation, route }: StackScreenProps<any>) =>
                   }
 
                   navigation.push(ScreenName.Detail, {
+                    bookmarkable: false,
                     details,
                     query: targetQuery,
                     queryVariables: { id: serviceRequestId },


### PR DESCRIPTION
With this PR, the bookmark icon that appeared in the header on the detail screen where I view my own report has been removed

|before|after|
|--|--|
<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-05-05 at 10 08 23" src="https://github.com/user-attachments/assets/2db917bc-b0b5-416d-b9e5-028e2785e222" />|<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-05-05 at 10 08 15" src="https://github.com/user-attachments/assets/3faa64d7-1d50-4e67-9edd-764b079244b8" />

SUE-204