### PR TITLE
fix: resolve gallery access permission issue

### DIFF
--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -452,6 +452,9 @@ export const texts = {
   errors: {
     image: {
       body: 'Es fehlt die Berechtigung Bilder aus der Medienbibliothek auszuwählen.',
+      cancel: 'Abbrechen',
+      openSettings: 'Einstellungen öffnen',
+      saveBody: 'Es fehlt die Berechtigung zum Speichern in der Medienbibliothek.',
       title: 'Hinweis'
     },
     errorTitle: 'Fehler',

--- a/src/hooks/imagePicker.ts
+++ b/src/hooks/imagePicker.ts
@@ -33,12 +33,16 @@ const saveImageToGallery = async (uri: string) => {
   const { status: existingStatus, canAskAgain } = await getPermissionsAsync();
   const appName = appJson.expo.name;
 
-  let status = existingStatus;
-
-  if (status !== PermissionStatus.GRANTED) {
-    if (canAskAgain) {
-      ({ status } = await requestPermissionsAsync(undefined, ['photo']));
+  if (existingStatus !== PermissionStatus.GRANTED) {
+    if (!canAskAgain) {
+      Alert.alert(texts.errors.image.title, texts.errors.image.saveBody, [
+        { text: texts.errors.image.cancel, style: 'cancel' },
+        { text: texts.errors.image.openSettings, onPress: () => Linking.openSettings() }
+      ]);
+      return;
     }
+
+    const { status } = await requestPermissionsAsync(undefined, ['photo']);
 
     if (status !== PermissionStatus.GRANTED) {
       Alert.alert(texts.errors.image.title, texts.errors.image.saveBody, [

--- a/src/hooks/imagePicker.ts
+++ b/src/hooks/imagePicker.ts
@@ -10,10 +10,11 @@ import {
   createAlbumAsync,
   createAssetAsync,
   getAlbumAsync,
+  getPermissionsAsync,
   requestPermissionsAsync
 } from 'expo-media-library';
 import { useCallback, useState } from 'react';
-import { Alert } from 'react-native';
+import { Alert, Linking } from 'react-native';
 
 import appJson from '../../app.json';
 import { device, texts } from '../config';
@@ -27,11 +28,25 @@ export const MediaTypeOptions: Record<'Images' | 'Videos' | 'All', TMediaTypeOpt
 };
 
 const saveImageToGallery = async (uri: string) => {
-  const { status } = await requestPermissionsAsync(undefined, ['photo']);
+  // Check existing permission status first to avoid triggering the iOS photo
+  // picker overlay when the user previously granted only limited access.
+  const { status: existingStatus, canAskAgain } = await getPermissionsAsync();
   const appName = appJson.expo.name;
 
+  let status = existingStatus;
+
   if (status !== PermissionStatus.GRANTED) {
-    return;
+    if (canAskAgain) {
+      ({ status } = await requestPermissionsAsync(undefined, ['photo']));
+    }
+
+    if (status !== PermissionStatus.GRANTED) {
+      Alert.alert(texts.errors.image.title, texts.errors.image.saveBody, [
+        { text: texts.errors.image.cancel, style: 'cancel' },
+        { text: texts.errors.image.openSettings, onPress: () => Linking.openSettings() }
+      ]);
+      return;
+    }
   }
 
   try {


### PR DESCRIPTION
This PR updates the system so that the permission request to access the gallery is only displayed when permission has not been granted while on the report screen

SUE-207