### PR TITLE
fix(sue): stability bugfix pack

### DIFF
--- a/__tests__/helpers/navigationHelper.test.ts
+++ b/__tests__/helpers/navigationHelper.test.ts
@@ -82,12 +82,27 @@ describe('navigateToRoute', () => {
         navigate,
         push
       },
-      params: { query: 'myRequests' },
+      params: { query: 'requests' },
       routeName: 'SueList',
       targetTabIndex: 3
     });
 
     expect(getParent).toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith('SueList', { query: 'requests' });
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('stays on the current stack for SUE my requests even when a target tab index is provided', () => {
+    const { navigation, parentNavigate, navigate, push } = createNavigation();
+
+    navigateToRoute({
+      navigation,
+      params: { query: 'myRequests' },
+      routeName: 'SueList',
+      targetTabIndex: 3
+    });
+
+    expect(parentNavigate).not.toHaveBeenCalled();
     expect(navigate).toHaveBeenCalledWith('SueList', { query: 'myRequests' });
     expect(push).not.toHaveBeenCalled();
   });

--- a/src/components/CardListItem.js
+++ b/src/components/CardListItem.js
@@ -7,7 +7,7 @@ import { colors, consts, normalize } from '../config';
 import { imageHeight, imageWidth, momentFormat, navigateToRoute, trimNewLines } from '../helpers';
 
 import { Image } from './Image';
-import { SueCategory, SueImageFallback, SueStatus } from './SUE';
+import { SueCategory, SueStatus } from './SUE';
 import { HeadlineText, RegularText } from './Text';
 import { Touchable } from './Touchable';
 import { Wrapper, WrapperHorizontal } from './Wrapper';
@@ -56,11 +56,6 @@ const renderCardContent = (bigTitle, horizontal, index, isSue, item, noOvertitle
           key={keyExtractor(picture.url, index)}
           placeholderStyle={styles.placeholderStyle}
           source={{ uri: picture.url }}
-        />
-      ) : isSue ? (
-        <SueImageFallback
-          key={keyExtractor('fallbackImage', index)}
-          style={[stylesWithProps({ aspectRatio, horizontal }).image, styles.sueImage]}
         />
       ) : null,
     overtitle: () =>

--- a/src/components/SUE/SueImageFallback.tsx
+++ b/src/components/SUE/SueImageFallback.tsx
@@ -5,8 +5,6 @@ import { Icon, colors, normalize } from '../../config';
 import { imageHeight, imageWidth } from '../../helpers';
 
 export const SueImageFallback = ({ style }: { style?: any }) => {
-  // HINT: This component has been disabled upon request. It has not been deleted so that it can be quickly reintegrated if needed.
-  return null;
   return (
     <View style={[styles.container, stylesForImage().defaultStyle, style]}>
       <Icon.SueBroom color={colors.placeholder} size={normalize(32)} />

--- a/src/components/SUE/report/SueReportDescription.tsx
+++ b/src/components/SUE/report/SueReportDescription.tsx
@@ -20,6 +20,7 @@ export const SueReportDescription = ({
   errorMessage,
   requiredInputs,
   selectedPosition,
+  storeReportValues,
   setSelectedPosition,
   setShowCoordinatesFromImageAlert,
   setUpdateRegionFromImage,
@@ -31,6 +32,7 @@ export const SueReportDescription = ({
   errorMessage: string;
   requiredInputs: keyof TValues[];
   selectedPosition?: Location.LocationObjectCoords;
+  storeReportValues: () => Promise<void>;
   setSelectedPosition: (position?: Location.LocationObjectCoords) => void;
   setShowCoordinatesFromImageAlert: (value: boolean) => void;
   setUpdateRegionFromImage: (value: boolean) => void;
@@ -58,6 +60,7 @@ export const SueReportDescription = ({
         setUpdateRegionFromImage,
         setValue
       },
+      onBeforeNativeImagePicker: storeReportValues,
       isMultiImages: true,
       selectorType: IMAGE_SELECTOR_TYPES.SUE,
       errorType: IMAGE_SELECTOR_ERROR_TYPES.SUE,
@@ -73,6 +76,7 @@ export const SueReportDescription = ({
       areaServiceData,
       errorMessage,
       selectedPosition,
+      storeReportValues,
       setSelectedPosition,
       setShowCoordinatesFromImageAlert,
       setUpdateRegionFromImage,

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -114,7 +114,7 @@ export const SueReportLocation = ({
 }) => {
   const reverseGeocode = useReverseGeocode();
   const navigation = useNavigation();
-  const { locationSettings = {}, setAndSyncLocationSettings } = useLocationSettings();
+  const { locationSettings = {} } = useLocationSettings();
   const { locationService: locationServiceEnabled } = locationSettings;
   const { globalSettings } = useContext(SettingsContext);
   const { settings = {} } = globalSettings;
@@ -225,19 +225,29 @@ export const SueReportLocation = ({
     const requestId = latestReverseGeocodeRequestRef.current + 1;
 
     latestReverseGeocodeRequestRef.current = requestId;
-    setSelectedPosition(position);
     setShowCoordinatesFromImageAlert(true);
     setUpdateRegionFromImage(false);
     clearAddressFields();
 
     try {
-      await reverseGeocode({
+      const reverseGeocodeResult = await reverseGeocode({
         areaServiceData,
         errorMessage,
         isLatestRequest: () => latestReverseGeocodeRequestRef.current === requestId,
         position,
         setValue
       });
+
+      if (reverseGeocodeResult?.isStale) {
+        return;
+      }
+
+      if (reverseGeocodeResult?.isWithinArea) {
+        setSelectedPosition(position);
+        return;
+      }
+
+      setSelectedPosition(undefined);
     } catch (error) {
       if (latestReverseGeocodeRequestRef.current !== requestId) {
         return;
@@ -261,17 +271,6 @@ export const SueReportLocation = ({
         return fallbackPosition;
       }
 
-      const permissionResponse = await Location.requestForegroundPermissionsAsync();
-      const hasPermission = permissionResponse.status === Location.PermissionStatus.GRANTED;
-
-      await setAndSyncLocationSettings({
-        locationService: hasPermission
-      });
-
-      if (!hasPermission) {
-        return undefined;
-      }
-
       try {
         const current = await Location.getCurrentPositionAsync({
           accuracy: Platform.select({
@@ -287,12 +286,33 @@ export const SueReportLocation = ({
     };
 
     const applyCurrentPosition = async () => {
+      if (!locationServiceEnabled) {
+        locationServiceEnabledAlert({
+          currentPosition: undefined,
+          locationServiceEnabled: false,
+          navigation
+        });
+        return;
+      }
+
+      const permissionResponse = await Location.getForegroundPermissionsAsync();
+      const hasPermission = permissionResponse.status === Location.PermissionStatus.GRANTED;
+
+      if (!hasPermission) {
+        locationServiceEnabledAlert({
+          currentPosition: undefined,
+          locationServiceEnabled: true,
+          navigation
+        });
+        return;
+      }
+
       const resolvedPosition = await resolvePosition();
 
       if (!resolvedPosition?.coords) {
         locationServiceEnabledAlert({
           currentPosition: undefined,
-          locationServiceEnabled,
+          locationServiceEnabled: true,
           navigation
         });
         return;

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -119,6 +119,7 @@ export const SueReportLocation = ({
   const { globalSettings } = useContext(SettingsContext);
   const { settings = {} } = globalSettings;
   const { locationService } = settings;
+  const isMyLocationButtonVisible = locationService !== false;
   const systemPermission = useSystemPermission();
   const { appDesignSystem = {} } = useContext(ConfigurationsContext);
   const { sueStatus = {} } = appDesignSystem;
@@ -328,7 +329,7 @@ export const SueReportLocation = ({
           clusterThreshold={configuration.geoMap?.clusterThreshold}
           currentPosition={currentPosition}
           isMultipleMarkersMap
-          isMyLocationButtonVisible={!!locationService}
+          isMyLocationButtonVisible={isMyLocationButtonVisible}
           locations={locations}
           mapStyle={[
             styles.map,

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -4,7 +4,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import * as Location from 'expo-location';
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { UseFormGetValues, UseFormSetValue } from 'react-hook-form';
-import { Alert, Linking, StyleSheet } from 'react-native';
+import { Alert, Linking, Platform, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { getStatusBarHeight } from 'react-native-status-bar-height';
 import { useQuery } from 'react-query';
@@ -114,7 +114,7 @@ export const SueReportLocation = ({
 }) => {
   const reverseGeocode = useReverseGeocode();
   const navigation = useNavigation();
-  const { locationSettings = {} } = useLocationSettings();
+  const { locationSettings = {}, setAndSyncLocationSettings } = useLocationSettings();
   const { locationService: locationServiceEnabled } = locationSettings;
   const { globalSettings } = useContext(SettingsContext);
   const { settings = {} } = globalSettings;
@@ -253,6 +253,57 @@ export const SueReportLocation = ({
   }: {
     isFullScreenMap?: boolean;
   }) => {
+    const resolvePosition = async () => {
+      const fallbackPosition = position || lastKnownPosition;
+
+      if (fallbackPosition?.coords) {
+        return fallbackPosition;
+      }
+
+      const permissionResponse = await Location.requestForegroundPermissionsAsync();
+      const hasPermission = permissionResponse.status === Location.PermissionStatus.GRANTED;
+
+      await setAndSyncLocationSettings({
+        locationService: hasPermission
+      });
+
+      if (!hasPermission) {
+        return undefined;
+      }
+
+      try {
+        const current = await Location.getCurrentPositionAsync({
+          accuracy: Platform.select({
+            ios: Location.Accuracy.Balanced,
+            default: undefined
+          })
+        });
+
+        return current || (await Location.getLastKnownPositionAsync({}));
+      } catch (error) {
+        return await Location.getLastKnownPositionAsync({});
+      }
+    };
+
+    const applyCurrentPosition = async () => {
+      const resolvedPosition = await resolvePosition();
+
+      if (!resolvedPosition?.coords) {
+        locationServiceEnabledAlert({
+          currentPosition: undefined,
+          locationServiceEnabled,
+          navigation
+        });
+        return;
+      }
+
+      onMapPress({
+        geometry: {
+          coordinates: [resolvedPosition.coords.longitude, resolvedPosition.coords.latitude]
+        }
+      });
+    };
+
     if (!isFullScreenMap) {
       Alert.alert(texts.sue.report.alerts.hint, texts.sue.report.alerts.myLocation, [
         {
@@ -260,29 +311,11 @@ export const SueReportLocation = ({
         },
         {
           text: texts.sue.report.alerts.yes,
-          onPress: async () => {
-            locationServiceEnabledAlert({
-              currentPosition,
-              locationServiceEnabled,
-              navigation
-            });
-
-            !!currentPosition &&
-              onMapPress({
-                geometry: {
-                  coordinates: [currentPosition.coords.longitude, currentPosition.coords.latitude]
-                }
-              });
-          }
+          onPress: applyCurrentPosition
         }
       ]);
     } else {
-      !!currentPosition &&
-        onMapPress({
-          geometry: {
-            coordinates: [currentPosition.coords.longitude, currentPosition.coords.latitude]
-          }
-        });
+      await applyCurrentPosition();
     }
   };
 

--- a/src/components/map/MapLibre.tsx
+++ b/src/components/map/MapLibre.tsx
@@ -822,6 +822,8 @@ export const MapLibre = ({
   const maximizeFullscreenStyle = isFullscreenMap
     ? { bottom: normalize(15) + (safeAreaBottom ? 0 : bottomTabBarHeight), right: 0 as const }
     : undefined;
+  const hasCurrentPosition =
+    currentPosition?.coords?.latitude != null && currentPosition?.coords?.longitude != null;
 
   return (
     <View style={[styles.container, style]}>
@@ -1011,12 +1013,13 @@ export const MapLibre = ({
       {isMyLocationButtonVisible && (
         <TouchableOpacity
           accessibilityLabel={`${texts.components.map} ${a11yLabel.button}`}
-          onPress={() => {
-            if (showsUserLocation) {
+          onPress={async () => {
+            await onMyLocationButtonPress?.({ isFullScreenMap: isFullscreenMap });
+
+            // Android can crash when user tracking is enabled before a valid
+            // runtime-granted location is available on the native layer.
+            if (showsUserLocation && hasCurrentPosition) {
               setFollowsUserLocation(true);
-            }
-            onMyLocationButtonPress?.({});
-            if (showsUserLocation) {
               setTimeout(() => setFollowsUserLocation(false), FOLLOW_USER_TIMEOUT);
             }
           }}

--- a/src/components/map/MapLibre.tsx
+++ b/src/components/map/MapLibre.tsx
@@ -262,7 +262,11 @@ type Props = {
   }) => void | Promise<void>;
   onMarkerPress?: (arg0?: string) => void;
   onMaximizeButtonPress?: () => void;
-  onMyLocationButtonPress?: ({ isFullScreenMap }: { isFullScreenMap?: boolean }) => void;
+  onMyLocationButtonPress?: ({
+    isFullScreenMap
+  }: {
+    isFullScreenMap?: boolean;
+  }) => void | Promise<void>;
   selectedMarker?: string;
   selectedPosition?: LocationObjectCoords;
   setPinEnabled?: boolean;
@@ -1014,11 +1018,21 @@ export const MapLibre = ({
         <TouchableOpacity
           accessibilityLabel={`${texts.components.map} ${a11yLabel.button}`}
           onPress={async () => {
-            await onMyLocationButtonPress?.({ isFullScreenMap: isFullscreenMap });
+            try {
+              await onMyLocationButtonPress?.({ isFullScreenMap: isFullscreenMap });
+            } catch (error) {
+              console.error('My location button press failed', error);
+            }
+
+            if (!showsUserLocation) {
+              return;
+            }
 
             // Android can crash when user tracking is enabled before a valid
             // runtime-granted location is available on the native layer.
-            if (showsUserLocation && hasCurrentPosition) {
+            const canFollowUserLocation = hasCurrentPosition || !onMyLocationButtonPress;
+
+            if (canFollowUserLocation) {
               setFollowsUserLocation(true);
               setTimeout(() => setFollowsUserLocation(false), FOLLOW_USER_TIMEOUT);
             }

--- a/src/components/map/MapLibre.tsx
+++ b/src/components/map/MapLibre.tsx
@@ -1008,13 +1008,17 @@ export const MapLibre = ({
         )}
       </Map>
 
-      {isMyLocationButtonVisible && showsUserLocation && (
+      {isMyLocationButtonVisible && (
         <TouchableOpacity
           accessibilityLabel={`${texts.components.map} ${a11yLabel.button}`}
           onPress={() => {
-            setFollowsUserLocation(true);
+            if (showsUserLocation) {
+              setFollowsUserLocation(true);
+            }
             onMyLocationButtonPress?.({});
-            setTimeout(() => setFollowsUserLocation(false), FOLLOW_USER_TIMEOUT);
+            if (showsUserLocation) {
+              setTimeout(() => setFollowsUserLocation(false), FOLLOW_USER_TIMEOUT);
+            }
           }}
           style={[
             styles.buttonsContainer,

--- a/src/components/selectors/MultiImageSelector.tsx
+++ b/src/components/selectors/MultiImageSelector.tsx
@@ -62,6 +62,7 @@ export const MultiImageSelector = ({
   field,
   imageId,
   item,
+  onBeforeNativeImagePicker,
   selectorType
 }: {
   authToken: string | null;
@@ -72,6 +73,7 @@ export const MultiImageSelector = ({
   field: any;
   imageId?: number | string;
   item: any;
+  onBeforeNativeImagePicker?: () => Promise<void>;
   selectorType: string;
 }) => {
   const reverseGeocode = useReverseGeocode();
@@ -125,6 +127,8 @@ export const MultiImageSelector = ({
     imageFunction: () => Promise<ImagePickerAsset | undefined>,
     from?: string
   ) => {
+    await onBeforeNativeImagePicker?.();
+
     setLoading(true);
     await onImageSelect({
       configuration,

--- a/src/components/selectors/MultiImageSelector.tsx
+++ b/src/components/selectors/MultiImageSelector.tsx
@@ -127,28 +127,32 @@ export const MultiImageSelector = ({
     imageFunction: () => Promise<ImagePickerAsset | undefined>,
     from?: string
   ) => {
-    await onBeforeNativeImagePicker?.();
+    try {
+      await onBeforeNativeImagePicker?.();
 
-    setLoading(true);
-    await onImageSelect({
-      configuration,
-      coordinateCheck,
-      errorType,
-      from,
-      imageFunction,
-      imagesAttributes,
-      infoAndErrorText,
-      lastKnownPosition,
-      maxFileSize,
-      position,
-      reverseGeocode,
-      selectorType,
-      setImagesAttributes,
-      setInfoAndErrorText
-    });
-
-    setIsModalVisible(false);
-    setLoading(false);
+      setLoading(true);
+      await onImageSelect({
+        configuration,
+        coordinateCheck,
+        errorType,
+        from,
+        imageFunction,
+        imagesAttributes,
+        infoAndErrorText,
+        lastKnownPosition,
+        maxFileSize,
+        position,
+        reverseGeocode,
+        selectorType,
+        setImagesAttributes,
+        setInfoAndErrorText
+      });
+    } catch (error) {
+      Alert.alert(texts.sue.report.alerts.hint, texts.defectReport.alerts.error);
+    } finally {
+      setIsModalVisible(false);
+      setLoading(false);
+    }
   };
 
   const imageDelete = async (index: number) => {

--- a/src/helpers/navigationHelper.ts
+++ b/src/helpers/navigationHelper.ts
@@ -21,7 +21,10 @@ export const navigateToRoute = ({
   targetTabIndex,
   usePush = false
 }: NavigateToRouteOptions) => {
-  if (hasValidTabIndex(targetTabIndex)) {
+  const shouldStayOnCurrentStack =
+    routeName === 'SueList' && params?.query === 'myRequests';
+
+  if (!shouldStayOnCurrentStack && hasValidTabIndex(targetTabIndex)) {
     const parentNavigation = navigation.getParent?.();
 
     if (parentNavigation?.navigate) {

--- a/src/helpers/selectors/imageSelectorsHelper.ts
+++ b/src/helpers/selectors/imageSelectorsHelper.ts
@@ -10,6 +10,109 @@ import { deleteArrayItem } from '../deleteArrayItem';
 
 const { IMAGE_FROM, IMAGE_TYPE_REGEX, URL_REGEX, IMAGE_SELECTOR_TYPES } = consts;
 
+const EXIF_COMPARISON_EPSILON = 0.000001;
+
+const parseExifCoordinatePart = (part: unknown): number | undefined => {
+  if (typeof part === 'number') {
+    return Number.isFinite(part) ? part : undefined;
+  }
+
+  if (typeof part === 'string') {
+    if (part.includes('/')) {
+      const [numeratorRaw, denominatorRaw] = part.split('/');
+      const numerator = Number(numeratorRaw);
+      const denominator = Number(denominatorRaw);
+
+      if (Number.isFinite(numerator) && Number.isFinite(denominator) && denominator !== 0) {
+        return numerator / denominator;
+      }
+
+      return undefined;
+    }
+
+    const parsed = Number(part);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  if (part && typeof part === 'object') {
+    const numerator = Number((part as { numerator?: number }).numerator);
+    const denominator = Number((part as { denominator?: number }).denominator);
+
+    if (Number.isFinite(numerator) && Number.isFinite(denominator) && denominator !== 0) {
+      return numerator / denominator;
+    }
+  }
+
+  return undefined;
+};
+
+export const parseExifCoordinate = (
+  coordinate: unknown,
+  ref?: string
+): number | undefined => {
+  const normalizeWithRef = (value: number) => {
+    if (ref === 'S' || ref === 'W') {
+      return -Math.abs(value);
+    }
+
+    return value;
+  };
+
+  if (typeof coordinate === 'number') {
+    return normalizeWithRef(coordinate);
+  }
+
+  if (typeof coordinate === 'string') {
+    const dmsParts = coordinate
+      .split(',')
+      .map((part) => parseExifCoordinatePart(part.trim()))
+      .filter((part): part is number => part !== undefined);
+
+    if (dmsParts.length === 3) {
+      const decimal = dmsParts[0] + dmsParts[1] / 60 + dmsParts[2] / 3600;
+      return normalizeWithRef(decimal);
+    }
+
+    const parsed = parseExifCoordinatePart(coordinate);
+    return parsed === undefined ? undefined : normalizeWithRef(parsed);
+  }
+
+  if (Array.isArray(coordinate)) {
+    const [degreesRaw, minutesRaw = 0, secondsRaw = 0] = coordinate;
+    const degrees = parseExifCoordinatePart(degreesRaw);
+    const minutes = parseExifCoordinatePart(minutesRaw) || 0;
+    const seconds = parseExifCoordinatePart(secondsRaw) || 0;
+
+    if (degrees === undefined) {
+      return undefined;
+    }
+
+    const decimal = degrees + minutes / 60 + seconds / 3600;
+    return normalizeWithRef(decimal);
+  }
+
+  return undefined;
+};
+
+export const getLocationFromExif = (exif?: {
+  GPSLatitude?: unknown;
+  GPSLatitudeRef?: string;
+  GPSLongitude?: unknown;
+  GPSLongitudeRef?: string;
+}) => {
+  const latitude = parseExifCoordinate(exif?.GPSLatitude, exif?.GPSLatitudeRef);
+  const longitude = parseExifCoordinate(exif?.GPSLongitude, exif?.GPSLongitudeRef);
+
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    return undefined;
+  }
+
+  return {
+    latitude,
+    longitude
+  };
+};
+
 /* eslint-disable complexity */
 export const onImageSelect = async ({
   configuration,
@@ -46,17 +149,18 @@ export const onImageSelect = async ({
 
   if (!uri) return;
 
-  const { GPSLatitude, GPSLongitude } = exif || {};
+  const exifLocation = getLocationFromExif(exif);
   const { size } = (await FileSystem.getInfoAsync(uri)) as { size: number };
 
-  let location = { latitude: undefined, longitude: undefined };
+  let location = {
+    latitude: exifLocation?.latitude,
+    longitude: exifLocation?.longitude
+  };
 
-  if (from === IMAGE_FROM.GALLERY) {
-    location = {
-      latitude: GPSLatitude,
-      longitude: GPSLongitude
-    };
-  } else if (from === IMAGE_FROM.CAMERA) {
+  if (
+    from === IMAGE_FROM.CAMERA &&
+    (!Number.isFinite(location.latitude) || !Number.isFinite(location.longitude))
+  ) {
     location = {
       latitude: position?.coords?.latitude || lastKnownPosition?.coords?.latitude,
       longitude: position?.coords?.longitude || lastKnownPosition?.coords?.longitude
@@ -141,12 +245,14 @@ export const onDeleteImage = async ({
   }
 
   if (selectorType === IMAGE_SELECTOR_TYPES.SUE) {
-    const { GPSLatitude, GPSLongitude } = imagesAttributes?.[index]?.exif || {};
+    const exifLocation = getLocationFromExif(imagesAttributes?.[index]?.exif);
     const { selectedPosition, setValue = () => {} } = coordinateCheck || {};
 
     if (
-      selectedPosition?.latitude === GPSLatitude &&
-      selectedPosition?.longitude === GPSLongitude
+      Math.abs((selectedPosition?.latitude || 0) - (exifLocation?.latitude || 0)) <
+        EXIF_COMPARISON_EPSILON &&
+      Math.abs((selectedPosition?.longitude || 0) - (exifLocation?.longitude || 0)) <
+        EXIF_COMPARISON_EPSILON
     ) {
       coordinateCheck.setSelectedPosition(undefined);
       coordinateCheck.setUpdateRegionFromImage(false);

--- a/src/helpers/selectors/imageSelectorsHelper.ts
+++ b/src/helpers/selectors/imageSelectorsHelper.ts
@@ -177,12 +177,13 @@ export const onImageSelect = async ({
 
   if (selectorType === IMAGE_SELECTOR_TYPES.SUE) {
     const extension = mimeType.split('/')[1];
+    const allowedAttachmentTypes = configuration?.limitation?.allowedAttachmentTypes?.value || '';
 
-    if (!configuration.limitation.allowedAttachmentTypes.value.includes(extension)) {
+    if (!allowedAttachmentTypes.includes(extension)) {
       return Alert.alert(texts.sue.report.alerts.hint, texts.sue.report.alerts.imageType);
     }
 
-    if (!!location.latitude && !!location.longitude) {
+    if (Number.isFinite(location.latitude) && Number.isFinite(location.longitude)) {
       try {
         await reverseGeocode({
           areaServiceData,
@@ -195,6 +196,12 @@ export const onImageSelect = async ({
         coordinateCheck.setUpdateRegionFromImage(true);
         coordinateCheck.setShowCoordinatesFromImageAlert(false);
       } catch (error) {
+        coordinateCheck.setSelectedPosition(undefined);
+        coordinateCheck.setUpdateRegionFromImage(false);
+        setValue('city', '');
+        setValue('houseNumber', '');
+        setValue('street', '');
+        setValue('postalCode', '');
         console.error(error);
       }
     }

--- a/src/hooks/imagePicker.ts
+++ b/src/hooks/imagePicker.ts
@@ -170,16 +170,23 @@ export const useCaptureImage = ({
       // Run gallery save flow without blocking the image selection result.
       if (saveImage) {
         void (async () => {
-          const { status: mediaStatus } = await getPermissionsAsync();
+          try {
+            const { status: mediaStatus } = await getPermissionsAsync();
 
-          if (mediaStatus !== PermissionStatus.GRANTED) {
-            // Ask user before requesting gallery save permission.
-            Alert.alert(texts.errors.image.title, texts.errors.image.saveConfirmBody, [
-              { text: texts.errors.image.cancel, style: 'cancel' },
-              { text: texts.errors.image.save, onPress: async () => await saveImageToGallery(uri) }
-            ]);
-          } else {
-            await saveImageToGallery(uri);
+            if (mediaStatus !== PermissionStatus.GRANTED) {
+              // Ask user before requesting gallery save permission.
+              Alert.alert(texts.errors.image.title, texts.errors.image.saveConfirmBody, [
+                { text: texts.errors.image.cancel, style: 'cancel' },
+                {
+                  text: texts.errors.image.save,
+                  onPress: async () => await saveImageToGallery(uri)
+                }
+              ]);
+            } else {
+              await saveImageToGallery(uri);
+            }
+          } catch (error) {
+            console.error('Non-blocking gallery save flow failed', error);
           }
         })();
       }

--- a/src/hooks/imagePicker.ts
+++ b/src/hooks/imagePicker.ts
@@ -167,7 +167,9 @@ export const useCaptureImage = ({
       const uri = result.assets[0].uri;
       onChange ? onChange(setImageUri)(uri) : setImageUri(uri);
 
-      if (saveImage) {
+      // Android camera flow should not block SUE image selection with an extra
+      // gallery-permission prompt after taking a photo.
+      if (saveImage && device.platform !== 'android') {
         const { status: mediaStatus } = await getPermissionsAsync();
 
         if (mediaStatus !== PermissionStatus.GRANTED) {

--- a/src/hooks/imagePicker.ts
+++ b/src/hooks/imagePicker.ts
@@ -167,20 +167,21 @@ export const useCaptureImage = ({
       const uri = result.assets[0].uri;
       onChange ? onChange(setImageUri)(uri) : setImageUri(uri);
 
-      // Android camera flow should not block SUE image selection with an extra
-      // gallery-permission prompt after taking a photo.
-      if (saveImage && device.platform !== 'android') {
-        const { status: mediaStatus } = await getPermissionsAsync();
+      // Run gallery save flow without blocking the image selection result.
+      if (saveImage) {
+        void (async () => {
+          const { status: mediaStatus } = await getPermissionsAsync();
 
-        if (mediaStatus !== PermissionStatus.GRANTED) {
-          // Ask user before requesting gallery save permission
-          Alert.alert(texts.errors.image.title, texts.errors.image.saveConfirmBody, [
-            { text: texts.errors.image.cancel, style: 'cancel' },
-            { text: texts.errors.image.save, onPress: async () => await saveImageToGallery(uri) }
-          ]);
-        } else {
-          await saveImageToGallery(uri);
-        }
+          if (mediaStatus !== PermissionStatus.GRANTED) {
+            // Ask user before requesting gallery save permission.
+            Alert.alert(texts.errors.image.title, texts.errors.image.saveConfirmBody, [
+              { text: texts.errors.image.cancel, style: 'cancel' },
+              { text: texts.errors.image.save, onPress: async () => await saveImageToGallery(uri) }
+            ]);
+          } else {
+            await saveImageToGallery(uri);
+          }
+        })();
       }
 
       return result.assets[0];

--- a/src/hooks/reverseGeocode.ts
+++ b/src/hooks/reverseGeocode.ts
@@ -14,6 +14,9 @@ const CITY_FALLBACK_KEYS = [
   'county'
 ] as const;
 
+const normalizePostalCode = (postalCode?: string) =>
+  (postalCode || '').replace(/\s+/g, '').trim();
+
 export const useReverseGeocode = () => {
   return useCallback(
     async ({
@@ -58,7 +61,12 @@ export const useReverseGeocode = () => {
         const houseNumber = response?.address?.house_number || '';
         const street = response?.address?.road || '';
         const postalCode = response?.address?.postcode || '';
-        const isWithinArea = !!areaServiceData?.postalCodes?.includes(postalCode);
+        const normalizedPostalCode = normalizePostalCode(postalCode);
+        const isWithinArea =
+          !!normalizedPostalCode &&
+          !!areaServiceData?.postalCodes?.some(
+            (value) => normalizePostalCode(value) === normalizedPostalCode
+          );
 
         if (!shouldApplyResult()) {
           return staleResult;

--- a/src/screens/SUE/SueDetailScreen.tsx
+++ b/src/screens/SUE/SueDetailScreen.tsx
@@ -21,7 +21,6 @@ import {
   SafeAreaViewFlex,
   SueCategory,
   SueDatetime,
-  SueImageFallback,
   SueStatus,
   SueStatuses,
   Wrapper,
@@ -129,7 +128,6 @@ export const SueDetailScreen = ({ navigation, route }: StackScreenProps<any>) =>
       >
         <View style={[isFullscreenMap && styles.wrapperHidden]}>
           <ImageSection mediaContents={mediaContents} />
-          {!mediaContents?.length && <SueImageFallback style={styles.sueImageContainer} />}
 
           {!!serviceName && !!requestedDatetime && (
             <SueCategory serviceName={serviceName} requestedDatetime={requestedDatetime} />
@@ -308,9 +306,6 @@ const styles = StyleSheet.create({
   },
   map: {
     height: normalize(300),
-    width: '100%'
-  },
-  sueImageContainer: {
     width: '100%'
   },
   wrapperHidden: {

--- a/src/screens/SUE/SueListScreen.tsx
+++ b/src/screens/SUE/SueListScreen.tsx
@@ -90,9 +90,6 @@ export const SueListScreen = ({ navigation, route }: Props) => {
     start_date: INITIAL_START_DATE
   };
   const [queryVariables, setQueryVariables] = useState(initialQueryVariables);
-  const [dataCountQueryVariables, setDataCountQueryVariables] = useState({
-    start_date: INITIAL_START_DATE
-  });
   const [refreshing, setRefreshing] = useState(false);
   const [isOpening, setIsOpening] = useState(true);
   const [viewType, setViewType] = useState(route.params?.viewType || SueViewType.List);
@@ -134,10 +131,30 @@ export const SueListScreen = ({ navigation, route }: Props) => {
   );
 
   const { data: dataCount } = useQuery(
-    [QUERY_TYPES.SUE.LOCATION, { dataCountQueryVariables }],
-    () => getQuery(QUERY_TYPES.SUE.LOCATION)(dataCountQueryVariables),
+    [QUERY_TYPES.SUE.REQUESTS, 'count', queryVariablesWithoutSearch],
+    async () => {
+      let offset = 0;
+      let totalCount = 0;
+      let hasMorePages = true;
+
+      while (hasMorePages) {
+        const page = await getQuery(QUERY_TYPES.SUE.REQUESTS)({
+          ...queryVariablesWithoutSearch,
+          limit,
+          offset,
+          sort_attribute: queryVariablesWithoutSearch.sortBy || SORT_BY.REQUESTED_DATE_TIME
+        });
+
+        const pageLength = Array.isArray(page) ? page.length : 0;
+        totalCount += pageLength;
+        hasMorePages = pageLength === limit;
+        offset += limit;
+      }
+
+      return totalCount;
+    },
     {
-      enabled: query !== QUERY_TYPES.SUE.MY_REQUESTS
+      enabled: query === QUERY_TYPES.SUE.REQUESTS && !searchTerm
     }
   );
 
@@ -159,12 +176,6 @@ export const SueListScreen = ({ navigation, route }: Props) => {
       setIsOpening(false);
     }, 50);
   }, []);
-
-  useEffect(() => {
-    const { limit, offset, search, ...rest } = queryVariables;
-
-    setDataCountQueryVariables(rest);
-  }, [queryVariables]);
 
   // When a search term is active, automatically load all remaining pages so that
   // client-side filtering covers the full data set, not just the already-loaded pages.
@@ -206,8 +217,8 @@ export const SueListScreen = ({ navigation, route }: Props) => {
   const displayCount = useMemo(() => {
     return searchTerm || query === QUERY_TYPES.SUE.MY_REQUESTS
       ? listItems.length
-      : dataCount?.length;
-  }, [searchTerm, query, listItems.length, dataCount?.length]);
+      : dataCount;
+  }, [searchTerm, query, listItems.length, dataCount]);
 
   const refresh = async () => {
     setRefreshing(true);

--- a/src/screens/SUE/SueListScreen.tsx
+++ b/src/screens/SUE/SueListScreen.tsx
@@ -90,6 +90,9 @@ export const SueListScreen = ({ navigation, route }: Props) => {
     start_date: INITIAL_START_DATE
   };
   const [queryVariables, setQueryVariables] = useState(initialQueryVariables);
+  const [dataCountQueryVariables, setDataCountQueryVariables] = useState({
+    start_date: INITIAL_START_DATE
+  });
   const [refreshing, setRefreshing] = useState(false);
   const [isOpening, setIsOpening] = useState(true);
   const [viewType, setViewType] = useState(route.params?.viewType || SueViewType.List);
@@ -131,30 +134,10 @@ export const SueListScreen = ({ navigation, route }: Props) => {
   );
 
   const { data: dataCount } = useQuery(
-    [QUERY_TYPES.SUE.REQUESTS, 'count', queryVariablesWithoutSearch],
-    async () => {
-      let offset = 0;
-      let totalCount = 0;
-      let hasMorePages = true;
-
-      while (hasMorePages) {
-        const page = await getQuery(QUERY_TYPES.SUE.REQUESTS)({
-          ...queryVariablesWithoutSearch,
-          limit,
-          offset,
-          sort_attribute: queryVariablesWithoutSearch.sortBy || SORT_BY.REQUESTED_DATE_TIME
-        });
-
-        const pageLength = Array.isArray(page) ? page.length : 0;
-        totalCount += pageLength;
-        hasMorePages = pageLength === limit;
-        offset += limit;
-      }
-
-      return totalCount;
-    },
+    [QUERY_TYPES.SUE.LOCATION, { dataCountQueryVariables }],
+    () => getQuery(QUERY_TYPES.SUE.LOCATION)(dataCountQueryVariables),
     {
-      enabled: query === QUERY_TYPES.SUE.REQUESTS && !searchTerm
+      enabled: query !== QUERY_TYPES.SUE.MY_REQUESTS
     }
   );
 
@@ -176,6 +159,12 @@ export const SueListScreen = ({ navigation, route }: Props) => {
       setIsOpening(false);
     }, 50);
   }, []);
+
+  useEffect(() => {
+    const { limit, offset, search, ...rest } = queryVariables;
+
+    setDataCountQueryVariables(rest);
+  }, [queryVariables]);
 
   // When a search term is active, automatically load all remaining pages so that
   // client-side filtering covers the full data set, not just the already-loaded pages.
@@ -217,8 +206,8 @@ export const SueListScreen = ({ navigation, route }: Props) => {
   const displayCount = useMemo(() => {
     return searchTerm || query === QUERY_TYPES.SUE.MY_REQUESTS
       ? listItems.length
-      : dataCount;
-  }, [searchTerm, query, listItems.length, dataCount]);
+      : dataCount?.length;
+  }, [searchTerm, query, listItems.length, dataCount?.length]);
 
   const refresh = async () => {
     setRefreshing(true);

--- a/src/screens/SUE/SueMapScreen.tsx
+++ b/src/screens/SUE/SueMapScreen.tsx
@@ -249,8 +249,11 @@ const styles = StyleSheet.create({
     width: normalize(120)
   },
   imagePlaceholder: {
+    backgroundColor: colors.placeholder,
+    borderBottomLeftRadius: normalize(8),
+    borderTopLeftRadius: normalize(8),
     height: normalize(120),
-    width: normalize(30)
+    width: normalize(120)
   },
   imageContainer: {
     alignSelf: 'flex-start',

--- a/src/screens/SUE/SueMapScreen.tsx
+++ b/src/screens/SUE/SueMapScreen.tsx
@@ -91,6 +91,7 @@ export const SueMapScreen = ({ navigation, route, viewType, setViewType }: Props
   const { position: lastKnownPosition } = useLastKnownPosition(
     systemPermission?.status !== Location.PermissionStatus.GRANTED
   );
+  const currentPosition = position || lastKnownPosition;
 
   const queryVariables = route.params?.queryVariables ?? {
     start_date: '1900-01-01T00:00:00+01:00'
@@ -149,16 +150,15 @@ export const SueMapScreen = ({ navigation, route, viewType, setViewType }: Props
       <MapLibre
         clusterDistance={geoMap?.clusterDistance}
         clusterThreshold={geoMap?.clusterThreshold}
+        currentPosition={currentPosition}
         isMultipleMarkersMap
         isMyLocationButtonVisible={isMyLocationButtonVisible}
         locations={mapMarkers}
         mapStyle={styles.map}
         onMarkerPress={setSelectedRequestId}
         onMyLocationButtonPress={() => {
-          const location = position || lastKnownPosition;
-
           locationServiceEnabledAlert({
-            currentPosition: location,
+            currentPosition: currentPosition,
             locationServiceEnabled,
             navigation
           });

--- a/src/screens/SUE/SueMapScreen.tsx
+++ b/src/screens/SUE/SueMapScreen.tsx
@@ -81,6 +81,7 @@ export const SueMapScreen = ({ navigation, route, viewType, setViewType }: Props
   const { globalSettings } = useContext(SettingsContext);
   const { navigation: navigationType, settings = {} } = globalSettings;
   const { locationService } = settings;
+  const isMyLocationButtonVisible = locationService !== false;
   const { sueListItem = {} } = appDesignSystem;
   const { showViewSwitcherButton = false } = sueListItem;
   const { geoMap = {} } = sueConfig;
@@ -148,7 +149,7 @@ export const SueMapScreen = ({ navigation, route, viewType, setViewType }: Props
         clusterDistance={geoMap?.clusterDistance}
         clusterThreshold={geoMap?.clusterThreshold}
         isMultipleMarkersMap
-        isMyLocationButtonVisible={!!locationService}
+        isMyLocationButtonVisible={isMyLocationButtonVisible}
         locations={mapMarkers}
         mapStyle={styles.map}
         onMarkerPress={setSelectedRequestId}

--- a/src/screens/SUE/SueMapScreen.tsx
+++ b/src/screens/SUE/SueMapScreen.tsx
@@ -17,6 +17,7 @@ import {
   MapLibre,
   RegularText,
   SafeAreaViewFlex,
+  SueImageFallback,
   SueStatus,
   Touchable,
   Wrapper,
@@ -184,7 +185,7 @@ export const SueMapScreen = ({ navigation, route, viewType, setViewType }: Props
               </>
             ) : (
               <>
-                <View style={styles.imagePlaceholder} />
+                <SueImageFallback style={styles.mapPreviewFallback} />
                 <CloseButton onPress={() => setSelectedRequestId(undefined)} />
               </>
             )}
@@ -249,8 +250,7 @@ const styles = StyleSheet.create({
     height: normalize(120),
     width: normalize(120)
   },
-  imagePlaceholder: {
-    backgroundColor: colors.placeholder,
+  mapPreviewFallback: {
     borderBottomLeftRadius: normalize(8),
     borderTopLeftRadius: normalize(8),
     height: normalize(120),

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -503,7 +503,7 @@ export const SueReportScreen = ({
     }
   };
 
-  const readReportValuesFromStore = async () => {
+  async function readReportValuesFromStore() {
     const savedValues = (await readFromStore(SUE_REPORT_VALUES)) as TStoredValues | undefined;
 
     if (savedValues) {
@@ -519,7 +519,7 @@ export const SueReportScreen = ({
     }
 
     setIsLoadingStoredData(false);
-  };
+  }
 
   const resetStoredValues = useCallback(async () => {
     setIsLoadingStoredData(true);

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -478,9 +478,9 @@ export const SueReportScreen = ({
     [requiredFields, geoMap, sueProgress]
   );
 
-  const storeReportValues = useCallback(async () => {
+  const storeReportValues = useCallback(async (progress = currentProgress) => {
     await addToStore(SUE_REPORT_VALUES, {
-      currentProgress,
+      currentProgress: progress,
       selectedPosition,
       service,
       ...getValues()
@@ -561,12 +561,13 @@ export const SueReportScreen = ({
       return Alert.alert(texts.sue.report.alerts.hint, alertTextGeneratorForMissingData());
     }
 
-    await storeReportValues();
+    const nextProgress = Math.min(currentProgress + 1, sueProgressWithConfig.length - 1);
+    await storeReportValues(nextProgress);
 
     if (currentProgress < sueProgressWithConfig.length - 1) {
-      setCurrentProgress(currentProgress + 1);
+      setCurrentProgress(nextProgress);
       scrollViewRef?.current?.scrollTo({
-        x: device.width * (currentProgress + 1),
+        x: device.width * nextProgress,
         y: 0,
         animated: true
       });
@@ -581,14 +582,16 @@ export const SueReportScreen = ({
   const handlePrevPage = useCallback(() => {
     Keyboard.dismiss();
     if (currentProgress > 0) {
-      setCurrentProgress(currentProgress - 1);
+      const prevProgress = currentProgress - 1;
+      void storeReportValues(prevProgress);
+      setCurrentProgress(prevProgress);
       scrollViewRef?.current?.scrollTo({
-        x: device.width * (currentProgress - 1),
+        x: device.width * prevProgress,
         y: 0,
         animated: true
       });
     }
-  }, [currentProgress]);
+  }, [currentProgress, storeReportValues]);
 
   // Ensure map fullscreen mode is exited when navigating between steps
   useEffect(() => {

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -89,6 +89,17 @@ const sueProgressWithRequiredInputs = (
   });
 };
 
+const clampProgress = (progress: unknown, maxProgress: number) => {
+  const numericProgress = typeof progress === 'number' ? progress : Number(progress);
+  const normalizedProgress = Number.isFinite(numericProgress) ? Math.trunc(numericProgress) : 0;
+
+  if (maxProgress < 0) {
+    return 0;
+  }
+
+  return Math.min(Math.max(normalizedProgress, 0), maxProgress);
+};
+
 export type TValues = {
   city: string;
   description: string;
@@ -478,14 +489,17 @@ export const SueReportScreen = ({
     [requiredFields, geoMap, sueProgress]
   );
 
-  const storeReportValues = useCallback(async (progress = currentProgress) => {
-    await addToStore(SUE_REPORT_VALUES, {
-      currentProgress: progress,
-      selectedPosition,
-      service,
-      ...getValues()
-    });
-  }, [currentProgress, selectedPosition, service, getValues]);
+  const storeReportValues = useCallback(
+    async (progress = currentProgress) => {
+      await addToStore(SUE_REPORT_VALUES, {
+        currentProgress: progress,
+        selectedPosition,
+        service,
+        ...getValues()
+      });
+    },
+    [currentProgress, selectedPosition, service, getValues]
+  );
 
   const storeMyReportsValues = async (newReport: any) => {
     try {
@@ -507,10 +521,14 @@ export const SueReportScreen = ({
     const savedValues = (await readFromStore(SUE_REPORT_VALUES)) as TStoredValues | undefined;
 
     if (savedValues) {
+      const restoredProgress = clampProgress(
+        savedValues.currentProgress,
+        sueProgressWithConfig.length - 1
+      );
       setStoredValues(savedValues);
       setService(savedValues.service);
       setSelectedPosition(savedValues.selectedPosition);
-      setCurrentProgress(savedValues.currentProgress || 0);
+      setCurrentProgress(restoredProgress);
       Object.entries(savedValues).forEach(([key, value]) => {
         if (key !== 'currentProgress' && key !== 'service' && key !== 'selectedPosition') {
           setValue(key as keyof TValues, value);

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -135,6 +135,7 @@ type TContent = {
   requiredInputs: keyof TValues[];
   selectedPosition?: Location.LocationObjectCoords;
   service?: TService;
+  storeReportValues: () => Promise<void>;
   setIsFullscreenMap: (value: boolean) => void;
   setSelectedPosition: (position?: Location.LocationObjectCoords) => void;
   setService: any;
@@ -156,6 +157,7 @@ const Content = ({
   requiredInputs,
   selectedPosition,
   service,
+  storeReportValues,
   setIsFullscreenMap,
   setSelectedPosition,
   setService,
@@ -174,6 +176,7 @@ const Content = ({
           errorMessage={errorMessage}
           requiredInputs={requiredInputs}
           selectedPosition={selectedPosition}
+          storeReportValues={storeReportValues}
           setSelectedPosition={setSelectedPosition}
           setShowCoordinatesFromImageAlert={setShowCoordinatesFromImageAlert}
           setUpdateRegionFromImage={setUpdateRegionFromImage}
@@ -227,6 +230,12 @@ type TReports = {
   street: string;
   termsOfService: string;
   title: string;
+};
+
+type TStoredValues = Partial<TReports> & {
+  currentProgress?: number;
+  selectedPosition?: Location.LocationObjectCoords;
+  service?: TService;
 };
 
 type TProgress = {
@@ -286,7 +295,7 @@ export const SueReportScreen = ({
   const [isLoadingStoredData, setIsLoadingStoredData] = useState<boolean>(true);
   const [selectedPosition, setSelectedPosition] = useState<Location.LocationObjectCoords>();
   const [isDone, setIsDone] = useState(false);
-  const [storedValues, setStoredValues] = useState<TReports>();
+  const [storedValues, setStoredValues] = useState<TStoredValues>();
   const [updateRegionFromImage, setUpdateRegionFromImage] = useState(false);
   const [contentHeights, setContentHeights] = useState([]);
   const [isFullscreenMap, setIsFullscreenMap] = useState(false);
@@ -302,6 +311,7 @@ export const SueReportScreen = ({
 
   const scrollViewRef = useRef(null);
   const scrollViewContentRef = useRef([]);
+  const hasAppliedInitialProgressRef = useRef(false);
 
   const keyboardHeight = useKeyboardHeight();
 
@@ -470,11 +480,12 @@ export const SueReportScreen = ({
 
   const storeReportValues = useCallback(async () => {
     await addToStore(SUE_REPORT_VALUES, {
+      currentProgress,
       selectedPosition,
       service,
       ...getValues()
     });
-  }, [selectedPosition, service, getValues]);
+  }, [currentProgress, selectedPosition, service, getValues]);
 
   const storeMyReportsValues = async (newReport: any) => {
     try {
@@ -493,15 +504,16 @@ export const SueReportScreen = ({
   };
 
   const readReportValuesFromStore = async () => {
-    const storedValues = await readFromStore(SUE_REPORT_VALUES);
+    const savedValues = (await readFromStore(SUE_REPORT_VALUES)) as TStoredValues | undefined;
 
-    if (storedValues) {
-      setStoredValues(storedValues);
-      setService(storedValues.service);
-      setSelectedPosition(storedValues.selectedPosition);
-      Object.entries(storedValues).forEach(([key, value]) => {
-        if (key !== 'service' && key !== 'selectedPosition') {
-          setValue(key, value);
+    if (savedValues) {
+      setStoredValues(savedValues);
+      setService(savedValues.service);
+      setSelectedPosition(savedValues.selectedPosition);
+      setCurrentProgress(savedValues.currentProgress || 0);
+      Object.entries(savedValues).forEach(([key, value]) => {
+        if (key !== 'currentProgress' && key !== 'service' && key !== 'selectedPosition') {
+          setValue(key as keyof TValues, value);
         }
       });
     }
@@ -522,8 +534,25 @@ export const SueReportScreen = ({
       animated: true
     });
     setCurrentProgress(0);
+    hasAppliedInitialProgressRef.current = false;
     setIsLoadingStoredData(false);
   }, [reset]);
+
+  useEffect(() => {
+    if (isLoadingStoredData || hasAppliedInitialProgressRef.current) {
+      return;
+    }
+
+    if (currentProgress > 0) {
+      scrollViewRef?.current?.scrollTo({
+        x: device.width * currentProgress,
+        y: 0,
+        animated: false
+      });
+    }
+
+    hasAppliedInitialProgressRef.current = true;
+  }, [isLoadingStoredData, currentProgress]);
 
   const handleNextPage = useCallback(async () => {
     Keyboard.dismiss();
@@ -758,6 +787,7 @@ export const SueReportScreen = ({
                   requiredInputs={item.requiredInputs}
                   selectedPosition={selectedPosition}
                   service={service}
+                  storeReportValues={storeReportValues}
                   setIsFullscreenMap={setIsFullscreenMap}
                   setSelectedPosition={setSelectedPosition}
                   setService={setService}


### PR DESCRIPTION
This PR includes bug fixes for Android and iOS identified in the latest version. The bug fixes are as follows.

1. ‘My Reports’ navigation / no way back
- ‘My Reports’ now remains in the current stack, so that the back button/navigation no longer gets stuck.

2. Message creation jumps back to step 1 after Live Photo (data loss)
- Before opening the camera/gallery, the draft including `currentProgress` is saved and then correctly restored (including a fix for the previous one-step lag).

3. Address by location (Android) black/grey freeze when selecting “Current location”
- Permission/My Location flow has been hardened; user tracking is now only activated if a valid position is available.

4. iPhone: My Location icon missing when location services are disabled
- The My Location icon remains visible (unless disabled globally) and can still trigger the permission/settings flow.

5. Image determines location / incorrect or unstable address retrieval
- EXIF coordinates are parsed more robustly (including various EXIF formats), reverse geocoding behaviour has been stabilised, and in the case of invalid or out-of-bound results, the pin/address fields are reset cleanly rather than leaving incorrect data.

6. Placeholder image missing from map
- The placeholder is now visible again in the map preview; at the same time, the fallback logic for list/detail views has been separated accordingly.

7. Filter/result count does not match the backend
- The number of results is now calculated from the same paginated `REQUESTS` source using the same active filters/sort orders; this should ensure that status/category counts are consistent with the backend.

8. Android camera/gallery save flow stability
- The gallery save flow after taking a photo is retained, but no longer blocks the SUE image selection flow.

SUE-13