### PR TITLE
feat: add alert for coordinates from image

### DIFF
--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -88,6 +88,7 @@ export const SueReportLocation = ({
   selectedPosition,
   setIsFullscreenMap,
   setSelectedPosition,
+  setShowCoordinatesFromImageAlert,
   setUpdateRegionFromImage,
   setValue
 }: {
@@ -106,6 +107,7 @@ export const SueReportLocation = ({
   selectedPosition?: Location.LocationObjectCoords;
   setIsFullscreenMap: (value: boolean) => void;
   setSelectedPosition: (position?: Location.LocationObjectCoords) => void;
+  setShowCoordinatesFromImageAlert: (value: boolean) => void;
   setUpdateRegionFromImage: (value: boolean) => void;
   setValue: UseFormSetValue<TValues>;
   updateRegionFromImage: boolean;
@@ -223,6 +225,7 @@ export const SueReportLocation = ({
 
     latestReverseGeocodeRequestRef.current = requestId;
     setSelectedPosition(position);
+    setShowCoordinatesFromImageAlert(true);
     setUpdateRegionFromImage(false);
     clearAddressFields();
 

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -193,6 +193,7 @@ const Content = ({
           selectedPosition={selectedPosition}
           setIsFullscreenMap={setIsFullscreenMap}
           setSelectedPosition={setSelectedPosition}
+          setShowCoordinatesFromImageAlert={setShowCoordinatesFromImageAlert}
           setUpdateRegionFromImage={setUpdateRegionFromImage}
           setValue={setValue}
           updateRegionFromImage={updateRegionFromImage}
@@ -272,7 +273,13 @@ export const SueReportScreen = ({
   const errorMessage =
     configuredErrorMessage || texts.sue.report.alerts.limitOfArea(limitOfAreaCity);
 
-  const [showCoordinatesFromImageAlert, setShowCoordinatesFromImageAlert] = useState(false);
+  // useRef instead of useState: the flag must be read synchronously inside
+  // alertTextGeneratorForMissingData to prevent React async-batching from
+  // causing the "coordinates from image" alert to fire more than once.
+  const showCoordinatesFromImageAlertRef = useRef(false);
+  const setShowCoordinatesFromImageAlert = useCallback((value: boolean) => {
+    showCoordinatesFromImageAlertRef.current = value;
+  }, []);
   const [currentProgress, setCurrentProgress] = useState(0);
   const [service, setService] = useState<TService>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -395,7 +402,7 @@ export const SueReportScreen = ({
             alertText = texts.sue.report.alerts.imagesTotalSizeError(
               formatSizeStandard(totalSizeLimit, 0)
             );
-          } else if (selectedPosition && !showCoordinatesFromImageAlert) {
+          } else if (selectedPosition && !showCoordinatesFromImageAlertRef.current) {
             setShowCoordinatesFromImageAlert(true);
             Alert.alert(texts.sue.report.alerts.hint, texts.sue.report.alerts.imageLocation);
           }


### PR DESCRIPTION
This PR resolves issues with the feature that retrieves a location from a selected image. If the selected location is within the defined boundaries, the user is notified on the location selection page. If the selected location is outside the defined boundaries, the user is prompted to select a location. If the selected image does not contain location information, the user is again prompted to select a location.

|When an image with a location is selected|When an image without a location is selected|When an image with no location information is selected|
|--|--|--|
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-05 at 13 27 16" src="https://github.com/user-attachments/assets/35509e4a-b060-4ee6-8e35-f10f9fd58d6d" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-05 at 13 27 45" src="https://github.com/user-attachments/assets/31a1c911-6a08-4322-a198-f19d6dfe36c3" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-05 at 13 28 08" src="https://github.com/user-attachments/assets/9f8d70a4-2e60-4cdd-ad31-364a7028e43b" />

SUE-194