### PR TITLE
fix: disable `SueImageFallback` component

### DIFF
--- a/src/components/SUE/SueImageFallback.tsx
+++ b/src/components/SUE/SueImageFallback.tsx
@@ -5,6 +5,8 @@ import { Icon, colors, normalize } from '../../config';
 import { imageHeight, imageWidth } from '../../helpers';
 
 export const SueImageFallback = ({ style }: { style?: any }) => {
+  // HINT: This component has been disabled upon request. It has not been deleted so that it can be quickly reintegrated if needed.
+  return null;
   return (
     <View style={[styles.container, stylesForImage().defaultStyle, style]}>
       <Icon.SueBroom color={colors.placeholder} size={normalize(32)} />


### PR DESCRIPTION
This PR removes the fallback image prepared for the SUE module.

|before list screen|after list screen|before detail screen|after detail screen|
|--|--|--|--|
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-06 at 09 04 16" src="https://github.com/user-attachments/assets/05e4048b-b4c1-4852-9cc5-e0e5f88572ba" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-06 at 09 04 09" src="https://github.com/user-attachments/assets/3dc8430b-664c-4345-ba7b-efc3019aa3b7" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-06 at 09 04 17" src="https://github.com/user-attachments/assets/e2031975-0ca6-4b2a-b963-65a473bcee98" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-06 at 09 04 11" src="https://github.com/user-attachments/assets/1927ce14-d4e3-45ec-89b6-645960f10e84" />


SUE-202