### PR TITLE
fix: resolve layout shift in map preview when fallback image is removed

### DIFF
--- a/src/screens/SUE/SueMapScreen.tsx
+++ b/src/screens/SUE/SueMapScreen.tsx
@@ -17,7 +17,6 @@ import {
   MapLibre,
   RegularText,
   SafeAreaViewFlex,
-  SueImageFallback,
   SueStatus,
   Touchable,
   Wrapper,
@@ -184,7 +183,7 @@ export const SueMapScreen = ({ navigation, route, viewType, setViewType }: Props
               </>
             ) : (
               <>
-                <SueImageFallback style={[styles.imageContainer, styles.image]} />
+                <View style={styles.imagePlaceholder} />
                 <CloseButton onPress={() => setSelectedRequestId(undefined)} />
               </>
             )}
@@ -248,6 +247,10 @@ const styles = StyleSheet.create({
   image: {
     height: normalize(120),
     width: normalize(120)
+  },
+  imagePlaceholder: {
+    height: normalize(120),
+    width: normalize(30)
   },
   imageContainer: {
     alignSelf: 'flex-start',


### PR DESCRIPTION
With this PR, the preview in the map view, which was broken after the fallback image was removed, has been fixed

|before without image preview|after without image preview|
|--|--|
<img width="200" alt="Simulator Screenshot - iPhone Air - 2026-05-07 at 13 53 58" src="https://github.com/user-attachments/assets/4008bba7-1435-407a-a4ae-6e09c6c64fe4" />|<img width="200" alt="Simulator Screenshot - iPhone Air - 2026-05-07 at 13 52 58" src="https://github.com/user-attachments/assets/d1e4a8ff-5879-4526-ba69-ad9fdfb93d0a" />

SUE-202