### PR TITLE
feat(bus): add area-aware life situations navigation and search handling

### DIFF
--- a/__tests__/components/AreaAutocomplete.test.tsx
+++ b/__tests__/components/AreaAutocomplete.test.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+import { AreaAutocomplete } from '../../src/components/BUS/AreaAutocomplete';
+
+type AutocompleteMockProps = {
+  renderTextInput?: () => React.ReactNode;
+};
+
+const mockSearchBar = jest.fn(() => null);
+const mockUseBusAreas = jest.fn();
+
+jest.mock('../../src/config', () => ({
+  colors: {
+    primary: '#123456',
+    darkText: '#222222',
+    backgroundRgba: 'rgba(0,0,0,0.1)',
+    borderRgba: 'rgba(0,0,0,0.2)',
+    transparent: 'transparent'
+  },
+  consts: {
+    a11yLabel: {
+      button: '(button)'
+    }
+  },
+  Icon: {
+    Close: () => null,
+    Search: () => null
+  },
+  normalize: (value: number) => value,
+  texts: {
+    accessibilityLabels: {
+      searchInputIcons: {
+        delete: 'Delete',
+        search: 'Search'
+      }
+    },
+    bus: {
+      locationFilter: {
+        label: 'Ort',
+        searchPlaceholder: 'Ort suchen',
+        error: 'Fehler',
+        loading: 'Laedt',
+        noResults: 'Keine Orte gefunden',
+        minSearchLength: 'Mindestens 3 Zeichen',
+        resetTo: (label: string) => `Zurueck zu ${label}`
+      }
+    }
+  }
+}));
+
+jest.mock('../../src/hooks', () => ({
+  useBusAreas: (...args: unknown[]) => mockUseBusAreas(...args)
+}));
+
+jest.mock('../../src/components/Label', () => ({
+  Label: ({ children }: { children: React.ReactNode }) => children
+}));
+
+jest.mock('../../src/components/Text', () => ({
+  RegularText: ({ children }: { children: React.ReactNode }) => children
+}));
+
+jest.mock('../../src/components/Wrapper', () => ({
+  WrapperHorizontal: ({ children }: { children: React.ReactNode }) => children,
+  WrapperRow: ({ children }: { children: React.ReactNode }) => children
+}));
+
+jest.mock('react-native-autocomplete-input', () => (props: AutocompleteMockProps) => {
+  const ReactLocal = jest.requireActual('react');
+  return ReactLocal.createElement(
+    'Autocomplete',
+    props,
+    typeof props.renderTextInput === 'function' ? props.renderTextInput() : null
+  );
+});
+
+jest.mock('react-native-elements', () => ({
+  SearchBar: (props: unknown) => mockSearchBar(props)
+}));
+
+describe('AreaAutocomplete', () => {
+  let testRenderer;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockSearchBar.mockClear();
+    mockUseBusAreas.mockReset();
+    mockUseBusAreas.mockReturnValue({
+      data: [],
+      hasBusConfig: true,
+      isError: false,
+      isFetching: false,
+      isLoading: false
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    if (testRenderer) {
+      act(() => {
+        testRenderer.unmount();
+      });
+      testRenderer = undefined;
+    }
+    jest.useRealTimers();
+  });
+
+  it('debounces area search input before updating the BUS query term', () => {
+    act(() => {
+      testRenderer = renderer.create(
+        <AreaAutocomplete
+          areaId="1"
+          areaName=""
+          initialAreaId="1"
+          initialAreaName="Testort"
+          onSelectArea={jest.fn()}
+        />
+      );
+    });
+
+    const initialCallCount = mockUseBusAreas.mock.calls.length;
+    const searchBarProps = mockSearchBar.mock.calls[mockSearchBar.mock.calls.length - 1][0];
+
+    act(() => {
+      searchBarProps.onChangeText('Dessau-R');
+    });
+
+    expect(mockUseBusAreas).toHaveBeenCalledTimes(initialCallCount + 1);
+    expect(mockUseBusAreas).toHaveBeenLastCalledWith('', false);
+
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+
+    expect(mockUseBusAreas).toHaveBeenCalledTimes(initialCallCount + 2);
+    expect(mockUseBusAreas).toHaveBeenLastCalledWith('Dessau-R', expect.any(Boolean));
+  });
+
+  it('shows the reset icon on initial mount when an area is already prefilled', () => {
+    act(() => {
+      testRenderer = renderer.create(
+        <AreaAutocomplete
+          areaId="1"
+          areaName="Bad Belzig"
+          initialAreaId="1"
+          initialAreaName="Bad Belzig"
+          onSelectArea={jest.fn()}
+        />
+      );
+    });
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    const searchBarProps = mockSearchBar.mock.calls[mockSearchBar.mock.calls.length - 1][0];
+
+    expect(searchBarProps.value).toBe('Bad Belzig');
+    expect(mockSearchBar.mock.calls.length).toBeGreaterThan(1);
+    expect(searchBarProps.clearIcon).toBeTruthy();
+  });
+
+  it('clears the debounced query term immediately when the selection is reset', () => {
+    act(() => {
+      testRenderer = renderer.create(
+        <AreaAutocomplete
+          areaId="1"
+          areaName="Bad Belzig"
+          initialAreaId="1"
+          initialAreaName="Bad Belzig"
+          onSelectArea={jest.fn()}
+        />
+      );
+    });
+
+    let searchBarProps = mockSearchBar.mock.calls[mockSearchBar.mock.calls.length - 1][0];
+
+    act(() => {
+      searchBarProps.onChangeText('Dessau-R');
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+
+    expect(mockUseBusAreas).toHaveBeenLastCalledWith('Dessau-R', expect.any(Boolean));
+
+    searchBarProps = mockSearchBar.mock.calls[mockSearchBar.mock.calls.length - 1][0];
+    const clearIcon = searchBarProps.clearIcon();
+
+    act(() => {
+      clearIcon.props.clearSelection();
+    });
+
+    expect(mockUseBusAreas).toHaveBeenLastCalledWith('', false);
+  });
+});

--- a/__tests__/components/LifeSituationListItem.test.tsx
+++ b/__tests__/components/LifeSituationListItem.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Text } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+
+jest.mock('../../src/config', () => ({
+  colors: {
+    darkText: '#222222',
+    transparent: 'transparent'
+  },
+  consts: {
+    a11yLabel: {
+      button: '(button)'
+    }
+  },
+  Icon: {
+    ArrowRight: () => null
+  },
+  normalize: (value: number) => value
+}));
+
+jest.mock('../../src/components/Image', () => ({
+  Image: () => null
+}));
+
+jest.mock('../../src/helpers', () => ({
+  spaceNewLines: (value?: string) => (value ? value.replace(/(\r\n|\n|\r)/gm, ' ') : value),
+  trimNewLines: (value?: string) => (value ? value.replace(/(\r\n|\n|\r)/gm, '') : value)
+}));
+
+jest.mock('../../src/components/Text', () => {
+  const { Text: MockText } = jest.requireActual('react-native');
+
+  return {
+    HeadlineText: ({ children }: { children?: React.ReactNode }) => <MockText>{children}</MockText>,
+    RegularText: ({ children }: { children?: React.ReactNode }) => <MockText>{children}</MockText>
+  };
+});
+
+jest.mock('../../src/components/Touchable', () => {
+  const { View: MockView } = jest.requireActual('react-native');
+
+  return {
+    Touchable: ({ children, ...props }: { children?: React.ReactNode }) => (
+      <MockView {...props}>{children}</MockView>
+    )
+  };
+});
+
+jest.mock('react-native-elements', () => {
+  const { View: MockView } = jest.requireActual('react-native');
+
+  const MockListItem = ({ children, ...props }: { children?: React.ReactNode }) => (
+    <MockView {...props}>{children}</MockView>
+  );
+
+  MockListItem.Content = ({ children }: { children?: React.ReactNode }) => (
+    <MockView>{children}</MockView>
+  );
+
+  return {
+    ListItem: MockListItem
+  };
+});
+
+describe('LifeSituationListItem', () => {
+  it('uses the sanitized title for the rendered label and accessibility label', () => {
+    const { LifeSituationListItem } = require('../../src/components/BUS/LifeSituationListItem');
+    let component: renderer.ReactTestRenderer;
+
+    act(() => {
+      component = renderer.create(
+        <LifeSituationListItem onPress={jest.fn()} title={'Titel\nmit Umbruch'} />
+      );
+    });
+
+    const item = component!.root.findByProps({
+      accessibilityLabel: '(Titelmit Umbruch) (button)'
+    });
+
+    expect(item).toBeTruthy();
+    expect(component!.root.findByType(Text).props.children).toBe('Titelmit Umbruch');
+  });
+});

--- a/__tests__/components/TextSearch.test.js
+++ b/__tests__/components/TextSearch.test.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+import { TextSearch } from '../../src/components/BUS/TextSearch';
+
+const mockSearchBar = jest.fn(() => null);
+
+jest.mock('../../src/config', () => ({
+  colors: {
+    primary: '#123456',
+    darkText: '#222222',
+    backgroundRgba: 'rgba(0,0,0,0.1)',
+    borderRgba: 'rgba(0,0,0,0.2)',
+    transparent: 'transparent'
+  },
+  consts: {
+    a11yLabel: {
+      button: '(button)'
+    }
+  },
+  normalize: (value) => value,
+  texts: {
+    accessibilityLabels: {
+      searchInputIcons: {
+        delete: 'Delete',
+        search: 'Search'
+      }
+    }
+  }
+}));
+
+jest.mock('../../src/components/Label', () => {
+  return {
+    Label: ({ children }) => children
+  };
+});
+
+jest.mock('../../src/components/Wrapper', () => {
+  return {
+    WrapperHorizontal: ({ children }) => children
+  };
+});
+
+jest.mock('react-native-elements', () => ({
+  SearchBar: (props) => mockSearchBar(props)
+}));
+
+describe('TextSearch', () => {
+  beforeEach(() => {
+    mockSearchBar.mockClear();
+  });
+
+  it('passes render functions for SearchBar icons', () => {
+    let testRenderer;
+
+    act(() => {
+      testRenderer = renderer.create(
+        <TextSearch data="" setData={jest.fn()} label="Label" placeholder="Search here" />
+      );
+    });
+
+    const searchBarProps = mockSearchBar.mock.calls[0][0];
+
+    expect(typeof searchBarProps.searchIcon).toBe('function');
+    expect(typeof searchBarProps.clearIcon).toBe('function');
+
+    act(() => {
+      testRenderer.unmount();
+    });
+  });
+});

--- a/__tests__/components/__snapshots__/Link.test.js.snap
+++ b/__tests__/components/__snapshots__/Link.test.js.snap
@@ -130,22 +130,31 @@ exports[`Link renders a Link that opens a WebScreen 1`] = `
         </RNSVGGroup>
       </RNSVGSvgView>
     </View>
-    <Text
-      primary={true}
+    <View
       style={
-        Array [
-          Object {
-            "color": "#107821",
-            "fontFamily": "regular",
-            "fontSize": 17.92,
-            "lineHeight": 24.64,
-            "textDecorationColor": "#107821",
-          },
-        ]
+        Object {
+          "flex": 1,
+          "minWidth": 0,
+        }
       }
     >
-      description
-    </Text>
+      <Text
+        primary={true}
+        style={
+          Array [
+            Object {
+              "color": "#107821",
+              "fontFamily": "regular",
+              "fontSize": 17.92,
+              "lineHeight": 24.64,
+              "textDecorationColor": "#107821",
+            },
+          ]
+        }
+      >
+        description
+      </Text>
+    </View>
   </View>
 </View>
 `;
@@ -280,22 +289,31 @@ exports[`Link renders a default Link 1`] = `
         </RNSVGGroup>
       </RNSVGSvgView>
     </View>
-    <Text
-      primary={true}
+    <View
       style={
-        Array [
-          Object {
-            "color": "#107821",
-            "fontFamily": "regular",
-            "fontSize": 17.92,
-            "lineHeight": 24.64,
-            "textDecorationColor": "#107821",
-          },
-        ]
+        Object {
+          "flex": 1,
+          "minWidth": 0,
+        }
       }
     >
-      description
-    </Text>
+      <Text
+        primary={true}
+        style={
+          Array [
+            Object {
+              "color": "#107821",
+              "fontFamily": "regular",
+              "fontSize": 17.92,
+              "lineHeight": 24.64,
+              "textDecorationColor": "#107821",
+            },
+          ]
+        }
+      >
+        description
+      </Text>
+    </View>
   </View>
 </View>
 `;

--- a/__tests__/helpers/searchHelper.test.js
+++ b/__tests__/helpers/searchHelper.test.js
@@ -1,0 +1,48 @@
+import { search } from '../../src/helpers/searchHelper';
+
+const createBusEntry = (name, areaId, suffix = '') => ({
+  id: `${name}-${areaId}${suffix}`,
+  params: {
+    areaId,
+    data: {
+      id: `${name}-${areaId}${suffix}`,
+      name
+    }
+  },
+  routeName: 'BusDetail',
+  title: name
+});
+
+describe('search helper', () => {
+  it('returns current A-Z matches for the current area even when the result count stays the same', () => {
+    const brandenburgResults = [
+      createBusEntry('Containerdienst, Angebot', '12000000'),
+      createBusEntry('Buergerservice', '12000000')
+    ];
+    const nrwResults = [
+      createBusEntry('Containerdienst, Angebot', '05000000'),
+      createBusEntry('Buergerservice', '05000000')
+    ];
+
+    const brandenburgMatches = search({
+      results: brandenburgResults,
+      character: 'C'
+    });
+    const nrwMatches = search({
+      results: nrwResults,
+      character: 'C'
+    });
+
+    expect(brandenburgMatches).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({ areaId: '12000000' })
+      })
+    ]);
+    expect(nrwMatches).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({ areaId: '05000000' })
+      })
+    ]);
+    expect(nrwMatches).not.toBe(brandenburgMatches);
+  });
+});

--- a/__tests__/helpers/shareHelper.test.js
+++ b/__tests__/helpers/shareHelper.test.js
@@ -1,0 +1,16 @@
+import { shareMessage } from '../../src/helpers/BUS/shareHelper';
+
+describe('BUS share helper', () => {
+  it('omits teaser text when it is missing', () => {
+    expect(
+      shareMessage({
+        name: 'Meldebescheinigung'
+      })
+    ).toContain('[Bürger- und Unternehmensservice] Meldebescheinigung');
+    expect(
+      shareMessage({
+        name: 'Meldebescheinigung'
+      })
+    ).not.toContain('false');
+  });
+});

--- a/__tests__/hooks/bus.test.ts
+++ b/__tests__/hooks/bus.test.ts
@@ -1,4 +1,15 @@
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn()
+}));
+
+jest.mock('react-query', () => ({
+  useQuery: jest.fn()
+}));
+
 jest.mock('../../src/queries/bus', () => ({
+  findBusCategoryChildren: jest.fn(),
+  findBusCategoryRoot: jest.fn(),
   findPublicServices: jest.fn(),
   getPublicService: jest.fn()
 }));
@@ -11,7 +22,84 @@ jest.mock('../../src/hooks/staticContent', () => ({
   useStaticContent: jest.fn()
 }));
 
-import { getBusQueryConfigKey } from '../../src/hooks/bus';
+import * as React from 'react';
+import { useQuery } from 'react-query';
+import TestRenderer, { act } from 'react-test-renderer';
+
+import {
+  DEFAULT_BUS_LIFE_SITUATIONS_ROOT_SEARCH_WORD,
+  getBusLifeSituationsRootSearchWord,
+  getBusQueryConfigKey,
+  useBusCategoryChildren,
+  useBusLifeSituationsRoot
+} from '../../src/hooks/bus';
+import { findBusCategoryChildren, findBusCategoryRoot } from '../../src/queries/bus';
+
+const mockedUseContext = jest.mocked(React.useContext);
+const mockedUseQuery = jest.mocked(useQuery);
+const mockedFindBusCategoryChildren = jest.mocked(findBusCategoryChildren);
+const mockedFindBusCategoryRoot = jest.mocked(findBusCategoryRoot);
+const defaultBusSettings = {
+  uri: 'https://one.example'
+};
+
+const createSettingsContextValue = (bus = {}) => ({
+  globalSettings: {
+    settings: {
+      bus: {
+        ...defaultBusSettings,
+        ...bus
+      }
+    }
+  }
+});
+
+const createUseQueryResult = () =>
+  ({
+    data: undefined,
+    error: null,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: jest.fn()
+  }) as never;
+
+const mockEnabledUseQuery = () => {
+  mockedUseQuery.mockImplementation((_, queryFn, options) => {
+    if (options?.enabled !== false) {
+      queryFn();
+    }
+
+    return createUseQueryResult();
+  });
+};
+
+const mockIdleUseQuery = () => {
+  mockedUseQuery.mockReturnValue(createUseQueryResult());
+};
+
+const renderHook = async (callback: () => void, shouldAwait = false) => {
+  const TestComponent = () => {
+    callback();
+    return null;
+  };
+
+  if (shouldAwait) {
+    await act(async () => {
+      TestRenderer.create(React.createElement(TestComponent));
+    });
+    return;
+  }
+
+  act(() => {
+    TestRenderer.create(React.createElement(TestComponent));
+  });
+};
+
+afterEach(() => {
+  jest.clearAllMocks();
+  jest.restoreAllMocks();
+});
 
 describe('getBusQueryConfigKey', () => {
   it('changes when relevant bus configuration changes', () => {
@@ -34,5 +122,150 @@ describe('getBusQueryConfigKey', () => {
     const queryKey = getBusQueryConfigKey({ uri: 'https://one.example', apiKey: 'secret-key' });
 
     expect(queryKey).not.toContain('secret-key');
+  });
+});
+
+describe('getBusLifeSituationsRootSearchWord', () => {
+  it('uses the default root search word when bus settings are missing', () => {
+    expect(getBusLifeSituationsRootSearchWord()).toBe(DEFAULT_BUS_LIFE_SITUATIONS_ROOT_SEARCH_WORD);
+    expect(getBusLifeSituationsRootSearchWord({})).toBe(
+      DEFAULT_BUS_LIFE_SITUATIONS_ROOT_SEARCH_WORD
+    );
+  });
+
+  it('falls back to the default when the configured value is blank after trimming', () => {
+    expect(
+      getBusLifeSituationsRootSearchWord({
+        lifeSituationsRootSearchWord: '   '
+      })
+    ).toBe(DEFAULT_BUS_LIFE_SITUATIONS_ROOT_SEARCH_WORD);
+  });
+
+  it('returns the trimmed configured root search word when present', () => {
+    expect(
+      getBusLifeSituationsRootSearchWord({
+        lifeSituationsRootSearchWord: '  Eigene Lebenslage  '
+      })
+    ).toBe('Eigene Lebenslage');
+  });
+});
+
+describe('useBusLifeSituationsRoot', () => {
+  it('calls findBusCategoryRoot with areaId and the default fallback search word when the BUS setting is blank', async () => {
+    mockedUseContext.mockReturnValue(
+      createSettingsContextValue({
+        lifeSituationsRootSearchWord: '   '
+      })
+    );
+    mockEnabledUseQuery();
+
+    await renderHook(() => useBusLifeSituationsRoot('09162000'), true);
+
+    expect(mockedFindBusCategoryRoot).toHaveBeenCalledWith({
+      areaId: '09162000',
+      bus: {
+        lifeSituationsRootSearchWord: '   ',
+        uri: 'https://one.example'
+      },
+      searchWord: DEFAULT_BUS_LIFE_SITUATIONS_ROOT_SEARCH_WORD
+    });
+  });
+
+  it('does not enable the life situations root query without areaId', async () => {
+    mockedUseContext.mockReturnValue(createSettingsContextValue());
+    mockIdleUseQuery();
+
+    await renderHook(() => useBusLifeSituationsRoot());
+
+    expect(mockedUseQuery).toHaveBeenCalledWith(
+      [
+        'bus',
+        'life-situations-root',
+        undefined,
+        DEFAULT_BUS_LIFE_SITUATIONS_ROOT_SEARCH_WORD,
+        'https://one.example::'
+      ],
+      expect.any(Function),
+      expect.objectContaining({ enabled: false })
+    );
+  });
+});
+
+describe('useBusCategoryChildren', () => {
+  it('calls findBusCategoryChildren for parentId 0 with areaId', async () => {
+    mockedUseContext.mockReturnValue(createSettingsContextValue());
+    mockEnabledUseQuery();
+
+    await renderHook(() => useBusCategoryChildren(0, '09162000'), true);
+
+    expect(mockedFindBusCategoryChildren).toHaveBeenCalledWith({
+      areaId: '09162000',
+      bus: {
+        uri: 'https://one.example'
+      },
+      parentId: 0
+    });
+  });
+
+  it('does not enable category children query without areaId', async () => {
+    mockedUseContext.mockReturnValue(createSettingsContextValue());
+    mockIdleUseQuery();
+
+    await renderHook(() => useBusCategoryChildren('247228741'));
+
+    expect(mockedUseQuery).toHaveBeenCalledWith(
+      ['bus', 'category-children', '247228741', undefined, 'https://one.example::'],
+      expect.any(Function),
+      expect.objectContaining({ enabled: false })
+    );
+  });
+
+  it('uses distinct query keys for different areaIds on life situations root and children', async () => {
+    mockedUseContext.mockReturnValue(createSettingsContextValue());
+    mockIdleUseQuery();
+
+    await renderHook(() => {
+      useBusLifeSituationsRoot('09162000');
+      useBusLifeSituationsRoot('06414000');
+      useBusCategoryChildren('247228741', '09162000');
+      useBusCategoryChildren('247228741', '06414000');
+    });
+
+    expect(mockedUseQuery).toHaveBeenNthCalledWith(
+      1,
+      [
+        'bus',
+        'life-situations-root',
+        '09162000',
+        DEFAULT_BUS_LIFE_SITUATIONS_ROOT_SEARCH_WORD,
+        'https://one.example::'
+      ],
+      expect.any(Function),
+      expect.objectContaining({ enabled: true })
+    );
+    expect(mockedUseQuery).toHaveBeenNthCalledWith(
+      2,
+      [
+        'bus',
+        'life-situations-root',
+        '06414000',
+        DEFAULT_BUS_LIFE_SITUATIONS_ROOT_SEARCH_WORD,
+        'https://one.example::'
+      ],
+      expect.any(Function),
+      expect.objectContaining({ enabled: true })
+    );
+    expect(mockedUseQuery).toHaveBeenNthCalledWith(
+      3,
+      ['bus', 'category-children', '247228741', '09162000', 'https://one.example::'],
+      expect.any(Function),
+      expect.objectContaining({ enabled: true })
+    );
+    expect(mockedUseQuery).toHaveBeenNthCalledWith(
+      4,
+      ['bus', 'category-children', '247228741', '06414000', 'https://one.example::'],
+      expect.any(Function),
+      expect.objectContaining({ enabled: true })
+    );
   });
 });

--- a/__tests__/queries/bus.test.js
+++ b/__tests__/queries/bus.test.js
@@ -1,8 +1,34 @@
-import { getPoliticalArea, searchPoliticalAreas } from '../../src/queries/bus';
+import {
+  findBusCategoryChildren,
+  findBusCategoryRoot,
+  getPoliticalArea,
+  searchPoliticalAreas
+} from '../../src/queries/bus';
 
 const bus = {
   apiKey: 'test-api-key',
   uri: 'https://server.int-development.smart-village.app/api/v1'
+};
+
+const mockFetchJson = (payload) =>
+  jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+    json: async () => payload,
+    ok: true
+  });
+
+const expectBusFetch = (url, options = {}) => {
+  const { headers, ...restOptions } = options;
+
+  expect(globalThis.fetch).toHaveBeenCalledWith(
+    url,
+    expect.objectContaining({
+      ...restOptions,
+      headers: expect.objectContaining({
+        'x-api-key': bus.apiKey,
+        ...headers
+      })
+    })
+  );
 };
 
 describe('BUS queries', () => {
@@ -20,32 +46,28 @@ describe('BUS queries', () => {
   });
 
   it('returns political-area search results as an array', async () => {
-    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
-      json: async () => ({
-        values: [
-          {
-            id: '3679',
-            name: 'Hagelberg',
-            displayName: 'Bad Belzig - OT Hagelberg',
-            ags: '12069020'
-          }
-        ]
-      }),
-      ok: true
+    mockFetchJson({
+      values: [
+        {
+          id: '3679',
+          name: 'Hagelberg',
+          displayName: 'Bad Belzig - OT Hagelberg',
+          ags: '12069020'
+        }
+      ]
     });
 
     const result = await searchPoliticalAreas({ searchTerm: 'zirk', bus });
 
-    expect(globalThis.fetch).toHaveBeenCalledWith(
+    expectBusFetch(
       'https://server.int-development.smart-village.app/api/v1/political-area/search?searchWords=zirk*',
-      expect.objectContaining({
-        headers: expect.objectContaining({
+      {
+        headers: {
           Accept: 'application/json',
-          'Accept-Language': 'de-DE',
-          'x-api-key': 'test-api-key'
-        }),
+          'Accept-Language': 'de-DE'
+        },
         method: 'GET'
-      })
+      }
     );
     expect(result).toEqual([
       {
@@ -58,57 +80,63 @@ describe('BUS queries', () => {
   });
 
   it('forwards multiple words as repeated wildcard searchWords params', async () => {
-    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
-      json: async () => ({
-        values: [
-          {
-            id: '123',
-            name: 'Bad Belzig',
-            displayName: 'Bad Belzig',
-            ags: '12069020'
-          }
-        ]
-      }),
-      ok: true
+    mockFetchJson({
+      values: [
+        {
+          id: '123',
+          name: 'Bad Belzig',
+          displayName: 'Bad Belzig',
+          ags: '12069020'
+        }
+      ]
     });
 
     await searchPoliticalAreas({ searchTerm: 'bad bel', bus });
 
-    expect(globalThis.fetch).toHaveBeenCalledWith(
+    expectBusFetch(
       'https://server.int-development.smart-village.app/api/v1/political-area/search?searchWords=bad*&searchWords=bel*',
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          'x-api-key': 'test-api-key'
-        })
-      })
+      {}
+    );
+  });
+
+  it('splits hyphenated political-area search terms into backend-compatible wildcard tokens', async () => {
+    mockFetchJson({
+      values: [
+        {
+          id: '15001000',
+          name: 'Dessau-Roßlau',
+          displayName: 'Dessau-Roßlau',
+          ags: '15001000'
+        }
+      ]
+    });
+
+    await searchPoliticalAreas({ searchTerm: 'Dessau-Roßlau - OT Meinsdorf', bus });
+
+    expectBusFetch(
+      'https://server.int-development.smart-village.app/api/v1/political-area/search?searchWords=Dessau*&searchWords=Ro%C3%9Flau*&searchWords=Meinsdorf*',
+      {}
     );
   });
 
   it('loads a political area detail by id and maps it into an area result', async () => {
-    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
-      json: async () => ({
-        id: '10004',
-        name: 'Bad Belzig',
-        nameShort: 'Bad Belzig',
-        displayName: 'Bad Belzig',
-        ags: '12069020'
-      }),
-      ok: true
+    mockFetchJson({
+      id: '10004',
+      name: 'Bad Belzig',
+      nameShort: 'Bad Belzig',
+      displayName: 'Bad Belzig',
+      ags: '12069020'
     });
 
     const result = await getPoliticalArea({ areaId: '10004', bus });
 
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      'https://server.int-development.smart-village.app/api/v1/political-area/10004',
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          Accept: 'application/json',
-          'Accept-Language': 'de-DE',
-          'x-api-key': 'test-api-key'
-        }),
-        method: 'GET'
-      })
-    );
+    expectBusFetch('https://server.int-development.smart-village.app/api/v1/political-area/10004', {
+      headers: {
+        Accept: 'application/json',
+        'Accept-Language': 'de-DE'
+      },
+      method: 'GET'
+    });
     expect(result).toEqual({
       ags: '12069020',
       id: '10004',
@@ -117,10 +145,7 @@ describe('BUS queries', () => {
   });
 
   it('returns null when the political area detail is invalid', async () => {
-    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
-      json: async () => ({}),
-      ok: true
-    });
+    mockFetchJson({});
 
     const result = await getPoliticalArea({ areaId: '10004', bus });
 
@@ -128,19 +153,16 @@ describe('BUS queries', () => {
   });
 
   it('returns an empty list for unexpected political-area search payloads', async () => {
-    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
-      json: async () => ({
-        suggestions: [
-          {
-            value: 'Zirkow (18528)',
-            data: {
-              id: '3679',
-              ags: '13073106'
-            }
+    mockFetchJson({
+      suggestions: [
+        {
+          value: 'Zirkow (18528)',
+          data: {
+            id: '3679',
+            ags: '13073106'
           }
-        ]
-      }),
-      ok: true
+        }
+      ]
     });
 
     const result = await searchPoliticalAreas({ searchTerm: 'zirk', bus });
@@ -149,13 +171,193 @@ describe('BUS queries', () => {
   });
 
   it('returns an empty list when the political-area response has no values', async () => {
-    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
-      json: async () => ({}),
-      ok: true
-    });
+    mockFetchJson({});
 
     const result = await searchPoliticalAreas({ searchTerm: 'zirk', bus });
 
     expect(result).toEqual([]);
+  });
+
+  it('loads the lebenslagen root category by searchWord', async () => {
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: async () => ({
+        results: [
+          {
+            object: {
+              id: '247228741',
+              name: 'Lebenslagen für Bürgerinnen und Bürger',
+              publicServiceTypes: []
+            }
+          }
+        ]
+      }),
+      ok: true
+    });
+
+    const result = await findBusCategoryRoot({
+      areaId: '09162000',
+      bus,
+      searchWord: 'Lebenslagen für Bürgerinnen und Bürger'
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://server.int-development.smart-village.app/api/v1/pstCategory/find?searchWord=Lebenslagen%20f%C3%BCr%20B%C3%BCrgerinnen%20und%20B%C3%BCrger&limit=1000&areaId=09162000&selectAttributes[]=id&selectAttributes[]=name',
+      expect.any(Object)
+    );
+    expect(result).toEqual({
+      id: '247228741',
+      name: 'Lebenslagen für Bürgerinnen und Bürger',
+      publicServiceTypes: []
+    });
+  });
+
+  it('loads child categories by parentId', async () => {
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: async () => ({
+        results: [
+          {
+            object: {
+              description: 'Beschreibung',
+              id: '247228745',
+              image: {
+                mimeType: 'image/svg+xml',
+                url: 'https://example.com/category.svg'
+              },
+              parentId: '247228741',
+              name: 'Partnerschaft und Familie',
+              position: 3,
+              publicServiceTypes: []
+            }
+          }
+        ]
+      }),
+      ok: true
+    });
+
+    const result = await findBusCategoryChildren({
+      areaId: '09162000',
+      bus,
+      parentId: '247228741'
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://server.int-development.smart-village.app/api/v1/pstCategory/find?parentId=247228741&limit=1000&areaId=09162000&selectAttributes[]=id&selectAttributes[]=name&selectAttributes[]=description&selectAttributes[]=parentId&selectAttributes[]=position&selectAttributes[]=image&selectAttributes[]=publicServiceTypes',
+      expect.any(Object)
+    );
+    expect(result).toEqual([
+      {
+        description: 'Beschreibung',
+        id: '247228745',
+        image: {
+          mimeType: 'image/svg+xml',
+          url: 'https://example.com/category.svg'
+        },
+        parentId: '247228741',
+        name: 'Partnerschaft und Familie',
+        position: 3,
+        publicServiceTypes: []
+      }
+    ]);
+  });
+
+  it('returns null for a blank lebenslagen root searchWord without calling the API', async () => {
+    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+
+    await expect(findBusCategoryRoot({ bus, searchWord: '   ' })).resolves.toBeNull();
+    await expect(findBusCategoryRoot({ bus, searchWord: undefined })).resolves.toBeNull();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no exact lebenslagen root match is present', async () => {
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: async () => ({
+        results: [
+          {
+            object: {
+              id: '247228741',
+              name: 'Lebenslagen für Unternehmen',
+              publicServiceTypes: []
+            }
+          },
+          {
+            object: {
+              id: '247228742',
+              name: 'Lebenslagen für Bürger',
+              publicServiceTypes: []
+            }
+          }
+        ]
+      }),
+      ok: true
+    });
+
+    const result = await findBusCategoryRoot({
+      bus,
+      searchWord: ' Lebenslagen für Bürgerinnen und Bürger '
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when lebenslagen root results are malformed', async () => {
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: async () => ({
+        results: [{}, { object: null }]
+      }),
+      ok: true
+    });
+
+    const result = await findBusCategoryRoot({
+      bus,
+      searchWord: 'Lebenslagen für Bürgerinnen und Bürger'
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when lebenslagen root results are a malformed object', async () => {
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: async () => ({
+        results: {}
+      }),
+      ok: true
+    });
+
+    const result = await findBusCategoryRoot({
+      bus,
+      searchWord: 'Lebenslagen für Bürgerinnen und Bürger'
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns an empty list when child category results are missing or malformed', async () => {
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce({
+        json: async () => ({}),
+        ok: true
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({
+          results: [{}, { object: null }]
+        }),
+        ok: true
+      });
+
+    await expect(findBusCategoryChildren({ bus, parentId: '247228741' })).resolves.toEqual([]);
+    await expect(findBusCategoryChildren({ bus, parentId: '247228741' })).resolves.toEqual([]);
+  });
+
+  it('returns an empty list when child category results are a malformed object', async () => {
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: async () => ({
+        results: {}
+      }),
+      ok: true
+    });
+
+    await expect(findBusCategoryChildren({ bus, parentId: '247228741' })).resolves.toEqual([]);
   });
 });

--- a/__tests__/screens/BUS/CategoryScreen.test.js
+++ b/__tests__/screens/BUS/CategoryScreen.test.js
@@ -1,0 +1,1212 @@
+import React from 'react';
+import { ScrollView, Text } from 'react-native';
+import renderer from 'react-test-renderer';
+
+import { ServiceList } from '../../../src/components/BUS/ServiceList';
+import * as hooks from '../../../src/hooks';
+import { shareMessage } from '../../../src/helpers/BUS/shareHelper';
+import { IndexScreen } from '../../../src/screens/BUS/IndexScreen';
+import { CategoryScreen } from '../../../src/screens/BUS/CategoryScreen';
+import { SettingsContext } from '../../../src/SettingsProvider';
+import { ScreenName } from '../../../src/types/Navigation';
+
+const mockIndexFilterWrapperAndList = jest.fn();
+const mockVerticalList = jest.fn();
+const getLatestVerticalListProps = () =>
+  mockVerticalList.mock.calls[mockVerticalList.mock.calls.length - 1][0];
+
+jest.mock('../../../src/hooks', () => ({
+  useBusCategoryChildren: jest.fn(),
+  useBusInitialArea: jest.fn(),
+  useBusLifeSituationsRoot: jest.fn(),
+  useBusServices: jest.fn(),
+  useBusTop10: jest.fn(),
+  useMatomoTrackScreenView: jest.fn()
+}));
+
+jest.mock('../../../src/SettingsProvider', () => {
+  const React = jest.requireActual('react');
+
+  return {
+    SettingsContext: React.createContext({
+      globalSettings: {
+        settings: {}
+      }
+    })
+  };
+});
+
+jest.mock('../../../src/components', () => {
+  const ActualPropTypes = jest.requireActual('prop-types');
+  const { View: RNView } = jest.requireActual('react-native');
+
+  const DefaultKeyboardAvoidingView = ({ children }) => <RNView>{children}</RNView>;
+  const SafeAreaViewFlex = ({ children }) => <RNView>{children}</RNView>;
+  const IndexFilterWrapperAndList = ({ filter }) => {
+    mockIndexFilterWrapperAndList({ filter });
+
+    return <RNView />;
+  };
+
+  DefaultKeyboardAvoidingView.propTypes = {
+    children: ActualPropTypes.node
+  };
+
+  SafeAreaViewFlex.propTypes = {
+    children: ActualPropTypes.node
+  };
+
+  IndexFilterWrapperAndList.propTypes = {
+    filter: ActualPropTypes.array
+  };
+
+  return {
+    DefaultKeyboardAvoidingView,
+    IndexFilterWrapperAndList,
+    SafeAreaViewFlex
+  };
+});
+
+jest.mock('../../../src/components/Text', () => {
+  const ActualPropTypes = jest.requireActual('prop-types');
+  const { Text: RNText } = jest.requireActual('react-native');
+
+  const BoldText = ({ children }) => <RNText>{children}</RNText>;
+  const RegularText = ({ children }) => <RNText>{children}</RNText>;
+
+  BoldText.propTypes = {
+    children: ActualPropTypes.node
+  };
+
+  RegularText.propTypes = {
+    children: ActualPropTypes.node
+  };
+
+  return { BoldText, RegularText };
+});
+
+jest.mock('../../../src/components/DefaultKeyboardAvoidingView', () => {
+  const ActualPropTypes = jest.requireActual('prop-types');
+  const { View: RNView } = jest.requireActual('react-native');
+
+  const DefaultKeyboardAvoidingView = ({ children }) => <RNView>{children}</RNView>;
+
+  DefaultKeyboardAvoidingView.propTypes = {
+    children: ActualPropTypes.node
+  };
+
+  return { DefaultKeyboardAvoidingView };
+});
+
+jest.mock('../../../src/components/SafeAreaViewFlex', () => {
+  const ActualPropTypes = jest.requireActual('prop-types');
+  const { View: RNView } = jest.requireActual('react-native');
+
+  const SafeAreaViewFlex = ({ children }) => <RNView>{children}</RNView>;
+
+  SafeAreaViewFlex.propTypes = {
+    children: ActualPropTypes.node
+  };
+
+  return { SafeAreaViewFlex };
+});
+
+jest.mock('../../../src/components/BUS/LifeSituationListItem', () => {
+  const ActualPropTypes = jest.requireActual('prop-types');
+  const { Text: RNText, View: RNView } = jest.requireActual('react-native');
+
+  const LifeSituationListItem = ({ imageUrl, onPress, subtitle, title }) => (
+    <RNView accessibilityLabel={`(${title}) button`} imageUrl={imageUrl} onPress={onPress}>
+      <RNText>{title}</RNText>
+      {!!subtitle && <RNText>{subtitle}</RNText>}
+    </RNView>
+  );
+
+  LifeSituationListItem.propTypes = {
+    imageUrl: ActualPropTypes.string,
+    onPress: ActualPropTypes.func,
+    subtitle: ActualPropTypes.string,
+    title: ActualPropTypes.string
+  };
+
+  return { LifeSituationListItem };
+});
+
+jest.mock('../../../src/components/BUS/IndexFilter', () => {
+  const { View: RNView } = jest.requireActual('react-native');
+
+  const IndexFilter = () => <RNView />;
+
+  IndexFilter.propTypes = {};
+
+  return { IndexFilter };
+});
+
+jest.mock('../../../src/components/BUS/AreaAutocomplete', () => {
+  const { View: RNView } = jest.requireActual('react-native');
+
+  const AreaAutocomplete = () => <RNView />;
+
+  AreaAutocomplete.propTypes = {};
+
+  return { AreaAutocomplete };
+});
+
+jest.mock('../../../src/components/VerticalList', () => {
+  const ActualPropTypes = jest.requireActual('prop-types');
+  const { View: RNView } = jest.requireActual('react-native');
+
+  const renderOptionalNode = (node) => {
+    if (!node) {
+      return null;
+    }
+
+    if (typeof node === 'function') {
+      const OptionalNode = node;
+
+      return <OptionalNode />;
+    }
+
+    return node;
+  };
+
+  const VerticalList = (props) => {
+    mockVerticalList(props);
+
+    return (
+      <RNView>
+        {renderOptionalNode(props.ListHeaderComponent)}
+        {renderOptionalNode(props.ListEmptyComponent)}
+      </RNView>
+    );
+  };
+
+  VerticalList.propTypes = {
+    data: ActualPropTypes.array,
+    ListEmptyComponent: ActualPropTypes.oneOfType([ActualPropTypes.func, ActualPropTypes.node]),
+    ListHeaderComponent: ActualPropTypes.oneOfType([ActualPropTypes.func, ActualPropTypes.node])
+  };
+
+  return { VerticalList };
+});
+
+describe('BUS CategoryScreen', () => {
+  const navigation = { push: jest.fn() };
+  const refetch = jest.fn();
+  const defaultCategoryChildrenState = {
+    data: [],
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch
+  };
+  const baseCategory = {
+    id: '247228741',
+    name: 'Lebenslagen für Bürgerinnen und Bürger',
+    publicServiceTypes: [{ id: 'service-1', name: 'Meldebescheinigung' }]
+  };
+  const route = {
+    params: {
+      areaId: '09162000',
+      category: baseCategory,
+      isRootCategory: true
+    }
+  };
+  const createCategoryRoute = ({
+    areaId = '09162000',
+    category = {},
+    isRootCategory = true
+  } = {}) => ({
+    params: {
+      areaId,
+      category: {
+        ...baseCategory,
+        publicServiceTypes: [],
+        ...category
+      },
+      isRootCategory
+    }
+  });
+  const pressServiceRow = (component, label = 'Meldebescheinigung') => {
+    const serviceRow = component.root.findByProps({
+      accessibilityLabel: `(${label}) button`
+    });
+
+    renderer.act(() => {
+      serviceRow.props.onPress();
+    });
+  };
+  const expectBusDetailNavigation = (service) => {
+    expect(navigation.push).toHaveBeenCalledWith(ScreenName.BusDetail, {
+      areaId: '09162000',
+      data: service,
+      query: '',
+      queryVariables: {},
+      rootRouteName: 'BUS',
+      shareContent: {
+        message: shareMessage(service)
+      },
+      title: service.name
+    });
+  };
+  const expectCategoryStateMessage = ({ isRootCategory, expectedText }) => {
+    hooks.useBusCategoryChildren.mockReturnValue({
+      ...defaultCategoryChildrenState,
+      isError: true
+    });
+
+    const component = renderScreen(createCategoryRoute({ isRootCategory }));
+
+    expect(component.root.findByType(ScrollView)).toBeTruthy();
+    expect(component.root.findByType(Text).props.children).toBe(expectedText);
+  };
+
+  beforeEach(() => {
+    navigation.push.mockClear();
+    refetch.mockClear();
+    hooks.useBusServices.mockReturnValue({
+      data: [{ id: 'service-1', name: 'Meldebescheinigung' }],
+      isFetching: false,
+      isLoading: false,
+      refetch
+    });
+  });
+
+  const renderScreen = (screenRoute = route) => {
+    let component;
+
+    renderer.act(() => {
+      component = renderer.create(<CategoryScreen navigation={navigation} route={screenRoute} />);
+    });
+
+    return component;
+  };
+
+  it('renders category entries and direct services together', () => {
+    hooks.useBusCategoryChildren.mockReturnValue({
+      data: [
+        {
+          id: '247228745',
+          image: {
+            url: 'https://example.com/partnerschaft.jpg'
+          },
+          name: 'Partnerschaft und Familie'
+        },
+        {
+          id: '247228746',
+          name: 'Geburt'
+        }
+      ],
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch
+    });
+
+    const component = renderScreen();
+    const renderedTexts = component.root
+      .findAllByType(Text)
+      .map((textNode) => textNode.props.children)
+      .filter(Boolean);
+
+    expect(renderedTexts).toEqual(
+      expect.arrayContaining(['Partnerschaft und Familie', 'Geburt', 'Meldebescheinigung'])
+    );
+    expect(
+      component.root.findByProps({
+        accessibilityLabel: '(Partnerschaft und Familie) button',
+        imageUrl: 'https://example.com/partnerschaft.jpg'
+      })
+    ).toBeTruthy();
+  });
+
+  it('pushes child categories to BusCategory', () => {
+    hooks.useBusCategoryChildren.mockReturnValue({
+      data: [
+        {
+          id: '247228745',
+          name: 'Partnerschaft und Familie',
+          publicServiceTypes: []
+        }
+      ],
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch
+    });
+
+    const component = renderScreen();
+    const categoryRow = component.root.findByProps({
+      accessibilityLabel: '(Partnerschaft und Familie) button'
+    });
+
+    renderer.act(() => {
+      categoryRow.props.onPress();
+    });
+
+    expect(navigation.push).toHaveBeenCalledWith(ScreenName.BusCategory, {
+      areaId: '09162000',
+      category: {
+        id: '247228745',
+        name: 'Partnerschaft und Familie',
+        publicServiceTypes: []
+      },
+      isRootCategory: false,
+      title: 'Partnerschaft und Familie'
+    });
+  });
+
+  it('filters invalid child categories and sorts valid ones by numeric position and title', () => {
+    hooks.useBusCategoryChildren.mockReturnValue({
+      data: [
+        {
+          id: 'child-c',
+          name: 'Charlie',
+          position: '2',
+          publicServiceTypes: []
+        },
+        {
+          id: 'child-a',
+          name: 'Alpha',
+          position: 1,
+          publicServiceTypes: []
+        },
+        {
+          id: 'child-b',
+          name: 'Bravo',
+          position: '2',
+          publicServiceTypes: []
+        },
+        {
+          id: null,
+          name: 'Ohne ID',
+          publicServiceTypes: []
+        },
+        {
+          id: 'child-empty-name',
+          name: '   ',
+          publicServiceTypes: []
+        }
+      ],
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch
+    });
+
+    const component = renderScreen();
+    const renderedTexts = component.root
+      .findAllByType(Text)
+      .map((textNode) => textNode.props.children)
+      .filter(Boolean);
+
+    expect(renderedTexts).toEqual(
+      expect.arrayContaining(['Alpha', 'Bravo', 'Charlie', 'Meldebescheinigung'])
+    );
+    expect(renderedTexts.indexOf('Alpha')).toBeLessThan(renderedTexts.indexOf('Bravo'));
+    expect(renderedTexts.indexOf('Bravo')).toBeLessThan(renderedTexts.indexOf('Charlie'));
+    expect(renderedTexts).not.toContain('Ohne ID');
+  });
+
+  it('pushes direct services to BusDetail', () => {
+    hooks.useBusCategoryChildren.mockReturnValue(defaultCategoryChildrenState);
+
+    const component = renderScreen();
+    pressServiceRow(component);
+    expectBusDetailNavigation({
+      id: 'service-1',
+      name: 'Meldebescheinigung'
+    });
+  });
+
+  it('resolves direct service refs against the current area services before opening details', () => {
+    hooks.useBusCategoryChildren.mockReturnValue(defaultCategoryChildrenState);
+    hooks.useBusServices.mockReturnValue({
+      data: [{ id: 'resolved-service-77', name: 'Meldebescheinigung' }],
+      isFetching: false,
+      isLoading: false,
+      refetch
+    });
+
+    const component = renderScreen();
+    pressServiceRow(component);
+    expectBusDetailNavigation({
+      id: 'resolved-service-77',
+      name: 'Meldebescheinigung'
+    });
+  });
+
+  it('does not render unresolved direct service refs for the current area', () => {
+    hooks.useBusCategoryChildren.mockReturnValue({
+      data: [],
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch
+    });
+    hooks.useBusServices.mockReturnValue({
+      data: [{ id: 'other-service', name: 'Anderer Dienst' }],
+      isFetching: false,
+      isLoading: false,
+      refetch
+    });
+
+    const component = renderScreen();
+
+    expect(() =>
+      component.root.findByProps({
+        accessibilityLabel: '(Meldebescheinigung) button'
+      })
+    ).toThrow();
+  });
+
+  it('keeps the refreshable container mounted for the empty state', () => {
+    hooks.useBusCategoryChildren.mockReturnValue(defaultCategoryChildrenState);
+
+    const emptyRoute = createCategoryRoute();
+    const component = renderScreen(emptyRoute);
+
+    expect(component.root.findByType(ScrollView)).toBeTruthy();
+    expect(component.root.findByType(Text).props.children).toBe(
+      'Für diese Lebenslage sind derzeit keine Unterkategorien oder Leistungen verfügbar.'
+    );
+  });
+
+  it.each([
+    [false, 'Diese Lebenslage konnte derzeit nicht geladen werden.'],
+    [true, 'Die Lebenslagen konnten derzeit nicht geladen werden.']
+  ])(
+    'renders the correct error copy for root category state %s',
+    (isRootCategory, expectedText) => {
+      expectCategoryStateMessage({ isRootCategory, expectedText });
+    }
+  );
+
+  it('does not render stale child categories after switching to a failed category', () => {
+    const categoryARoute = {
+      params: {
+        areaId: '09162000',
+        category: {
+          id: 'category-a',
+          name: 'Kategorie A',
+          publicServiceTypes: []
+        },
+        isRootCategory: false
+      }
+    };
+    const categoryBRoute = {
+      params: {
+        areaId: '09162000',
+        category: {
+          id: 'category-b',
+          name: 'Kategorie B',
+          publicServiceTypes: []
+        },
+        isRootCategory: false
+      }
+    };
+
+    hooks.useBusCategoryChildren
+      .mockReturnValueOnce({
+        data: [
+          {
+            id: 'child-a',
+            name: 'Unterkategorie A',
+            publicServiceTypes: []
+          }
+        ],
+        isError: false,
+        isFetching: false,
+        isLoading: false,
+        refetch
+      })
+      .mockReturnValueOnce({
+        data: [
+          {
+            id: 'child-a',
+            name: 'Unterkategorie A',
+            publicServiceTypes: []
+          }
+        ],
+        isError: true,
+        isFetching: false,
+        isLoading: false,
+        refetch
+      });
+
+    const component = renderScreen(categoryARoute);
+
+    expect(
+      component.root.findByProps({
+        accessibilityLabel: '(Unterkategorie A) button'
+      })
+    ).toBeTruthy();
+
+    renderer.act(() => {
+      component.update(<CategoryScreen navigation={navigation} route={categoryBRoute} />);
+    });
+
+    expect(
+      component.root.findAllByProps({
+        accessibilityLabel: '(Unterkategorie A) button'
+      })
+    ).toHaveLength(0);
+    expect(component.root.findByType(Text).props.children).toBe(
+      'Diese Lebenslage konnte derzeit nicht geladen werden.'
+    );
+  });
+
+  it('does not return null for category id 0', () => {
+    hooks.useBusCategoryChildren.mockReturnValue({
+      data: [],
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch
+    });
+
+    const zeroIdRoute = {
+      params: {
+        areaId: '09162000',
+        category: {
+          id: 0,
+          name: 'Kategorie Null',
+          publicServiceTypes: []
+        },
+        isRootCategory: false
+      }
+    };
+    const component = renderScreen(zeroIdRoute);
+
+    expect(component.toJSON()).not.toBeNull();
+    expect(component.root.findByType(ScrollView)).toBeTruthy();
+  });
+
+  it('shows back to top in nested life situations when the content exceeds the viewport', () => {
+    hooks.useBusCategoryChildren.mockReturnValue({
+      data: [
+        {
+          id: '247228745',
+          name: 'Partnerschaft und Familie',
+          publicServiceTypes: []
+        }
+      ],
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch
+    });
+
+    const nestedRoute = {
+      params: {
+        areaId: '09162000',
+        category: {
+          ...baseCategory,
+          publicServiceTypes: []
+        },
+        isRootCategory: false
+      }
+    };
+    const component = renderScreen(nestedRoute);
+
+    renderer.act(() => {
+      component.root.findByType(ScrollView).props.onContentSizeChange(0, 5000);
+    });
+
+    const renderedTexts = component.root
+      .findAllByType(Text)
+      .map((textNode) => textNode.props.children)
+      .filter(Boolean);
+
+    expect(renderedTexts).toContain('ZURÜCK NACH OBEN');
+  });
+});
+
+describe('BUS IndexScreen', () => {
+  const navigation = { navigate: jest.fn(), push: jest.fn() };
+  let lifeSituationsRefetch;
+  let lifeSituationChildrenRefetch;
+  const expectedDefaultFilter = [
+    expect.objectContaining({
+      id: 2,
+      selected: true,
+      title: 'Lebenslagen'
+    }),
+    expect.objectContaining({
+      id: 3,
+      selected: false,
+      title: 'Suche'
+    }),
+    expect.objectContaining({
+      id: 4,
+      selected: false,
+      title: 'A-Z'
+    })
+  ];
+  const rootCategory = {
+    id: '247228741',
+    name: 'Lebenslagen fuer Buergerinnen und Buerger',
+    publicServiceTypes: []
+  };
+  const rootChildCategories = [
+    {
+      id: '247228745',
+      image: {
+        url: 'https://example.com/familie.jpg'
+      },
+      name: 'Partnerschaft und Familie',
+      description: 'Beschreibung B',
+      position: 2
+    },
+    {
+      id: '247228744',
+      image: {
+        url: 'https://example.com/ausweise.jpg'
+      },
+      name: 'Ausweise und Dokumente',
+      description: 'Beschreibung A',
+      position: 1
+    },
+    {
+      id: '247228746',
+      name: 'Geburt',
+      description: 'Beschreibung C',
+      position: 2
+    }
+  ];
+  let servicesRefetch;
+  let top10Refetch;
+  const expectDefaultFilterState = () => {
+    const [{ filter }] = mockIndexFilterWrapperAndList.mock.calls[0];
+
+    expect(filter).toEqual(expectedDefaultFilter);
+  };
+  const expectSortedRootChildren = (data) => {
+    expect(data).toEqual([
+      expect.objectContaining({
+        id: '247228744',
+        routeName: 'BusCategory',
+        subtitle: 'Beschreibung A',
+        title: 'Ausweise und Dokumente'
+      }),
+      expect.objectContaining({
+        id: '247228746',
+        routeName: 'BusCategory',
+        subtitle: 'Beschreibung C',
+        title: 'Geburt'
+      }),
+      expect.objectContaining({
+        id: '247228745',
+        routeName: 'BusCategory',
+        subtitle: 'Beschreibung B',
+        title: 'Partnerschaft und Familie'
+      })
+    ]);
+  };
+
+  beforeEach(() => {
+    mockIndexFilterWrapperAndList.mockClear();
+    mockVerticalList.mockClear();
+    lifeSituationsRefetch = jest.fn();
+    lifeSituationChildrenRefetch = jest.fn();
+    navigation.navigate.mockClear();
+    navigation.push.mockClear();
+    servicesRefetch = jest.fn();
+    top10Refetch = jest.fn();
+    hooks.useBusInitialArea.mockReturnValue({
+      data: {
+        id: '09162000',
+        label: 'Testort'
+      }
+    });
+    hooks.useBusServices.mockReturnValue({
+      data: [],
+      isFetching: false,
+      isLoading: false,
+      refetch: servicesRefetch
+    });
+    hooks.useBusTop10.mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: top10Refetch
+    });
+    hooks.useBusLifeSituationsRoot.mockReturnValue({
+      data: rootCategory,
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch: lifeSituationsRefetch
+    });
+    hooks.useBusCategoryChildren.mockReturnValue({
+      data: rootChildCategories,
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch: lifeSituationChildrenRefetch
+    });
+  });
+
+  const renderIndexScreen = (bus = {}) => {
+    let component;
+
+    renderer.act(() => {
+      component = renderer.create(
+        <SettingsContext.Provider
+          value={{
+            globalSettings: {
+              settings: {
+                bus: {
+                  areaId: '09162000',
+                  initialFilter: ['lifeSituations', 'search', 'aToZ'],
+                  uri: 'https://bus.example',
+                  ...bus
+                }
+              }
+            }
+          }}
+        >
+          <IndexScreen navigation={navigation} />
+        </SettingsContext.Provider>
+      );
+    });
+
+    return component;
+  };
+
+  it('respects the configured BUS tab order including top10 before Lebenslagen', () => {
+    renderIndexScreen({
+      initialFilter: ['top10', 'lifeSituations', 'search', 'aToZ']
+    });
+
+    const [{ filter }] = mockIndexFilterWrapperAndList.mock.calls[0];
+
+    expect(filter).toEqual([
+      expect.objectContaining({
+        id: 1,
+        selected: true,
+        title: 'Meistgesucht'
+      }),
+      expect.objectContaining({
+        id: 2,
+        selected: false,
+        title: 'Lebenslagen'
+      }),
+      expect.objectContaining({
+        id: 3,
+        selected: false,
+        title: 'Suche'
+      }),
+      expect.objectContaining({
+        id: 4,
+        selected: false,
+        title: 'A-Z'
+      })
+    ]);
+  });
+
+  it('falls back to the full default BUS filter set when initialFilter is missing or empty', () => {
+    renderIndexScreen({
+      initialFilter: []
+    });
+
+    expectDefaultFilterState();
+  });
+
+  it('creates a fresh default filter state on repeated mounts', () => {
+    const firstComponent = renderIndexScreen({
+      initialFilter: []
+    });
+
+    const [{ filter: firstFilter }] = mockIndexFilterWrapperAndList.mock.calls[0];
+    firstFilter[0].selected = false;
+    renderer.act(() => {
+      firstComponent.unmount();
+    });
+
+    mockIndexFilterWrapperAndList.mockClear();
+
+    renderIndexScreen({
+      initialFilter: []
+    });
+
+    expectDefaultFilterState();
+  });
+
+  it('does not block the Lebenslagen view when services are still fetching but the root is ready', () => {
+    hooks.useBusServices.mockReturnValue({
+      data: [],
+      isFetching: true,
+      isLoading: false,
+      refetch: servicesRefetch
+    });
+
+    renderIndexScreen();
+
+    const [verticalListProps] = mockVerticalList.mock.calls[0];
+
+    expect(verticalListProps.isLoading).toBe(false);
+    expectSortedRootChildren(verticalListProps.data);
+  });
+
+  it('renders explicit root empty copy when the Lebenslagen root lookup returns null', () => {
+    hooks.useBusLifeSituationsRoot.mockReturnValue({
+      data: null,
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch: lifeSituationsRefetch
+    });
+
+    const component = renderIndexScreen();
+    const renderedTexts = component.root
+      .findAllByType(Text)
+      .map((textNode) => textNode.props.children)
+      .filter(Boolean);
+
+    const [verticalListProps] = mockVerticalList.mock.calls[0];
+
+    expect(verticalListProps.data).toEqual([]);
+    expect(renderedTexts).toEqual(
+      expect.arrayContaining([
+        '0 TREFFER',
+        'Für diese Lebenslage sind derzeit keine Unterkategorien oder Leistungen verfügbar.'
+      ])
+    );
+  });
+
+  it('renders explicit root error copy when the Lebenslagen root lookup fails', () => {
+    hooks.useBusLifeSituationsRoot.mockReturnValue({
+      data: null,
+      isError: true,
+      isFetching: false,
+      isLoading: false,
+      refetch: lifeSituationsRefetch
+    });
+
+    const component = renderIndexScreen();
+    const renderedTexts = component.root
+      .findAllByType(Text)
+      .map((textNode) => textNode.props.children)
+      .filter(Boolean);
+
+    expect(renderedTexts).toEqual(
+      expect.arrayContaining(['0 TREFFER', 'Die Lebenslagen konnten derzeit nicht geladen werden.'])
+    );
+  });
+
+  it('renders root children when the Lebenslagen root category id is 0', () => {
+    hooks.useBusLifeSituationsRoot.mockReturnValue({
+      data: {
+        id: 0,
+        name: 'Lebenslagen Wurzel',
+        publicServiceTypes: []
+      },
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch: lifeSituationsRefetch
+    });
+    hooks.useBusCategoryChildren.mockReturnValue({
+      data: [
+        {
+          id: 'child-zero',
+          name: 'Direktes Kind',
+          description: 'Direkte Beschreibung',
+          position: 1
+        }
+      ],
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch: lifeSituationChildrenRefetch
+    });
+
+    renderIndexScreen();
+
+    const [verticalListProps] = mockVerticalList.mock.calls[0];
+
+    expect(verticalListProps.data).toEqual([
+      expect.objectContaining({
+        id: 'child-zero',
+        routeName: 'BusCategory',
+        subtitle: 'Direkte Beschreibung',
+        title: 'Direktes Kind'
+      })
+    ]);
+  });
+
+  it('refetches the Lebenslagen root alongside the other BUS index data on refresh', async () => {
+    renderIndexScreen();
+
+    await renderer.act(async () => {
+      const [verticalListProps] = mockVerticalList.mock.calls[0];
+
+      await verticalListProps.refreshControl.props.onRefresh();
+    });
+
+    expect(lifeSituationsRefetch).toHaveBeenCalled();
+    expect(lifeSituationChildrenRefetch).toHaveBeenCalled();
+    expect(servicesRefetch).toHaveBeenCalled();
+    expect(top10Refetch).toHaveBeenCalled();
+  });
+
+  it('does not refetch life situation children on refresh when the root category is missing', async () => {
+    hooks.useBusLifeSituationsRoot.mockReturnValue({
+      data: null,
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch: lifeSituationsRefetch
+    });
+
+    renderIndexScreen();
+
+    await renderer.act(async () => {
+      const [verticalListProps] = mockVerticalList.mock.calls[0];
+
+      await verticalListProps.refreshControl.props.onRefresh();
+    });
+
+    expect(lifeSituationsRefetch).toHaveBeenCalled();
+    expect(lifeSituationChildrenRefetch).not.toHaveBeenCalled();
+    expect(servicesRefetch).toHaveBeenCalled();
+    expect(top10Refetch).toHaveBeenCalled();
+  });
+
+  it('sorts root children by numeric position and then alphabetically by title', () => {
+    renderIndexScreen();
+
+    const [verticalListProps] = mockVerticalList.mock.calls[0];
+
+    expect(verticalListProps.data.map((item) => item.title)).toEqual([
+      'Ausweise und Dokumente',
+      'Geburt',
+      'Partnerschaft und Familie'
+    ]);
+  });
+
+  it('resolves root direct service refs against the current area services', () => {
+    hooks.useBusLifeSituationsRoot.mockReturnValue({
+      data: {
+        ...rootCategory,
+        publicServiceTypes: [{ id: 'root-service-ref', name: 'Wohnsitz anmelden' }]
+      },
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch: lifeSituationsRefetch
+    });
+    hooks.useBusServices.mockReturnValue({
+      data: [{ id: 'resolved-root-service', name: 'Wohnsitz anmelden' }],
+      isFetching: false,
+      isLoading: false,
+      refetch: servicesRefetch
+    });
+
+    renderIndexScreen();
+
+    const [verticalListProps] = mockVerticalList.mock.calls[0];
+
+    expect(verticalListProps.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'resolved-root-service',
+          routeName: 'BusDetail',
+          title: 'Wohnsitz anmelden'
+        })
+      ])
+    );
+  });
+
+  it('omits unresolved root direct service refs for the current area', () => {
+    hooks.useBusLifeSituationsRoot.mockReturnValue({
+      data: {
+        ...rootCategory,
+        publicServiceTypes: [{ id: 'missing-root-service', name: 'Nicht verfuegbar' }]
+      },
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch: lifeSituationsRefetch
+    });
+    hooks.useBusServices.mockReturnValue({
+      data: [{ id: 'resolved-root-service', name: 'Wohnsitz anmelden' }],
+      isFetching: false,
+      isLoading: false,
+      refetch: servicesRefetch
+    });
+
+    renderIndexScreen();
+
+    const [verticalListProps] = mockVerticalList.mock.calls[0];
+
+    expect(
+      verticalListProps.data.find((item) => item.routeName === 'BusDetail' && item.title === 'Nicht verfuegbar')
+    ).toBeUndefined();
+  });
+});
+
+describe('BUS ServiceList', () => {
+  const navigation = { navigate: jest.fn(), push: jest.fn() };
+  const setArea = jest.fn();
+
+  beforeEach(() => {
+    mockVerticalList.mockClear();
+    navigation.navigate.mockClear();
+    navigation.push.mockClear();
+    setArea.mockClear();
+  });
+
+  const renderServiceList = (props = {}) => {
+    let component;
+
+    renderer.act(() => {
+      component = renderer.create(
+        <ServiceList
+          areaId="09162000"
+          areaName="Testort"
+          initialAreaId="09162000"
+          initialAreaName="Testort"
+          isListLoading={false}
+          lifeSituationsEmptyStateMessage="Für diese Lebenslage sind derzeit keine Unterkategorien oder Leistungen verfügbar."
+          lifeSituations={[]}
+          navigation={navigation}
+          results={[]}
+          selectedFilter={{ id: 1, title: 'Meistgesucht', selected: true }}
+          setArea={setArea}
+          top10={[
+            {
+              id: 'service-a',
+              title: 'Altes Top10',
+              routeName: 'BusDetail',
+              params: { areaId: '09162000' }
+            }
+          ]}
+          {...props}
+        />
+      );
+    });
+
+    return component;
+  };
+
+  it('does not show stale TOP10 data after an area switch while the new area is still loading', () => {
+    const component = renderServiceList();
+    let [verticalListProps] = mockVerticalList.mock.calls[0];
+
+    expect(verticalListProps.data).toEqual([
+      expect.objectContaining({
+        id: 'service-a',
+        title: 'Altes Top10'
+      })
+    ]);
+
+    renderer.act(() => {
+      component.update(
+        <ServiceList
+          areaId="11000000"
+          areaName="Neuort"
+          initialAreaId="09162000"
+          initialAreaName="Testort"
+          isListLoading
+          lifeSituationsEmptyStateMessage="Für diese Lebenslage sind derzeit keine Unterkategorien oder Leistungen verfügbar."
+          lifeSituations={[]}
+          navigation={navigation}
+          results={[]}
+          selectedFilter={{ id: 1, title: 'Meistgesucht', selected: true }}
+          setArea={setArea}
+          top10={[
+            {
+              id: 'service-a',
+              title: 'Altes Top10',
+              routeName: 'BusDetail',
+              params: { areaId: '09162000' }
+            }
+          ]}
+        />
+      );
+    });
+
+    [verticalListProps] = mockVerticalList.mock.calls[mockVerticalList.mock.calls.length - 1];
+
+    expect(verticalListProps.isLoading).toBe(true);
+    expect(verticalListProps.data).toEqual([]);
+  });
+
+  it('does not show stale A-Z data while the new area is still loading', () => {
+    renderServiceList({
+      areaId: '11000000',
+      areaName: 'Neuort',
+      isListLoading: true,
+      results: [
+        {
+          id: 'service-b',
+          title: 'Altes A-Z Ergebnis',
+          routeName: 'BusDetail',
+          params: { areaId: '09162000' }
+        }
+      ],
+      selectedFilter: { id: 4, title: 'A-Z', selected: true }
+    });
+
+    const verticalListProps = getLatestVerticalListProps();
+
+    expect(verticalListProps).toEqual(expect.objectContaining({ data: [], isLoading: true }));
+  });
+
+  it('does not show stale life situations while the new area is still loading', () => {
+    renderServiceList({
+      areaId: '11000000',
+      areaName: 'Neuort',
+      isListLoading: true,
+      lifeSituations: [
+        {
+          id: 'life-a',
+          title: 'Alte Lebenslage',
+          routeName: 'BusCategory',
+          params: { areaId: '09162000' }
+        }
+      ],
+      selectedFilter: { id: 2, title: 'Lebenslagen', selected: true }
+    });
+
+    const verticalListProps = getLatestVerticalListProps();
+
+    expect(verticalListProps).toEqual(expect.objectContaining({ data: [], isLoading: true }));
+  });
+
+  it('renders no items when the selected area is removed', () => {
+    renderServiceList({
+      areaId: undefined,
+      areaName: '',
+      results: [
+        {
+          id: 'service-b',
+          title: 'Buergeramt',
+          routeName: 'BusDetail',
+          params: { areaId: '09162000' }
+        }
+      ],
+      selectedFilter: { id: 3, title: 'Suche', selected: true }
+    });
+
+    const verticalListProps = getLatestVerticalListProps();
+
+    expect(verticalListProps.data).toEqual([]);
+  });
+
+  it('does not render the life situations empty state when no area is selected', () => {
+    renderServiceList({
+      areaId: undefined,
+      areaName: '',
+      lifeSituationsEmptyStateMessage:
+        'Für diese Lebenslage sind derzeit keine Unterkategorien oder Leistungen verfügbar.',
+      selectedFilter: { id: 2, title: 'Lebenslagen', selected: true }
+    });
+
+    const verticalListProps = getLatestVerticalListProps();
+
+    expect(verticalListProps.data).toEqual([]);
+    expect(verticalListProps.ListEmptyComponent).toBeNull();
+  });
+});

--- a/src/components/BUS/AreaAutocomplete.tsx
+++ b/src/components/BUS/AreaAutocomplete.tsx
@@ -3,14 +3,13 @@ import { Platform, StyleSheet, TouchableOpacity, View } from 'react-native';
 import Autocomplete from 'react-native-autocomplete-input';
 import { SearchBar } from 'react-native-elements';
 
-import { colors, consts, normalize, texts } from '../../config';
-import { useBusAreas } from '../../hooks';
+import { colors, consts, Icon, normalize, texts } from '../../config';
+import { BUS_MIN_SEARCH_LENGTH, BUS_SEARCH_DEBOUNCE_MS, useBusAreas } from '../../hooks';
 import type { BusAreaSearchResult } from '../../types';
 import { Label } from '../Label';
 import { RegularText } from '../Text';
 import { WrapperHorizontal, WrapperRow } from '../Wrapper';
 
-const MIN_SEARCH_LENGTH = 3;
 const { a11yLabel } = consts;
 
 type SelectionArea = {
@@ -55,6 +54,14 @@ type SearchAreaOption = BusAreaSearchResult & {
   label: string;
 };
 
+type ClearIconProps = {
+  clearSelection: () => void;
+};
+
+type SearchIconProps = {
+  inputValue: string;
+};
+
 const getSearchStateText = ({ hasNoResults, isSearching, isUnavailable }: SearchStateTextArgs) => {
   if (isUnavailable) return texts.bus.locationFilter.error;
   if (isSearching) return texts.bus.locationFilter.loading;
@@ -83,7 +90,7 @@ const getHelperText = ({
 }: HelperTextArgs) => {
   const hasInitialAreaName = !!initialAreaName;
   const isEmpty = trimmedInputLength === 0;
-  const isBelowMinLength = trimmedInputLength > 0 && trimmedInputLength < MIN_SEARCH_LENGTH;
+  const isBelowMinLength = trimmedInputLength > 0 && trimmedInputLength < BUS_MIN_SEARCH_LENGTH;
   const isUnavailable = !hasBusConfig || isError;
   const isSearching = isLoading || isFetching;
   const hasNoResults = !normalizedAreasLength;
@@ -101,7 +108,7 @@ const getHelperText = ({
     return texts.bus.locationFilter.minSearchLength;
   }
 
-  if (shouldSearch) {
+  if (shouldSearch && isFocused) {
     return getSearchStateText({ hasNoResults, isSearching, isUnavailable });
   }
 
@@ -112,6 +119,25 @@ const getHelperText = ({
   return '';
 };
 
+const SearchBarClearIcon = ({ clearSelection }: ClearIconProps) => (
+  <TouchableOpacity
+    accessibilityLabel={`${texts.accessibilityLabels.searchInputIcons.delete} ${a11yLabel.button}`}
+    activeOpacity={1}
+    onPress={clearSelection}
+  >
+    <Icon.Close color={colors.primary} size={normalize(24)} />
+  </TouchableOpacity>
+);
+
+const SearchBarSearchIcon = ({ inputValue }: SearchIconProps) =>
+  inputValue.length ? null : (
+    <Icon.Search
+      accessibilityLabel={`${texts.accessibilityLabels.searchInputIcons.search} ${a11yLabel.button}`}
+      color={colors.primary}
+      size={normalize(28)}
+    />
+  );
+
 export const AreaAutocomplete = memo(function AreaAutocomplete({
   areaId,
   areaName,
@@ -120,18 +146,24 @@ export const AreaAutocomplete = memo(function AreaAutocomplete({
   onSelectArea
 }: AreaAutocompleteProps) {
   const [inputValue, setInputValue] = useState(areaName || '');
+  const [debouncedInputValue, setDebouncedInputValue] = useState(areaName || '');
   const [isFocused, setIsFocused] = useState(false);
   const [searchBarRenderKey, setSearchBarRenderKey] = useState(0);
+  const didForceInitialClearIconRender = useRef(false);
   const previousSelection = useRef({ areaId, areaName });
+  const searchBarRef = useRef<any>(null);
   const trimmedInputValue = inputValue.trim();
-  const shouldSearch = trimmedInputValue.length >= MIN_SEARCH_LENGTH;
+  const shouldSearch = trimmedInputValue.length >= BUS_MIN_SEARCH_LENGTH;
+  const trimmedDebouncedInputValue = debouncedInputValue.trim();
+  const shouldFetchAreas = trimmedDebouncedInputValue.length >= BUS_MIN_SEARCH_LENGTH;
+  const isDebouncing = inputValue !== debouncedInputValue;
   const {
     data = [],
     hasBusConfig,
     isError,
     isFetching,
     isLoading
-  } = useBusAreas(inputValue, isFocused && shouldSearch);
+  } = useBusAreas(debouncedInputValue, isFocused && shouldFetchAreas);
   const areas = useMemo(
     () =>
       data.map((item) => ({
@@ -140,6 +172,15 @@ export const AreaAutocomplete = memo(function AreaAutocomplete({
       })),
     [data]
   );
+  const visibleAreas = isDebouncing ? [] : areas;
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedInputValue(inputValue);
+    }, BUS_SEARCH_DEBOUNCE_MS);
+
+    return () => clearTimeout(timeoutId);
+  }, [inputValue]);
 
   useEffect(() => {
     const hasSelectionChanged =
@@ -156,10 +197,23 @@ export const AreaAutocomplete = memo(function AreaAutocomplete({
     // query briefly reappears and the selected area label gets lost until the next render.
     const timeoutId = setTimeout(() => {
       setInputValue(areaName || '');
+      setDebouncedInputValue(areaName || '');
     }, 0);
 
     return () => clearTimeout(timeoutId);
   }, [areaId, areaName]);
+
+  useEffect(() => {
+    if (didForceInitialClearIconRender.current || !areaName?.length) return;
+
+    didForceInitialClearIconRender.current = true;
+
+    const timeoutId = setTimeout(() => {
+      setSearchBarRenderKey((currentKey) => currentKey + 1);
+    }, 0);
+
+    return () => clearTimeout(timeoutId);
+  }, [areaName]);
 
   const shouldHideResults = !isFocused || !shouldSearch;
   const hasDifferentSelection = !!initialAreaId && `${areaId}` !== `${initialAreaId}`;
@@ -172,9 +226,9 @@ export const AreaAutocomplete = memo(function AreaAutocomplete({
         initialAreaName,
         isFocused,
         isError,
-        isFetching,
-        isLoading,
-        normalizedAreasLength: areas.length,
+        isFetching: isFetching || isDebouncing,
+        isLoading: isLoading || isDebouncing,
+        normalizedAreasLength: visibleAreas.length,
         shouldSearch,
         trimmedInputLength: trimmedInputValue.length
       }),
@@ -186,7 +240,8 @@ export const AreaAutocomplete = memo(function AreaAutocomplete({
       isError,
       isFetching,
       isLoading,
-      areas.length,
+      isDebouncing,
+      visibleAreas.length,
       shouldSearch,
       trimmedInputValue.length
     ]
@@ -199,6 +254,7 @@ export const AreaAutocomplete = memo(function AreaAutocomplete({
       onPress={() => {
         setInputValue(item.label);
         setIsFocused(false);
+        searchBarRef.current?.blur?.();
         onSelectArea({ id: item.id, label: item.label });
       }}
       style={styles.suggestionItem}
@@ -206,6 +262,15 @@ export const AreaAutocomplete = memo(function AreaAutocomplete({
       <RegularText>{item.label}</RegularText>
     </TouchableOpacity>
   );
+
+  const clearSelection = () => {
+    setIsFocused(true);
+    setInputValue('');
+    setDebouncedInputValue('');
+    onSelectArea({ id: undefined, label: '' });
+  };
+  const renderClearIcon = () => <SearchBarClearIcon clearSelection={clearSelection} />;
+  const renderSearchIcon = () => <SearchBarSearchIcon inputValue={inputValue} />;
 
   return (
     <View>
@@ -215,7 +280,7 @@ export const AreaAutocomplete = memo(function AreaAutocomplete({
       <Autocomplete
         autoCorrect={false}
         containerStyle={styles.autoCompleteContainer}
-        data={areas}
+        data={visibleAreas}
         disableFullscreenUI
         flatListProps={{
           keyboardShouldPersistTaps: 'handled',
@@ -236,11 +301,8 @@ export const AreaAutocomplete = memo(function AreaAutocomplete({
         renderTextInput={() => (
           <SearchBar
             key={searchBarRenderKey}
-            clearIcon={{
-              accessibilityLabel: `${texts.accessibilityLabels.searchInputIcons.delete} ${a11yLabel.button}`,
-              color: colors.primary,
-              size: normalize(24)
-            }}
+            ref={searchBarRef}
+            clearIcon={renderClearIcon}
             containerStyle={styles.searchBarContainerStyle}
             inputContainerStyle={styles.searchBarInputContainerStyle}
             inputStyle={[
@@ -254,23 +316,12 @@ export const AreaAutocomplete = memo(function AreaAutocomplete({
               setIsFocused(true);
               setInputValue(text);
             }}
-            onClearText={() => {
-              setIsFocused(true);
-              setInputValue('');
-            }}
+            onClearText={clearSelection}
             onFocus={() => setIsFocused(true)}
             placeholder={texts.bus.locationFilter.searchPlaceholder}
             placeholderTextColor={colors.darkText}
             rightIconContainerStyle={styles.searchBarRightIconContainerStyle}
-            searchIcon={
-              inputValue.length
-                ? null
-                : {
-                    accessibilityLabel: `${texts.accessibilityLabels.searchInputIcons.search} ${a11yLabel.button}`,
-                    color: colors.primary,
-                    size: normalize(28)
-                  }
-            }
+            searchIcon={renderSearchIcon}
             value={inputValue}
           />
         )}

--- a/src/components/BUS/IndexFilter.js
+++ b/src/components/BUS/IndexFilter.js
@@ -52,6 +52,15 @@ export const IndexFilter = ({
   const [categoryFilterData, setCategoryFilterData] = useState(initialCategoryFilterData);
   const [AZFilterData, setAZFilterData] = useState(initialAZFilterData);
   const listItemsCount = listItems.length;
+  const renderAreaAutocomplete = () => (
+    <AreaAutocomplete
+      areaId={areaId}
+      areaName={areaName}
+      initialAreaId={initialAreaId}
+      initialAreaName={initialAreaName}
+      onSelectArea={setArea}
+    />
+  );
 
   const renderFilterComponents = (selectedFilterId) => {
     switch (selectedFilterId) {
@@ -64,13 +73,7 @@ export const IndexFilter = ({
               label={texts.bus.categoryFilter.label}
             />
             <Divider style={styles.divider} />
-            <AreaAutocomplete
-              areaId={areaId}
-              areaName={areaName}
-              initialAreaId={initialAreaId}
-              initialAreaName={initialAreaName}
-              onSelectArea={setArea}
-            />
+            {renderAreaAutocomplete()}
           </WrapperVertical>
         );
       case 3:
@@ -83,28 +86,14 @@ export const IndexFilter = ({
               label={texts.bus.textSearch.label}
             />
             <Divider style={styles.divider} />
-            <AreaAutocomplete
-              areaId={areaId}
-              areaName={areaName}
-              initialAreaId={initialAreaId}
-              initialAreaName={initialAreaName}
-              onSelectArea={setArea}
-            />
+            {renderAreaAutocomplete()}
           </WrapperVertical>
         );
       case 4:
         return (
           <WrapperVertical>
             <AZFilter data={AZFilterData} setData={setAZFilterData} />
-            <WrapperVertical>
-              <AreaAutocomplete
-                areaId={areaId}
-                areaName={areaName}
-                initialAreaId={initialAreaId}
-                initialAreaName={initialAreaName}
-                onSelectArea={setArea}
-              />
-            </WrapperVertical>
+            <WrapperVertical>{renderAreaAutocomplete()}</WrapperVertical>
           </WrapperVertical>
         );
       default:
@@ -115,53 +104,54 @@ export const IndexFilter = ({
   useEffect(() => {
     if (loading) return;
 
-    if (selectedFilter.id === 2) {
-      const category = categoryFilterData.find((item) => item.selected);
+    switch (selectedFilter.id) {
+      case 2: {
+        const category = categoryFilterData.find((item) => item.selected);
 
-      if (category?.id > 0) {
-        const searchResults = search({
-          results,
-          category: category.value
-        });
-
-        setListItems(searchResults);
-      } else {
-        setListItems([]);
+        setListItems(
+          category?.id > 0
+            ? search({
+                results,
+                category: category.value
+              })
+            : []
+        );
+        break;
       }
-    }
-  }, [areaId, categoryFilterData, loading, results, selectedFilter.id, setListItems]);
+      case 3:
+        setListItems(
+          search({
+            results,
+            keyword: serviceSearchData
+          })
+        );
+        break;
+      case 4: {
+        const character = (AZFilterData.find((item) => item.selected) || {}).value;
 
-  useEffect(() => {
-    if (loading) return;
-
-    if (selectedFilter.id === 3) {
-      const searchResults = search({
-        results,
-        keyword: serviceSearchData
-      });
-
-      setListItems(searchResults);
-    }
-  }, [areaId, loading, results, selectedFilter.id, serviceSearchData, setListItems]);
-
-  useEffect(() => {
-    if (loading) return;
-
-    if (selectedFilter.id === 4) {
-      const character = (AZFilterData.find((item) => item.selected) || {}).value;
-
-      if (character) {
-        const searchResults = search({
-          results,
+        setListItems(
           character
-        });
-
-        setListItems(searchResults);
-      } else {
-        setListItems([]);
+            ? search({
+                results,
+                character
+              })
+            : []
+        );
+        break;
       }
+      default:
+        break;
     }
-  }, [AZFilterData, areaId, loading, results, selectedFilter.id, setListItems]);
+  }, [
+    AZFilterData,
+    areaId,
+    categoryFilterData,
+    loading,
+    results,
+    selectedFilter.id,
+    serviceSearchData,
+    setListItems
+  ]);
 
   return (
     <View>
@@ -191,9 +181,9 @@ const styles = StyleSheet.create({
 });
 
 IndexFilter.propTypes = {
-  areaId: PropTypes.string.isRequired,
+  areaId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   areaName: PropTypes.string,
-  initialAreaId: PropTypes.string,
+  initialAreaId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   initialAreaName: PropTypes.string,
   listItems: PropTypes.array.isRequired,
   loading: PropTypes.bool.isRequired,

--- a/src/components/BUS/LifeSituationListItem.tsx
+++ b/src/components/BUS/LifeSituationListItem.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { ListItem } from 'react-native-elements';
+
+import { colors, consts, Icon, normalize } from '../../config';
+import { spaceNewLines, trimNewLines } from '../../helpers';
+import { Image } from '../Image';
+import { HeadlineText, RegularText } from '../Text';
+import { Touchable } from '../Touchable';
+
+type LifeSituationListItemProps = {
+  bottomDivider?: boolean;
+  imageUrl?: string;
+  onPress: () => void;
+  subtitle?: string;
+  title: string;
+};
+
+export const LifeSituationListItem = ({
+  bottomDivider = true,
+  imageUrl,
+  onPress,
+  subtitle,
+  title
+}: LifeSituationListItemProps) => {
+  const sanitizedTitle = trimNewLines(title) ?? '';
+
+  return (
+    <ListItem
+      bottomDivider={bottomDivider}
+      containerStyle={styles.container}
+      onPress={onPress}
+      delayPressIn={0}
+      Component={Touchable}
+      accessibilityLabel={`(${sanitizedTitle}) ${consts.a11yLabel.button}`}
+    >
+      {imageUrl ? (
+        <Image
+          source={{ uri: imageUrl }}
+          style={styles.image}
+          borderRadius={normalize(8)}
+          containerStyle={styles.imageContainer}
+        />
+      ) : null}
+
+      <ListItem.Content>
+        <HeadlineText small>{sanitizedTitle}</HeadlineText>
+        {!!subtitle && (
+          <RegularText small style={styles.subtitle}>
+            {spaceNewLines(subtitle)}
+          </RegularText>
+        )}
+      </ListItem.Content>
+
+      <Icon.ArrowRight color={colors.darkText} size={normalize(18)} />
+    </ListItem>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.transparent,
+    paddingHorizontal: 0,
+    paddingVertical: normalize(16)
+  },
+  image: {
+    height: normalize(72),
+    width: normalize(96)
+  },
+  imageContainer: {
+    alignSelf: 'flex-start'
+  },
+  subtitle: {
+    marginTop: normalize(6)
+  }
+});

--- a/src/components/BUS/LifeSituationsList.tsx
+++ b/src/components/BUS/LifeSituationsList.tsx
@@ -1,0 +1,266 @@
+import React, { useMemo, useRef, useState } from 'react';
+import { ScrollView, StyleSheet, View, type RefreshControlProps } from 'react-native';
+
+import { device, normalize, texts } from '../../config';
+import { shareMessage } from '../../helpers/BUS/shareHelper';
+import type { AreaId, BusCategory, BusServiceListItem } from '../../types';
+import { ScreenName } from '../../types/Navigation';
+import { BackToTop } from '../BackToTop';
+import { LoadingSpinner } from '../LoadingSpinner';
+import { RegularText } from '../Text';
+
+import { LifeSituationListItem } from './LifeSituationListItem';
+
+const ITEM_TYPES = {
+  CATEGORY: 'category',
+  SERVICE: 'service'
+} as const;
+
+type CategoryListItem = {
+  data: BusCategory;
+  type: typeof ITEM_TYPES.CATEGORY;
+};
+
+type ServiceListItem = {
+  data: BusServiceListItem;
+  type: typeof ITEM_TYPES.SERVICE;
+};
+
+type LifeSituationEntry = CategoryListItem | ServiceListItem;
+
+type BusNavigation = {
+  push: (screen: ScreenName, params: Record<string, unknown>) => void;
+};
+
+type LifeSituationsListProps = {
+  areaId?: AreaId;
+  category?: BusCategory;
+  childCategories?: BusCategory[];
+  isError?: boolean;
+  isLoading?: boolean;
+  isRootCategory?: boolean;
+  isServicesLoading?: boolean;
+  navigation: BusNavigation;
+  refreshControl?: React.ReactElement<RefreshControlProps>;
+  services?: BusServiceListItem[];
+};
+
+const normalizeName = (value?: string | null) => `${value ?? ''}`.trim().toLowerCase();
+const getSortPosition = (value?: string | number) => {
+  const numericValue = Number(value);
+
+  return Number.isFinite(numericValue) ? numericValue : Number.POSITIVE_INFINITY;
+};
+const hasCategoryListData = (childCategory?: BusCategory) =>
+  childCategory?.id !== null &&
+  childCategory?.id !== undefined &&
+  !!normalizeName(childCategory?.name);
+
+const shouldShowLoadingSpinner = ({
+  hasListData,
+  isLoading,
+  isResolvingServices
+}: {
+  hasListData: boolean;
+  isLoading: boolean;
+  isResolvingServices: boolean;
+}) => (isLoading || isResolvingServices) && !hasListData;
+
+const getResolvedServices = ({
+  category,
+  services = []
+}: {
+  category?: BusCategory;
+  services?: BusServiceListItem[];
+}) => {
+  const servicesById = new Map(
+    services
+      .filter((service) => service?.id !== null && service?.id !== undefined)
+      .map((service) => [`${service.id}`, service] as const)
+  );
+  const servicesByName = new Map(
+    services
+      .filter((service) => !!normalizeName(service?.name))
+      .map((service) => [normalizeName(service.name), service] as const)
+  );
+
+  return (category?.publicServiceTypes ?? [])
+    .map((serviceReference) => {
+      const serviceId = serviceReference?.id;
+      const serviceName = serviceReference?.name;
+
+      return (
+        servicesById.get(`${serviceId ?? ''}`) || servicesByName.get(normalizeName(serviceName))
+      );
+    })
+    .filter((service): service is BusServiceListItem => !!service);
+};
+
+const getListData = ({
+  category,
+  childCategories = [],
+  isServicesLoading = false,
+  services = []
+}: {
+  category?: BusCategory;
+  childCategories?: BusCategory[];
+  isServicesLoading?: boolean;
+  services?: BusServiceListItem[];
+}) => {
+  const categories: CategoryListItem[] = childCategories
+    .filter(hasCategoryListData)
+    .sort((firstCategory, secondCategory) => {
+      const positionDifference =
+        getSortPosition(firstCategory.position) - getSortPosition(secondCategory.position);
+
+      if (positionDifference !== 0) {
+        return positionDifference;
+      }
+
+      return normalizeName(firstCategory.name).localeCompare(normalizeName(secondCategory.name));
+    })
+    .map((childCategory) => ({
+      data: childCategory,
+      type: ITEM_TYPES.CATEGORY
+    }));
+  const resolvedServices = isServicesLoading ? [] : getResolvedServices({ category, services });
+  const serviceItems: ServiceListItem[] = resolvedServices.map((service) => ({
+    data: service,
+    type: ITEM_TYPES.SERVICE
+  }));
+
+  return [...categories, ...serviceItems];
+};
+
+const isCategoryItem = (item: LifeSituationEntry): item is CategoryListItem =>
+  item.type === ITEM_TYPES.CATEGORY;
+
+export const LifeSituationsList = ({
+  areaId,
+  category,
+  childCategories = [],
+  isError = false,
+  isLoading = false,
+  isRootCategory = false,
+  isServicesLoading = false,
+  navigation,
+  refreshControl,
+  services = []
+}: LifeSituationsListProps) => {
+  const scrollViewRef = useRef<ScrollView | null>(null);
+  const [showBackToTop, setShowBackToTop] = useState(false);
+  const isResolvingServices = isServicesLoading && !!category?.publicServiceTypes?.length;
+  const listData = useMemo(
+    () => getListData({ category, childCategories, services, isServicesLoading }),
+    [category, childCategories, services, isServicesLoading]
+  );
+  const hasListData = !!listData.length;
+  const emptyStateMessage = isError
+    ? isRootCategory
+      ? texts.bus.emptyStates.lifeSituationsRoot
+      : texts.bus.emptyStates.lifeSituationsNested
+    : texts.bus.emptyStates.lifeSituations;
+  const shouldRenderLoadingSpinner = shouldShowLoadingSpinner({
+    isLoading,
+    isResolvingServices,
+    hasListData
+  });
+
+  return (
+    <ScrollView
+      ref={scrollViewRef}
+      onContentSizeChange={(_contentWidth, contentHeight) =>
+        setShowBackToTop(contentHeight > device.height)
+      }
+      refreshControl={refreshControl}
+      keyboardShouldPersistTaps="handled"
+      contentContainerStyle={styles.contentContainer}
+      style={styles.list}
+    >
+      {shouldRenderLoadingSpinner ? <LoadingSpinner loading /> : null}
+
+      {!isLoading && !isResolvingServices && !hasListData ? (
+        <View style={styles.emptyState}>
+          <RegularText placeholder small center>
+            {emptyStateMessage}
+          </RegularText>
+        </View>
+      ) : null}
+
+      {listData.map((item, index) => {
+        const bottomDivider = index < listData.length - 1;
+
+        if (isCategoryItem(item)) {
+          const childCategory = item.data;
+
+          return (
+            <LifeSituationListItem
+              key={`${item.type}-${childCategory?.id ?? index}`}
+              bottomDivider={bottomDivider}
+              imageUrl={childCategory?.image?.url ?? undefined}
+              title={childCategory?.name ?? ''}
+              subtitle={childCategory?.description ?? undefined}
+              onPress={() =>
+                navigation.push(ScreenName.BusCategory, {
+                  areaId,
+                  category: childCategory,
+                  isRootCategory: false,
+                  title: childCategory?.name ?? ''
+                })
+              }
+            />
+          );
+        }
+
+        const service = item.data;
+
+        return (
+          <LifeSituationListItem
+            key={`${item.type}-${service?.id ?? index}`}
+            bottomDivider={bottomDivider}
+            title={service?.name ?? ''}
+            onPress={() =>
+              navigation.push(ScreenName.BusDetail, {
+                areaId,
+                title: service?.name ?? '',
+                query: '',
+                queryVariables: {},
+                rootRouteName: 'BUS',
+                shareContent: {
+                  message: shareMessage(service)
+                },
+                data: service
+              })
+            }
+          />
+        );
+      })}
+
+      {showBackToTop && (
+        <BackToTop
+          onPress={() =>
+            scrollViewRef.current?.scrollTo({
+              x: 0,
+              y: 0,
+              animated: true
+            })
+          }
+        />
+      )}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    flexGrow: 1
+  },
+  emptyState: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: normalize(16)
+  },
+  list: {
+    paddingHorizontal: normalize(16)
+  }
+});

--- a/src/components/BUS/ServiceList.js
+++ b/src/components/BUS/ServiceList.js
@@ -1,9 +1,98 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
 
+import { colors, consts, normalize } from '../../config';
 import { VerticalList } from '../VerticalList';
+import { IndexFilterWrapper } from '../IndexFilterElement';
+import { RegularText } from '../Text';
+import { WrapperHorizontal, WrapperVertical } from '../Wrapper';
 
+import { AreaAutocomplete } from './AreaAutocomplete';
 import { IndexFilter } from './IndexFilter';
+
+const FILTER_IDS = {
+  TOP10: 1,
+  LIFE_SITUATIONS: 2
+};
+const { LIST_TYPES } = consts;
+const areaIdPropType = PropTypes.oneOfType([PropTypes.string, PropTypes.number]);
+
+const getVisibleListItems = ({
+  areaId,
+  filteredListState,
+  isListLoading,
+  lifeSituations,
+  selectedFilterId,
+  top10
+}) => {
+  if (!areaId || isListLoading) {
+    return [];
+  }
+
+  if (selectedFilterId === FILTER_IDS.TOP10) {
+    return top10;
+  }
+
+  if (selectedFilterId === FILTER_IDS.LIFE_SITUATIONS) {
+    return lifeSituations;
+  }
+
+  return filteredListState.areaId === areaId && filteredListState.filterId === selectedFilterId
+    ? filteredListState.items
+    : [];
+};
+
+const LifeSituationsHeader = ({
+  areaId,
+  areaName,
+  initialAreaId,
+  initialAreaName,
+  listItemsCount,
+  setArea
+}) => {
+  return (
+    <View>
+      <WrapperVertical>
+        <AreaAutocomplete
+          areaId={areaId}
+          areaName={areaName}
+          initialAreaId={initialAreaId}
+          initialAreaName={initialAreaName}
+          onSelectArea={setArea}
+        />
+      </WrapperVertical>
+      <IndexFilterWrapper>
+        <WrapperHorizontal>
+          <RegularText style={styles.results}>{`${listItemsCount} TREFFER`}</RegularText>
+        </WrapperHorizontal>
+      </IndexFilterWrapper>
+    </View>
+  );
+};
+
+LifeSituationsHeader.propTypes = {
+  areaId: areaIdPropType,
+  areaName: PropTypes.string,
+  initialAreaId: areaIdPropType,
+  initialAreaName: PropTypes.string,
+  listItemsCount: PropTypes.number.isRequired,
+  setArea: PropTypes.func.isRequired
+};
+
+const LifeSituationsEmptyState = ({ message }) => {
+  return (
+    <View style={styles.emptyState}>
+      <RegularText placeholder small center>
+        {message}
+      </RegularText>
+    </View>
+  );
+};
+
+LifeSituationsEmptyState.propTypes = {
+  message: PropTypes.string.isRequired
+};
 
 export const ServiceList = ({
   areaId,
@@ -11,6 +100,8 @@ export const ServiceList = ({
   initialAreaId,
   initialAreaName,
   isListLoading,
+  lifeSituationsEmptyStateMessage,
+  lifeSituations = [],
   navigation,
   refreshControl,
   results = [],
@@ -19,41 +110,72 @@ export const ServiceList = ({
   top10
 }) => {
   const activeFilter = selectedFilter || { id: 3 };
-  const [listItems, setListItems] = useState(activeFilter.id === 1 ? top10 : []);
-  const previousAreaId = useRef(areaId);
+  const [filteredListState, setFilteredListState] = useState({
+    areaId,
+    filterId: activeFilter.id,
+    items: []
+  });
+  const setFilteredListItems = useCallback(
+    (items) =>
+      setFilteredListState({
+        areaId,
+        filterId: activeFilter.id,
+        items
+      }),
+    [activeFilter.id, areaId]
+  );
+  const listItems = getVisibleListItems({
+    areaId,
+    filteredListState,
+    isListLoading,
+    lifeSituations,
+    selectedFilterId: activeFilter.id,
+    top10
+  });
 
-  useEffect(() => {
-    if (previousAreaId.current !== areaId) {
-      previousAreaId.current = areaId;
-      setListItems([]);
-    }
-  }, [areaId]);
+  const listHeaderComponent =
+    activeFilter.id === FILTER_IDS.LIFE_SITUATIONS ? (
+      <LifeSituationsHeader
+        areaId={areaId}
+        areaName={areaName}
+        initialAreaId={initialAreaId}
+        initialAreaName={initialAreaName}
+        listItemsCount={listItems.length}
+        setArea={setArea}
+      />
+    ) : (
+      <IndexFilter
+        selectedFilter={activeFilter}
+        results={results}
+        listItems={listItems}
+        setListItems={setFilteredListItems}
+        areaId={areaId}
+        areaName={areaName}
+        initialAreaId={initialAreaId}
+        initialAreaName={initialAreaName}
+        setArea={setArea}
+        loading={isListLoading}
+      />
+    );
 
-  useEffect(() => {
-    if (activeFilter.id === 1) {
-      setListItems(top10);
-    }
-  }, [activeFilter.id, results.length, top10]);
+  const listEmptyComponent =
+    activeFilter.id === FILTER_IDS.LIFE_SITUATIONS &&
+    !!areaId &&
+    !isListLoading &&
+    !!lifeSituationsEmptyStateMessage ? (
+      <LifeSituationsEmptyState message={lifeSituationsEmptyStateMessage} />
+    ) : null;
 
   return (
     <VerticalList
       navigation={navigation}
       data={listItems}
-      noSubtitle
-      ListHeaderComponent={
-        <IndexFilter
-          selectedFilter={activeFilter}
-          results={results}
-          listItems={listItems}
-          setListItems={setListItems}
-          areaId={areaId}
-          areaName={areaName}
-          initialAreaId={initialAreaId}
-          initialAreaName={initialAreaName}
-          setArea={setArea}
-          loading={isListLoading}
-        />
+      listType={
+        activeFilter.id === FILTER_IDS.LIFE_SITUATIONS ? LIST_TYPES.IMAGE_TEXT_LIST : undefined
       }
+      noSubtitle={activeFilter.id !== FILTER_IDS.LIFE_SITUATIONS}
+      ListEmptyComponent={listEmptyComponent}
+      ListHeaderComponent={listHeaderComponent}
       isLoading={isListLoading}
       showBackToTop
       refreshControl={refreshControl}
@@ -62,11 +184,13 @@ export const ServiceList = ({
 };
 
 ServiceList.propTypes = {
-  areaId: PropTypes.string.isRequired,
+  areaId: areaIdPropType,
   areaName: PropTypes.string,
-  initialAreaId: PropTypes.string,
+  initialAreaId: areaIdPropType,
   initialAreaName: PropTypes.string,
   isListLoading: PropTypes.bool.isRequired,
+  lifeSituationsEmptyStateMessage: PropTypes.string,
+  lifeSituations: PropTypes.array,
   navigation: PropTypes.object.isRequired,
   refreshControl: PropTypes.object,
   results: PropTypes.array,
@@ -74,3 +198,17 @@ ServiceList.propTypes = {
   setArea: PropTypes.func.isRequired,
   top10: PropTypes.array.isRequired
 };
+
+const styles = StyleSheet.create({
+  emptyState: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: normalize(16)
+  },
+  results: {
+    color: colors.text,
+    fontSize: normalize(10),
+    letterSpacing: normalize(1.5),
+    lineHeight: normalize(30)
+  }
+});

--- a/src/components/BUS/TextSearch.js
+++ b/src/components/BUS/TextSearch.js
@@ -1,29 +1,49 @@
 import PropTypes from 'prop-types';
 import React, { memo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import { SearchBar } from 'react-native-elements';
 
-import { colors, consts, normalize, texts } from '../../config';
+import { colors, consts, Icon, normalize, texts } from '../../config';
 import { Label } from '../Label';
 import { WrapperHorizontal } from '../Wrapper';
 
 const { a11yLabel } = consts;
 
+const SearchIcon = () => (
+  <Icon.Search
+    accessibilityLabel={`${texts.accessibilityLabels.searchInputIcons.search} ${a11yLabel.button}`}
+    color={colors.primary}
+    size={normalize(28)}
+  />
+);
+
+const ClearIcon = ({ onPress }) => (
+  <TouchableOpacity
+    accessibilityLabel={`${texts.accessibilityLabels.searchInputIcons.delete} ${a11yLabel.button}`}
+    activeOpacity={1}
+    onPress={onPress}
+  >
+    <Icon.Close color={colors.primary} size={normalize(24)} />
+  </TouchableOpacity>
+);
+
+ClearIcon.propTypes = {
+  onPress: PropTypes.func.isRequired
+};
+
 export const TextSearch = memo(({ data, setData, label, placeholder }) => {
+  const clearSearch = () => setData('');
+
   return (
     <View>
       <WrapperHorizontal>
         <Label>{label}</Label>
       </WrapperHorizontal>
       <SearchBar
-        clearIcon={{
-          accessibilityLabel: `${texts.accessibilityLabels.searchInputIcons.delete} ${a11yLabel.button}`,
-          color: colors.primary,
-          size: normalize(24)
-        }}
+        clearIcon={() => <ClearIcon onPress={clearSearch} />}
         value={data}
         onChangeText={(value) => setData(value)}
-        onClearText={() => setData('')}
+        onClearText={clearSearch}
         placeholder={placeholder}
         placeholderTextColor={colors.darkText}
         lightTheme
@@ -32,15 +52,7 @@ export const TextSearch = memo(({ data, setData, label, placeholder }) => {
         inputStyle={[styles.inputStyle, data.length && styles.marginLeft]}
         leftIconContainerStyle={styles.leftIconContainerStyle}
         rightIconContainerStyle={styles.rightIconContainerStyle}
-        searchIcon={
-          data.length
-            ? null
-            : {
-                accessibilityLabel: `${texts.accessibilityLabels.searchInputIcons.search} ${a11yLabel.button}`,
-                color: colors.primary,
-                size: normalize(28)
-              }
-        }
+        searchIcon={() => (data.length ? null : <SearchIcon />)}
       />
     </View>
   );

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { StyleSheet, TouchableOpacity } from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { colors, consts, Icon, normalize } from '../config';
 import { openLink } from '../helpers';
@@ -15,7 +15,9 @@ export const Link = ({ url, description, openWebScreen }) => (
   >
     <WrapperRow>
       <Icon.Link color={colors.primary} style={styles.icon} />
-      <RegularText primary>{description}</RegularText>
+      <View style={styles.textContainer}>
+        <RegularText primary>{description}</RegularText>
+      </View>
     </WrapperRow>
   </TouchableOpacity>
 );
@@ -24,6 +26,10 @@ const styles = StyleSheet.create({
   icon: {
     marginRight: normalize(5),
     marginTop: normalize(3)
+  },
+  textContainer: {
+    flex: 1,
+    minWidth: 0
   }
 });
 

--- a/src/config/navigation/defaultStackConfig.tsx
+++ b/src/config/navigation/defaultStackConfig.tsx
@@ -101,7 +101,11 @@ import {
   WhistleblowFormScreen,
   getTilesScreen
 } from '../../screens';
-import { DetailScreen as BusDetailScreen, IndexScreen as BusIndexScreen } from '../../screens/BUS';
+import {
+  CategoryScreen as BusCategoryScreen,
+  DetailScreen as BusDetailScreen,
+  IndexScreen as BusIndexScreen
+} from '../../screens/BUS';
 import { ScreenName, StackConfig } from '../../types';
 import { consts } from '../consts';
 import { texts } from '../texts';
@@ -115,10 +119,10 @@ export const defaultStackConfig = ({
   isDrawer,
   tilesScreenParams
 }: {
-  initialParams?: Record<string, any>;
+  initialParams?: Record<string, unknown>;
   initialRouteName: ScreenName;
   isDrawer: boolean;
-  tilesScreenParams?: Record<string, any>;
+  tilesScreenParams?: Record<string, unknown>;
 }): StackConfig => ({
   initialRouteName,
   screenOptions: getScreenOptions({ withDrawer: isDrawer }),
@@ -153,6 +157,11 @@ export const defaultStackConfig = ({
       initialParams,
       routeName: ScreenName.BusIndexFallback,
       screenComponent: BusIndexScreen
+    },
+    {
+      initialParams,
+      routeName: ScreenName.BusCategory,
+      screenComponent: BusCategoryScreen
     },
     {
       initialParams,

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -84,9 +84,16 @@ export const texts = {
     categoryFilter: {
       label: 'Lebenslage'
     },
+    emptyStates: {
+      lifeSituations:
+        'Für diese Lebenslage sind derzeit keine Unterkategorien oder Leistungen verfügbar.',
+      lifeSituationsNested: 'Diese Lebenslage konnte derzeit nicht geladen werden.',
+      lifeSituationsRoot: 'Die Lebenslagen konnten derzeit nicht geladen werden.'
+    },
     employees: 'Ansprechpartner',
     initialFilter: {
       aToZ: 'A-Z',
+      lifeSituations: 'Lebenslagen',
       top10: 'Meistgesucht',
       search: 'Suche'
     },

--- a/src/helpers/BUS/shareHelper.js
+++ b/src/helpers/BUS/shareHelper.js
@@ -2,7 +2,7 @@ import appJson from '../../../app.json';
 
 export const shareMessage = (data) => {
   const buildMessage = () => {
-    return `${!!data.name && data.name}: ${!!data.teaser && data.teaser}`;
+    return [data?.name, data?.teaser].filter(Boolean).join(': ');
   };
 
   return `[Bürger- und Unternehmensservice] ${buildMessage()}\n\nQuelle: ${appJson.expo.name}`;

--- a/src/helpers/searchHelper.js
+++ b/src/helpers/searchHelper.js
@@ -1,5 +1,3 @@
-import _memoize from 'lodash/memoize';
-
 /**
  * Search all results with a given config.
  *
@@ -12,37 +10,32 @@ import _memoize from 'lodash/memoize';
  *
  * @return {array} a filtered array of elements
  */
-export const search = _memoize(
-  (config) => {
-    const { results, previousResults, category, keyword, character } = config;
-    let searchResults = previousResults || results;
-    // console.log('Call search for', { category, keyword, character });
+export const search = (config) => {
+  const { results, previousResults, category, keyword, character } = config;
+  let searchResults = previousResults || results;
 
-    if (category) {
-      // TODO: filter for category, when we will receive categories
-      searchResults = results;
-    }
+  if (category) {
+    // TODO: filter for category, when we will receive categories
+    searchResults = results;
+  }
 
-    // keyword can be an empty string, so there is the need to check explicitly for not undefined
-    if (keyword !== undefined) {
-      if (keyword.length > 3) {
-        searchResults = results.filter((entry) =>
-          entry.params.data.name.toLowerCase().includes(keyword.toLowerCase().trim())
-        );
-      } else if (keyword.length === 0) {
-        // show nothing if nothing is searched for
-        searchResults = [];
-      }
-    }
-
-    if (character) {
+  // keyword can be an empty string, so there is the need to check explicitly for not undefined
+  if (keyword !== undefined) {
+    if (keyword.length > 3) {
       searchResults = results.filter((entry) =>
-        entry.params.data.name.toLowerCase().startsWith(character.toLowerCase())
+        entry.params.data.name.toLowerCase().includes(keyword.toLowerCase().trim())
       );
+    } else if (keyword.length === 0) {
+      // show nothing if nothing is searched for
+      searchResults = [];
     }
+  }
 
-    return searchResults;
-  },
-  ({ category, keyword, character, location, results }) =>
-    [category, keyword, character, location, results.length].join('-')
-);
+  if (character) {
+    searchResults = results.filter((entry) =>
+      entry.params.data.name.toLowerCase().startsWith(character.toLowerCase())
+    );
+  }
+
+  return searchResults;
+};

--- a/src/hooks/bus.ts
+++ b/src/hooks/bus.ts
@@ -3,6 +3,8 @@ import { useContext } from 'react';
 import { useQuery } from 'react-query';
 
 import {
+  findBusCategoryChildren,
+  findBusCategoryRoot,
   findPublicServices,
   getPoliticalArea,
   getPublicService,
@@ -12,6 +14,7 @@ import { SettingsContext } from '../SettingsProvider';
 import type {
   AreaId,
   BusAreaSearchResult,
+  BusCategory,
   BusServiceArgs,
   BusServiceDetail,
   BusServiceListItem,
@@ -24,12 +27,19 @@ import { useStaticContent } from './staticContent';
 
 const BUS_QUERY_KEYS = {
   AREAS: 'areas',
+  CATEGORY_CHILDREN: 'category-children',
+  LIFE_SITUATIONS_ROOT: 'life-situations-root',
   ROOT: 'bus',
   SERVICE: 'service',
   SERVICES: 'services',
   INITIAL_AREA: 'initial-area',
   TOP10: 'top10'
 } as const;
+
+export const DEFAULT_BUS_LIFE_SITUATIONS_ROOT_SEARCH_WORD =
+  'Lebenslagen für Bürgerinnen und Bürger';
+export const BUS_MIN_SEARCH_LENGTH = 3;
+export const BUS_SEARCH_DEBOUNCE_MS = 400;
 
 // Avoid leaking the raw API key into React Query devtools while still changing the cache key
 // when credentials change.
@@ -54,6 +64,12 @@ export const getBusQueryConfigKey = (bus: Pick<BusSettings, 'apiKey' | 'uri'> = 
   return `${bus.uri ?? ''}::${getHashedKeyPart(bus.apiKey)}`;
 };
 
+export const getBusLifeSituationsRootSearchWord = (bus?: BusSettings) => {
+  const trimmedSearchWord = bus?.lifeSituationsRootSearchWord?.trim();
+
+  return trimmedSearchWord || DEFAULT_BUS_LIFE_SITUATIONS_ROOT_SEARCH_WORD;
+};
+
 const useBusSettings = (): BusSettings => {
   const { globalSettings } = useContext(SettingsContext) as BusSettingsContextValue;
   return globalSettings?.settings?.bus ?? {};
@@ -62,7 +78,8 @@ const useBusSettings = (): BusSettings => {
 export const useBusAreas = (searchTerm: string = '', isEnabled: boolean = true) => {
   const bus = useBusSettings();
   const hasBusConfig = !!bus.uri;
-  const isQueryEnabled = isEnabled && hasBusConfig && searchTerm.trim().length >= 3;
+  const isQueryEnabled =
+    isEnabled && hasBusConfig && searchTerm.trim().length >= BUS_MIN_SEARCH_LENGTH;
 
   const { data, error, isError, isFetching, isLoading, refetch } = useQuery<
     BusAreaSearchResult[],
@@ -87,6 +104,63 @@ export const useBusAreas = (searchTerm: string = '', isEnabled: boolean = true) 
   };
 };
 
+export const useBusLifeSituationsRoot = (areaId?: AreaId) => {
+  const bus = useBusSettings();
+  const hasBusConfig = !!bus.uri && !!areaId;
+  const busQueryConfigKey = getBusQueryConfigKey(bus);
+  const searchWord = getBusLifeSituationsRootSearchWord(bus);
+
+  const { data, error, isError, isFetching, isLoading, refetch } = useQuery<BusCategory | null>(
+    [
+      BUS_QUERY_KEYS.ROOT,
+      BUS_QUERY_KEYS.LIFE_SITUATIONS_ROOT,
+      areaId,
+      searchWord,
+      busQueryConfigKey
+    ],
+    () => findBusCategoryRoot({ areaId, bus, searchWord }),
+    {
+      enabled: hasBusConfig
+    }
+  );
+
+  return {
+    data,
+    error,
+    hasBusConfig,
+    isError,
+    isFetching,
+    isLoading,
+    refetch
+  };
+};
+
+export const useBusCategoryChildren = (parentId?: string | number | null, areaId?: AreaId) => {
+  const bus = useBusSettings();
+  const hasValidParentId =
+    parentId !== null && parentId !== undefined && `${parentId}`.trim().length > 0;
+  const hasBusConfig = !!bus.uri && !!areaId && hasValidParentId;
+  const busQueryConfigKey = getBusQueryConfigKey(bus);
+
+  const { data, error, isError, isFetching, isLoading, refetch } = useQuery<BusCategory[], Error>(
+    [BUS_QUERY_KEYS.ROOT, BUS_QUERY_KEYS.CATEGORY_CHILDREN, parentId, areaId, busQueryConfigKey],
+    () => findBusCategoryChildren({ areaId, bus, parentId }),
+    {
+      enabled: hasBusConfig
+    }
+  );
+
+  return {
+    data,
+    error,
+    hasBusConfig,
+    isError,
+    isFetching,
+    isLoading,
+    refetch
+  };
+};
+
 export const useBusServices = (areaId: AreaId) => {
   const bus = useBusSettings();
   const hasBusConfig = !!bus.uri && !!areaId;
@@ -96,8 +170,7 @@ export const useBusServices = (areaId: AreaId) => {
     [BUS_QUERY_KEYS.ROOT, BUS_QUERY_KEYS.SERVICES, areaId, busQueryConfigKey],
     () => findPublicServices({ areaId, bus }),
     {
-      enabled: hasBusConfig,
-      keepPreviousData: true
+      enabled: hasBusConfig
     }
   );
 

--- a/src/queries/bus.js
+++ b/src/queries/bus.js
@@ -1,4 +1,18 @@
 const DEFAULT_LIST_LIMIT = 1000;
+const ROOT_CATEGORY_SELECT_ATTRIBUTES = ['id', 'name']
+  .map((attribute) => `&selectAttributes[]=${attribute}`)
+  .join('');
+const CHILD_CATEGORY_SELECT_ATTRIBUTES = [
+  'id',
+  'name',
+  'description',
+  'parentId',
+  'position',
+  'image',
+  'publicServiceTypes'
+]
+  .map((attribute) => `&selectAttributes[]=${attribute}`)
+  .join('');
 
 const createRequestOptions = (apiKey) => ({
   headers: {
@@ -49,6 +63,40 @@ export const findPublicServices = async ({ areaId, bus, searchWord = '' }) => {
   return services;
 };
 
+export const findBusCategoryRoot = async ({ areaId, bus, searchWord }) => {
+  const { apiKey, uri: baseUrl } = bus;
+  const normalizedSearchWord = searchWord?.trim();
+
+  if (!normalizedSearchWord) return null;
+
+  const encodedSearchWord = encodeURIComponent(normalizedSearchWord);
+  const areaIdQuery = areaId ? `&areaId=${encodeURIComponent(areaId)}` : '';
+  const payload = await requestJson(
+    `${baseUrl}/pstCategory/find?searchWord=${encodedSearchWord}&limit=${DEFAULT_LIST_LIMIT}${areaIdQuery}${ROOT_CATEGORY_SELECT_ATTRIBUTES}`,
+    apiKey
+  );
+  const results = Array.isArray(payload?.results) ? payload.results : [];
+
+  return (
+    results
+      .map((item) => item?.object)
+      .find((category) => category?.name === normalizedSearchWord) ?? null
+  );
+};
+
+export const findBusCategoryChildren = async ({ areaId, bus, parentId }) => {
+  const { apiKey, uri: baseUrl } = bus;
+  const encodedParentId = encodeURIComponent(parentId);
+  const areaIdQuery = areaId ? `&areaId=${encodeURIComponent(areaId)}` : '';
+  const payload = await requestJson(
+    `${baseUrl}/pstCategory/find?parentId=${encodedParentId}&limit=${DEFAULT_LIST_LIMIT}${areaIdQuery}${CHILD_CATEGORY_SELECT_ATTRIBUTES}`,
+    apiKey
+  );
+  const results = Array.isArray(payload?.results) ? payload.results : [];
+
+  return results.map((item) => item?.object).filter(Boolean);
+};
+
 export const getPublicService = async ({ areaId, bus, id }) => {
   const { apiKey, uri: baseUrl } = bus;
   const encodedAreaId = encodeURIComponent(areaId);
@@ -73,9 +121,9 @@ export const searchPoliticalAreas = async ({ searchTerm = '', bus }) => {
   if (query.length < 3) return [];
 
   const sanitizedSearchWords = query
-    .split(/\s+/)
+    .split(/[\s-]+/)
     .map((word) => word.replace(/[^0-9A-Za-zÄÖÜäöüß]/g, ''))
-    .filter(Boolean);
+    .filter((word) => word.length >= 3);
 
   if (!sanitizedSearchWords.length) return [];
 

--- a/src/screens/BUS/CategoryScreen.tsx
+++ b/src/screens/BUS/CategoryScreen.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { RefreshControl } from 'react-native';
+
+import { DefaultKeyboardAvoidingView } from '../../components/DefaultKeyboardAvoidingView';
+import { LifeSituationsList } from '../../components/BUS/LifeSituationsList';
+import { SafeAreaViewFlex } from '../../components/SafeAreaViewFlex';
+import { colors } from '../../config';
+import { useBusCategoryChildren, useBusServices, useMatomoTrackScreenView } from '../../hooks';
+import type { BusCategory } from '../../types';
+
+type CategoryRouteParams = {
+  areaId?: string | number;
+  category?: BusCategory;
+  isRootCategory?: boolean;
+  title?: string;
+};
+
+type CategoryScreenProps = {
+  navigation: {
+    push: (screen: string, params: Record<string, unknown>) => void;
+  };
+  route: {
+    params?: CategoryRouteParams;
+  };
+};
+
+const hasValidCategoryId = (category?: BusCategory) =>
+  category?.id !== null && category?.id !== undefined && `${category.id}`.trim().length > 0;
+
+export const CategoryScreen = ({ navigation, route }: CategoryScreenProps) => {
+  const areaId = route?.params?.areaId;
+  const category = route?.params?.category;
+  const isRootCategory = route?.params?.isRootCategory ?? false;
+  const {
+    data = [],
+    isError = false,
+    isFetching = false,
+    isLoading = false,
+    refetch
+  } = useBusCategoryChildren(category?.id, areaId);
+  const { data: services = [], isLoading: isServicesLoading = false } = useBusServices(areaId);
+  const childCategories = isError ? [] : data;
+
+  useMatomoTrackScreenView(`BUS/${category?.name || 'Lebenslagen'}`);
+
+  if (!hasValidCategoryId(category)) {
+    return null;
+  }
+
+  return (
+    <SafeAreaViewFlex>
+      <DefaultKeyboardAvoidingView>
+        <LifeSituationsList
+          navigation={navigation}
+          areaId={areaId}
+          category={category}
+          childCategories={childCategories}
+          isError={isError}
+          isLoading={isLoading}
+          isRootCategory={isRootCategory}
+          isServicesLoading={isServicesLoading}
+          refreshControl={
+            <RefreshControl
+              refreshing={isFetching && !isLoading}
+              onRefresh={refetch}
+              colors={[colors.refreshControl]}
+              tintColor={colors.refreshControl}
+            />
+          }
+          services={services}
+        />
+      </DefaultKeyboardAvoidingView>
+    </SafeAreaViewFlex>
+  );
+};

--- a/src/screens/BUS/DetailScreen.js
+++ b/src/screens/BUS/DetailScreen.js
@@ -91,7 +91,10 @@ const parseTextBlocks = (service) => {
       return (
         textBlock.type.name.toUpperCase() === 'TEASER' ||
         textBlock.type.name.toUpperCase() === 'FACHLICH FREIGEGEBEN DURCH' ||
-        textBlock.type.name.toUpperCase() === 'FACHLICH FREIGEGEBEN AM'
+        textBlock.type.name.toUpperCase() === 'FACHLICH FREIGEGEBEN AM' ||
+        textBlock.type.name.toUpperCase() === 'TYPISIERUNG' ||
+        textBlock.type.name.toUpperCase() === 'STATUS KATALOGEINTRAG' ||
+        textBlock.type.name.toUpperCase() === 'STATUS BIBLIOTHEKSEINTRAG'
       );
     });
   }

--- a/src/screens/BUS/IndexScreen.js
+++ b/src/screens/BUS/IndexScreen.js
@@ -11,10 +11,12 @@ import {
 } from '../../components';
 import { ServiceList } from '../../components/BUS/ServiceList';
 import { colors, consts, texts } from '../../config';
-import { runAsyncTasksSafely } from '../../helpers';
+import { runAsyncTasksSafely, spaceNewLines } from '../../helpers';
 import { shareMessage } from '../../helpers/BUS/shareHelper';
 import {
+  useBusCategoryChildren,
   useBusInitialArea,
+  useBusLifeSituationsRoot,
   useBusServices,
   useBusTop10,
   useMatomoTrackScreenView
@@ -26,16 +28,62 @@ const { MATOMO_TRACKING } = consts;
 const INITIAL_FILTER = [
   // NOTE: the top 10 should not be available as initial filter anymore
   // { id: 1, title: texts.bus.initialFilter.top10, selected: true },
-  // TODO: commented out 'Lebenslagen' as the main server does not have data for that section yet
-  // { id: 2, title: 'Lebenslagen', selected: false },
-  { id: 3, title: texts.bus.initialFilter.search, selected: true },
+  { id: 2, title: texts.bus.initialFilter.lifeSituations, selected: true },
+  { id: 3, title: texts.bus.initialFilter.search, selected: false },
   { id: 4, title: texts.bus.initialFilter.aToZ, selected: false }
 ];
 
+const getDefaultFilter = () => INITIAL_FILTER.map((entry) => ({ ...entry }));
+
 const FILTER_IDS = {
   TOP10: 1,
+  LIFE_SITUATIONS: 2,
   SEARCH: 3,
   ATOZ: 4
+};
+
+const FILTER_SETTING_IDS = {
+  top10: FILTER_IDS.TOP10,
+  lifeSituations: FILTER_IDS.LIFE_SITUATIONS,
+  search: FILTER_IDS.SEARCH,
+  aToZ: FILTER_IDS.ATOZ
+};
+
+const hasValue = (value) => value !== null && value !== undefined && `${value}`.trim().length > 0;
+const normalizeName = (value) => `${value ?? ''}`.trim().toLowerCase();
+
+const getFilterEntry = (id) => {
+  switch (id) {
+    case FILTER_IDS.TOP10:
+      return { id, title: texts.bus.initialFilter.top10 };
+    case FILTER_IDS.LIFE_SITUATIONS:
+      return { id, title: texts.bus.initialFilter.lifeSituations };
+    case FILTER_IDS.SEARCH:
+      return { id, title: texts.bus.initialFilter.search };
+    case FILTER_IDS.ATOZ:
+      return { id, title: texts.bus.initialFilter.aToZ };
+    default:
+      return null;
+  }
+};
+
+const getEffectiveInitialFilter = (configuredFilter = []) => {
+  const configuredIds = configuredFilter
+    .map((entry) => FILTER_SETTING_IDS[entry])
+    .filter(Boolean)
+    .filter((id, index, entries) => entries.indexOf(id) === index);
+
+  if (!configuredIds.length) {
+    return getDefaultFilter();
+  }
+
+  return configuredIds
+    .map(getFilterEntry)
+    .filter(Boolean)
+    .map((entry, index) => ({
+      ...entry,
+      selected: index === 0
+    }));
 };
 
 const getListItems = (areaId, data) =>
@@ -59,6 +107,108 @@ const getListItems = (areaId, data) =>
     }
   }));
 
+const getResolvedLifeSituationServices = (category, services = []) => {
+  const servicesById = new Map(
+    services
+      .filter((service) => service?.id !== null && service?.id !== undefined)
+      .map((service) => [`${service.id}`, service])
+  );
+  const servicesByName = new Map(
+    services
+      .filter((service) => !!normalizeName(service?.name))
+      .map((service) => [normalizeName(service.name), service])
+  );
+
+  return (category?.publicServiceTypes ?? [])
+    .map((serviceReference) => {
+      const serviceId = serviceReference?.id;
+      const serviceName = serviceReference?.name;
+
+      return (
+        servicesById.get(`${serviceId ?? ''}`) || servicesByName.get(normalizeName(serviceName))
+      );
+    })
+    .filter(Boolean);
+};
+
+const getLifeSituationsItems = (areaId, category, childCategories = [], services = []) => {
+  const hasValidCategoryId = hasValue(category?.id);
+  if (!hasValidCategoryId) {
+    return [];
+  }
+
+  const categoryItems = _sortBy(
+    childCategories.filter(
+      (childCategory) => hasValue(childCategory?.id) && hasValue(childCategory?.name)
+    ),
+    [
+      (childCategory) =>
+        Number.isFinite(Number(childCategory?.position))
+          ? Number(childCategory.position)
+          : Number.POSITIVE_INFINITY,
+      (childCategory) => childCategory.name.toUpperCase()
+    ]
+  ).map((childCategory) => ({
+    id: childCategory.id,
+    picture: childCategory?.image?.url ? { url: childCategory.image.url } : undefined,
+    subtitle: spaceNewLines(childCategory.description),
+    title: childCategory.name,
+    routeName: 'BusCategory',
+    params: {
+      areaId,
+      category: childCategory,
+      isRootCategory: false,
+      title: childCategory.name
+    }
+  }));
+  const serviceItems = getResolvedLifeSituationServices(category, services)
+    .filter((service) => hasValue(service?.id) && hasValue(service?.name))
+    .map((service) => ({
+      id: service.id,
+      title: service.name,
+      routeName: 'BusDetail',
+      params: {
+        areaId,
+        title: service.name,
+        query: '',
+        queryVariables: {},
+        rootRouteName: 'BUS',
+        shareContent: {
+          message: shareMessage(service)
+        },
+        data: service
+      }
+    }));
+
+  return [...categoryItems, ...serviceItems];
+};
+
+const getIsListLoading = ({
+  hasLifeSituationsRoot,
+  isFetchingLifeSituationChildren,
+  isFetchingLifeSituationsRoot,
+  isFetchingServices,
+  isLoadingLifeSituationChildren,
+  isLoadingLifeSituationsRoot,
+  isLoadingServices,
+  isLoadingTop10,
+  selectedFilterId
+}) => {
+  switch (selectedFilterId) {
+    case FILTER_IDS.LIFE_SITUATIONS:
+      return (
+        isLoadingLifeSituationsRoot ||
+        isFetchingLifeSituationsRoot ||
+        (hasLifeSituationsRoot &&
+          (isLoadingLifeSituationChildren || isFetchingLifeSituationChildren))
+      );
+    case FILTER_IDS.TOP10:
+      return isLoadingServices || isFetchingServices || isLoadingTop10;
+    default:
+      return isLoadingServices || isFetchingServices;
+  }
+};
+
 export const IndexScreen = ({ navigation }) => {
   const { globalSettings } = useContext(SettingsContext);
   const { settings = {} } = globalSettings;
@@ -68,18 +218,28 @@ export const IndexScreen = ({ navigation }) => {
   const initialAreaName = initialArea?.label || '';
   const [areaId, setAreaId] = useState(initialAreaId);
   const [areaName, setAreaName] = useState('');
-  const [filter, setFilter] = useState(
-    bus?.initialFilter?.map((entry, index) => ({
-      id: FILTER_IDS[entry.toUpperCase()],
-      title: texts.bus.initialFilter[entry],
-      selected: index === 0
-    })) || INITIAL_FILTER
-  );
+  const initialFilter = getEffectiveInitialFilter(bus?.initialFilter);
+  const [filter, setFilter] = useState(initialFilter.length ? initialFilter : getDefaultFilter());
   const selectedFilter = filter.find((entry) => entry.selected) || filter[0];
   const [refreshing, setRefreshing] = useState(false);
 
   useMatomoTrackScreenView(MATOMO_TRACKING.SCREEN_VIEW.BUS);
 
+  const {
+    data: lifeSituationsRoot,
+    isError: isLifeSituationsRootError,
+    isFetching: isFetchingLifeSituationsRoot,
+    isLoading: isLoadingLifeSituationsRoot,
+    refetch: refetchLifeSituationsRoot
+  } = useBusLifeSituationsRoot(areaId);
+  const hasLifeSituationsRoot = hasValue(lifeSituationsRoot?.id);
+  const {
+    data: lifeSituationChildren = [],
+    isError: isLifeSituationChildrenError,
+    isFetching: isFetchingLifeSituationChildren,
+    isLoading: isLoadingLifeSituationChildren,
+    refetch: refetchLifeSituationChildren
+  } = useBusCategoryChildren(lifeSituationsRoot?.id, areaId);
   const {
     data: services = [],
     isFetching: isFetchingServices,
@@ -101,17 +261,36 @@ export const IndexScreen = ({ navigation }) => {
   const refresh = async () => {
     setRefreshing(true);
     try {
-      await runAsyncTasksSafely([refetchServices, refetchTop10]);
+      await runAsyncTasksSafely([
+        refetchLifeSituationsRoot,
+        hasLifeSituationsRoot ? refetchLifeSituationChildren : undefined,
+        refetchServices,
+        refetchTop10
+      ]);
     } finally {
       setRefreshing(false);
     }
   };
 
+  const isLifeSituationsError = isLifeSituationsRootError || isLifeSituationChildrenError;
+  const lifeSituations = isLifeSituationsError
+    ? []
+    : getLifeSituationsItems(areaId, lifeSituationsRoot, lifeSituationChildren, services);
+  const lifeSituationsEmptyStateMessage = isLifeSituationsError
+    ? texts.bus.emptyStates.lifeSituationsRoot
+    : texts.bus.emptyStates.lifeSituations;
   const top10 = getListItems(areaId, top10Services);
-  const isListLoading =
-    isLoadingServices ||
-    isFetchingServices ||
-    (selectedFilter?.id === FILTER_IDS.TOP10 && isLoadingTop10);
+  const isListLoading = getIsListLoading({
+    hasLifeSituationsRoot,
+    isFetchingLifeSituationChildren,
+    isFetchingLifeSituationsRoot,
+    isFetchingServices,
+    isLoadingLifeSituationChildren,
+    isLoadingLifeSituationsRoot,
+    isLoadingServices,
+    isLoadingTop10,
+    selectedFilterId: selectedFilter?.id
+  });
   const results = getListItems(areaId, services);
 
   return (
@@ -121,6 +300,8 @@ export const IndexScreen = ({ navigation }) => {
         <ServiceList
           navigation={navigation}
           selectedFilter={selectedFilter}
+          lifeSituationsEmptyStateMessage={lifeSituationsEmptyStateMessage}
+          lifeSituations={lifeSituations}
           results={results}
           areaId={areaId}
           areaName={resolvedAreaName}

--- a/src/screens/BUS/index.js
+++ b/src/screens/BUS/index.js
@@ -1,2 +1,3 @@
+export * from './CategoryScreen';
 export * from './DetailScreen';
 export * from './IndexScreen';

--- a/src/types/Bus.ts
+++ b/src/types/Bus.ts
@@ -4,7 +4,34 @@ export type BusSettings = {
   apiKey?: string;
   areaId?: string | number;
   initialFilter?: string[];
+  lifeSituationsRootSearchWord?: string;
   uri?: string;
+};
+
+export type BusCategoryServiceReference = {
+  id?: string | number;
+  name?: string | null;
+};
+
+export type BusCategoryImage = {
+  fileSize?: string;
+  mimeType?: string;
+  name?: string;
+  originalFileName?: string;
+  source?: string;
+  url?: string;
+  height?: number;
+  width?: number;
+};
+
+export type BusCategory = {
+  description?: string | null;
+  id?: string | number;
+  image?: BusCategoryImage;
+  name?: string | null;
+  parentId?: string | number;
+  position?: string | number;
+  publicServiceTypes?: BusCategoryServiceReference[];
 };
 
 export type BusServiceListItem = {

--- a/src/types/Navigation.ts
+++ b/src/types/Navigation.ts
@@ -1,6 +1,7 @@
 import { BottomTabNavigationOptions } from '@react-navigation/bottom-tabs';
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationOptions } from '@react-navigation/stack';
+import { ComponentType } from 'react';
 import { ViewStyle } from 'react-native';
 
 import { Icon } from '../config';
@@ -10,6 +11,7 @@ export enum ScreenName {
   ARShow = 'ARShow',
   ARInfo = 'ARInfo',
   ArtworkDetail = 'ArtworkDetail',
+  BusCategory = 'BusCategory',
   BusDetail = 'BusDetail',
   BusDetailFallback = 'BBBUSDetail',
   BusIndex = 'BusIndex',
@@ -135,7 +137,7 @@ export type TabOptions =
 
 export type ScreenConfig = {
   routeName: ScreenName;
-  screenComponent: (props: { navigation: any; route: any }) => JSX.Element | null;
+  screenComponent: ComponentType<any>;
   screenOptions?: ScreenOptions;
   // eslint-disable-next-line @typescript-eslint/ban-types
   initialParams?: Object;
@@ -155,12 +157,12 @@ export type CustomTab = {
   iconSize?: number;
   iconStyle?: ViewStyle;
   label: string;
-  params?: Record<string, any>;
+  params?: Record<string, unknown>;
   screen: ScreenName;
   strokeColor?: string;
   strokeWidth?: number;
   tabBarLabelStyle?: ViewStyle;
-  tilesScreenParams?: Record<string, any>;
+  tilesScreenParams?: Record<string, unknown>;
 };
 
 export type TabConfig = {


### PR DESCRIPTION
This PR adds and extends the BUS `Lebenslagen` flow and makes BUS results reliably area-aware.

The main change is that `Lebenslagen` now works as a category tree via `pstCategory/find`, including nested navigation, direct services inside categories, first-level descriptions, and teaser images where available. In parallel, BUS loading and filtering were tightened so content gets reloaded correctly after area changes and stale entries from another federal state are no longer shown.

**What changed**

- Re-enabled the BUS `Lebenslagen` tab and implemented category-based loading via `searchWord` + `parentId`
- Added a dedicated nested BUS category screen for life situation navigation
- Made BUS category and service queries consistently `areaId`-aware, including deeper life situation levels
- Added support for first-level descriptions and nested category list rendering in the existing BUS list style
- Added teaser image support for life situations where category `image` data is available
- Improved BUS location search with:
  - debounced requests
  - backend-compatible tokenization for hyphenated place names
  - blur-on-select
  - proper reset behavior
  - visible initial clear icon for prefilled locations
- Fixed stale data issues in `A-Z`, search, and life situations after area changes
- Added/expanded regression coverage for BUS queries, hooks, area autocomplete, search helper behavior, and category navigation

**Why**

We had two main issues:

1. `Lebenslagen` was not modeled as a navigable BUS category tree in the app, even though the backend exposes it that way.
2. BUS content could remain tied to the wrong federal state after changing the selected area, especially in filtered/indexed views and deep life situation navigation.

This PR addresses both by aligning the frontend with the actual `pstCategory` model and by ensuring area changes invalidate and reload the relevant BUS data paths.

**Testing**

Covered by targeted BUS regression tests, including:

- category root/child loading
- `areaId`-aware BUS queries
- stale result prevention after area changes
- nested life situation navigation
- location search debounce and tokenization
- initial clear icon / reset behavior in the BUS location field

**Notes**

- Category queries now use explicit `selectAttributes` and only request the fields needed by the app.
- Life situation images are wired through category `image` data; SVG handling was reviewed during implementation, and the data path is now explicit enough for follow-up hardening if needed.

SBB-190