### PR TITLE
feat(bus): add paginated service search and resilient service resolution

### DIFF
--- a/__tests__/helpers/busDetailHelper.test.js
+++ b/__tests__/helpers/busDetailHelper.test.js
@@ -1,0 +1,180 @@
+import {
+  getBusTopActions,
+  getBusVisibleTextBlocks,
+  splitBusTextBlocks
+} from '../../src/helpers/busDetailHelper';
+
+const KURZTEXT_BLOCK = {
+  type: { name: 'Kurztext' },
+  text: 'Kurzbeschreibung'
+};
+
+const VOLLTEXT_BLOCK = {
+  type: { name: 'Volltext' },
+  text: 'Ausfuehrliche Beschreibung'
+};
+
+const FORMULARE_BLOCK = {
+  type: { name: 'Formulare' },
+  text: 'Formulare im Akkordeon'
+};
+
+const TEASER_BLOCK = {
+  type: { name: 'Teaser' },
+  text: 'wird nicht angezeigt'
+};
+
+const HIDDEN_METADATA_BLOCKS = [
+  {
+    type: { name: 'Typisierung' },
+    text: 'interne Metadaten'
+  },
+  {
+    type: { name: 'Status Katalogeintrag' },
+    text: 'interner Status'
+  },
+  {
+    type: { name: 'Status Bibliothekseintrag' },
+    text: 'interner Bibliotheksstatus'
+  }
+];
+
+describe('busDetailHelper', () => {
+  it('places online services before forms in the top action area', () => {
+    const service = {
+      onlineServices: [
+        {
+          links: [{ url: 'https://example.org/online-1' }],
+          name: 'Online-Antrag'
+        },
+        {
+          links: [{ url: 'https://example.org/online-2' }],
+          name: 'Status prüfen'
+        }
+      ],
+      organisationalUnits: [
+        {
+          forms: [
+            {
+              links: [{ url: 'https://example.org/form-1' }],
+              name: 'PDF Formular'
+            }
+          ]
+        }
+      ]
+    };
+
+    expect(getBusTopActions(service)).toEqual([
+      {
+        kind: 'onlineService',
+        links: [{ url: 'https://example.org/online-1' }],
+        name: 'Online-Antrag'
+      },
+      {
+        kind: 'onlineService',
+        links: [{ url: 'https://example.org/online-2' }],
+        name: 'Status prüfen'
+      },
+      {
+        kind: 'form',
+        links: [{ url: 'https://example.org/form-1' }],
+        name: 'PDF Formular'
+      }
+    ]);
+  });
+
+  it('keeps form actions even when a form has no explicit name', () => {
+    const service = {
+      organisationalUnits: [
+        {
+          forms: [
+            {
+              links: [{ name: 'PDF herunterladen', url: 'https://example.org/form-1' }]
+            }
+          ]
+        }
+      ]
+    };
+
+    expect(getBusTopActions(service)).toEqual([
+      {
+        kind: 'form',
+        links: [{ name: 'PDF herunterladen', url: 'https://example.org/form-1' }],
+        name: undefined
+      }
+    ]);
+  });
+
+  it('maps only supported communication types for top actions', () => {
+    const service = {
+      onlineServices: [
+        {
+          communications: [
+            { type: { key: 'WWW' }, value: 'https://example.org/service' },
+            { type: { key: 'EMAIL' }, value: 'service@example.org' },
+            { type: { key: 'TELEFON' }, value: '+49 30 123456' },
+            { type: { key: 'FAX' }, value: '+49 30 999999' }
+          ],
+          name: 'Digital beantragen'
+        }
+      ]
+    };
+
+    expect(getBusTopActions(service)).toEqual([
+      {
+        kind: 'onlineService',
+        links: [
+          { url: 'https://example.org/service' },
+          { url: 'mailto:service@example.org' },
+          { url: 'tel:+49 30 123456' }
+        ],
+        name: 'Digital beantragen'
+      }
+    ]);
+  });
+
+  it('keeps the Formulare text block visible in the accordion', () => {
+    const textBlocks = [KURZTEXT_BLOCK, FORMULARE_BLOCK, TEASER_BLOCK];
+
+    expect(getBusVisibleTextBlocks({ textBlocks })).toEqual([
+      KURZTEXT_BLOCK,
+      FORMULARE_BLOCK
+    ]);
+  });
+
+  it('keeps legacy hidden BUS metadata blocks hidden after unwrapping nested text blocks', () => {
+    const textBlocks = [
+      {
+        type: { name: 'Weiterführende Informationen' },
+        textBlock: {
+          type: { name: 'Volltext' },
+          text: 'Ausfuehrliche Beschreibung'
+        }
+      },
+      KURZTEXT_BLOCK,
+      ...HIDDEN_METADATA_BLOCKS
+    ];
+
+    expect(getBusVisibleTextBlocks({ textBlocks })).toEqual([KURZTEXT_BLOCK, VOLLTEXT_BLOCK]);
+  });
+
+  it('keeps text blocks without a type name visible unless they are explicitly hidden', () => {
+    const textBlockWithoutTypeName = {
+      text: 'Freitext ohne Typ'
+    };
+
+    expect(getBusVisibleTextBlocks({ textBlocks: [KURZTEXT_BLOCK, textBlockWithoutTypeName] })).toEqual([
+      KURZTEXT_BLOCK,
+      textBlockWithoutTypeName
+    ]);
+  });
+
+  it('keeps Kurztext and Volltext as the first two accordion blocks', () => {
+    const textBlocks = [KURZTEXT_BLOCK, VOLLTEXT_BLOCK, FORMULARE_BLOCK];
+
+    expect(splitBusTextBlocks({ textBlocks })).toEqual({
+      firstTextBlocks: [KURZTEXT_BLOCK, VOLLTEXT_BLOCK],
+      sortedTextBlocks: [FORMULARE_BLOCK]
+    });
+  });
+});

--- a/__tests__/hooks/bus.test.ts
+++ b/__tests__/hooks/bus.test.ts
@@ -4,14 +4,18 @@ jest.mock('react', () => ({
 }));
 
 jest.mock('react-query', () => ({
+  useInfiniteQuery: jest.fn(),
   useQuery: jest.fn()
 }));
 
 jest.mock('../../src/queries/bus', () => ({
+  DEFAULT_LIST_LIMIT: 500,
   findBusCategoryChildren: jest.fn(),
   findBusCategoryRoot: jest.fn(),
+  findPublicServicesPage: jest.fn(),
   findPublicServices: jest.fn(),
-  getPublicService: jest.fn()
+  getPublicService: jest.fn(),
+  searchPoliticalAreas: jest.fn()
 }));
 
 jest.mock('../../src/SettingsProvider', () => ({
@@ -23,22 +27,33 @@ jest.mock('../../src/hooks/staticContent', () => ({
 }));
 
 import * as React from 'react';
-import { useQuery } from 'react-query';
+import { useInfiniteQuery, useQuery } from 'react-query';
 import TestRenderer, { act } from 'react-test-renderer';
 
 import {
   DEFAULT_BUS_LIFE_SITUATIONS_ROOT_SEARCH_WORD,
   getBusLifeSituationsRootSearchWord,
   getBusQueryConfigKey,
+  useBusAreas,
   useBusCategoryChildren,
-  useBusLifeSituationsRoot
+  useBusLifeSituationsRoot,
+  useBusServiceSearch,
+  useBusServices
 } from '../../src/hooks/bus';
-import { findBusCategoryChildren, findBusCategoryRoot } from '../../src/queries/bus';
+import {
+  findBusCategoryChildren,
+  findBusCategoryRoot,
+  findPublicServicesPage,
+  searchPoliticalAreas
+} from '../../src/queries/bus';
 
 const mockedUseContext = jest.mocked(React.useContext);
+const mockedUseInfiniteQuery = jest.mocked(useInfiniteQuery);
 const mockedUseQuery = jest.mocked(useQuery);
 const mockedFindBusCategoryChildren = jest.mocked(findBusCategoryChildren);
 const mockedFindBusCategoryRoot = jest.mocked(findBusCategoryRoot);
+const mockedFindPublicServicesPage = jest.mocked(findPublicServicesPage);
+const mockedSearchPoliticalAreas = jest.mocked(searchPoliticalAreas);
 const defaultBusSettings = {
   uri: 'https://one.example'
 };
@@ -62,7 +77,20 @@ const createUseQueryResult = () =>
     isFetching: false,
     isLoading: false,
     refetch: jest.fn()
-  }) as never;
+  } as never);
+
+const createUseInfiniteQueryResult = (pages: unknown[] = []) =>
+  ({
+    data: { pages },
+    error: null,
+    fetchNextPage: jest.fn(),
+    hasNextPage: false,
+    isError: false,
+    isFetching: false,
+    isFetchingNextPage: false,
+    isLoading: false,
+    refetch: jest.fn()
+  } as never);
 
 const mockEnabledUseQuery = () => {
   mockedUseQuery.mockImplementation((_, queryFn, options) => {
@@ -76,6 +104,18 @@ const mockEnabledUseQuery = () => {
 
 const mockIdleUseQuery = () => {
   mockedUseQuery.mockReturnValue(createUseQueryResult());
+};
+
+const mockEnabledUseInfiniteQuery = () => {
+  mockedUseInfiniteQuery.mockImplementation((_, queryFn) => {
+    queryFn({ pageParam: 0 });
+
+    return createUseInfiniteQueryResult();
+  });
+};
+
+const mockIdleUseInfiniteQuery = (pages: unknown[] = []) => {
+  mockedUseInfiniteQuery.mockReturnValue(createUseInfiniteQueryResult(pages));
 };
 
 const renderHook = async (callback: () => void, shouldAwait = false) => {
@@ -191,6 +231,55 @@ describe('useBusLifeSituationsRoot', () => {
   });
 });
 
+describe('useBusAreas', () => {
+  it('separates area search query keys when BUS credentials change', async () => {
+    mockedUseContext
+      .mockReturnValueOnce(
+        createSettingsContextValue({
+          apiKey: 'alpha'
+        })
+      )
+      .mockReturnValueOnce(
+        createSettingsContextValue({
+          apiKey: 'beta'
+        })
+      );
+    mockIdleUseQuery();
+
+    await renderHook(() => {
+      useBusAreas('berlin');
+      useBusAreas('berlin');
+    });
+
+    expect(mockedUseQuery).toHaveBeenNthCalledWith(
+      1,
+      ['bus', 'areas', 'berlin', 'https://one.example::92909918'],
+      expect.any(Function),
+      expect.objectContaining({ enabled: true, keepPreviousData: true })
+    );
+    expect(mockedUseQuery).toHaveBeenNthCalledWith(
+      2,
+      ['bus', 'areas', 'berlin', 'https://one.example::3020272'],
+      expect.any(Function),
+      expect.objectContaining({ enabled: true, keepPreviousData: true })
+    );
+  });
+
+  it('calls the political area search with the current term when enabled', async () => {
+    mockedUseContext.mockReturnValue(createSettingsContextValue());
+    mockEnabledUseQuery();
+
+    await renderHook(() => useBusAreas('berlin'), true);
+
+    expect(mockedSearchPoliticalAreas).toHaveBeenCalledWith({
+      bus: {
+        uri: 'https://one.example'
+      },
+      searchTerm: 'berlin'
+    });
+  });
+});
+
 describe('useBusCategoryChildren', () => {
   it('calls findBusCategoryChildren for parentId 0 with areaId', async () => {
     mockedUseContext.mockReturnValue(createSettingsContextValue());
@@ -267,5 +356,133 @@ describe('useBusCategoryChildren', () => {
       expect.any(Function),
       expect.objectContaining({ enabled: true })
     );
+  });
+});
+
+describe('useBusServices', () => {
+  it('requests the first paginated BUS service page for the selected area', async () => {
+    mockedUseContext.mockReturnValue(createSettingsContextValue());
+    mockEnabledUseInfiniteQuery();
+
+    await renderHook(() => useBusServices('09162000'), true);
+
+    expect(mockedFindPublicServicesPage).toHaveBeenCalledWith({
+      areaId: '09162000',
+      bus: {
+        uri: 'https://one.example'
+      },
+      limit: 500,
+      offset: 0
+    });
+    expect(mockedUseInfiniteQuery).toHaveBeenCalledWith(
+      ['bus', 'services', '09162000', 'https://one.example::'],
+      expect.any(Function),
+      expect.objectContaining({
+        enabled: true,
+        retry: 0
+      })
+    );
+  });
+
+  it('flattens accumulated BUS service pages and keeps them sorted by name', async () => {
+    mockedUseContext.mockReturnValue(createSettingsContextValue());
+    mockIdleUseInfiniteQuery([
+      {
+        items: [
+          { id: '2', name: 'Zweiter Dienst' },
+          { id: '1', name: 'Alpha Dienst' }
+        ],
+        totalItemCount: 4
+      },
+      {
+        items: [{ id: '3', name: 'Mitte Dienst' }],
+        totalItemCount: 4
+      }
+    ]);
+
+    let result;
+    await renderHook(() => {
+      result = useBusServices('09162000');
+    });
+
+    expect(result?.data).toEqual([
+      { id: '1', name: 'Alpha Dienst' },
+      { id: '3', name: 'Mitte Dienst' },
+      { id: '2', name: 'Zweiter Dienst' }
+    ]);
+  });
+
+  it('exposes BUS service pagination errors to the UI layer', async () => {
+    mockedUseContext.mockReturnValue(createSettingsContextValue());
+    mockedUseInfiniteQuery.mockReturnValue({
+      ...createUseInfiniteQueryResult(),
+      error: new Error('timeout'),
+      isError: true
+    } as never);
+
+    let result;
+    await renderHook(() => {
+      result = useBusServices('09162000');
+    });
+
+    expect(result?.isError).toBe(true);
+    expect(result?.error).toEqual(expect.any(Error));
+  });
+});
+
+describe('useBusServiceSearch', () => {
+  it('does not enable backend BUS search below the minimum search length', async () => {
+    mockedUseContext.mockReturnValue(createSettingsContextValue());
+    mockIdleUseInfiniteQuery();
+
+    await renderHook(() => useBusServiceSearch('09162000', 'ab'));
+
+    expect(mockedUseInfiniteQuery).toHaveBeenCalledWith(
+      ['bus', 'service-search', '09162000', 'ab', 'https://one.example::'],
+      expect.any(Function),
+      expect.objectContaining({ enabled: false })
+    );
+  });
+
+  it('requests backend BUS search pages with the current search term', async () => {
+    mockedUseContext.mockReturnValue(createSettingsContextValue());
+    mockEnabledUseInfiniteQuery();
+
+    await renderHook(() => useBusServiceSearch('09162000', 'unternehmen'), true);
+
+    expect(mockedFindPublicServicesPage).toHaveBeenCalledWith({
+      areaId: '09162000',
+      bus: {
+        uri: 'https://one.example'
+      },
+      limit: 500,
+      offset: 0,
+      searchWord: 'unternehmen'
+    });
+    expect(mockedUseInfiniteQuery).toHaveBeenCalledWith(
+      ['bus', 'service-search', '09162000', 'unternehmen', 'https://one.example::'],
+      expect.any(Function),
+      expect.objectContaining({
+        enabled: true,
+        retry: 0
+      })
+    );
+  });
+
+  it('exposes backend BUS search errors to the UI layer', async () => {
+    mockedUseContext.mockReturnValue(createSettingsContextValue());
+    mockedUseInfiniteQuery.mockReturnValue({
+      ...createUseInfiniteQueryResult(),
+      error: new Error('timeout'),
+      isError: true
+    } as never);
+
+    let result;
+    await renderHook(() => {
+      result = useBusServiceSearch('09162000', 'unternehmen');
+    });
+
+    expect(result?.isError).toBe(true);
+    expect(result?.error).toEqual(expect.any(Error));
   });
 });

--- a/__tests__/queries/bus.test.js
+++ b/__tests__/queries/bus.test.js
@@ -1,7 +1,10 @@
 import {
+  BUS_REQUEST_TIMEOUT_MS,
   findBusCategoryChildren,
   findBusCategoryRoot,
+  findPublicServicesPage,
   getPoliticalArea,
+  getPublicService,
   searchPoliticalAreas
 } from '../../src/queries/bus';
 
@@ -34,6 +37,7 @@ const expectBusFetch = (url, options = {}) => {
 describe('BUS queries', () => {
   afterEach(() => {
     jest.restoreAllMocks();
+    jest.useRealTimers();
   });
 
   it('does not call the autocomplete endpoint below the minimum search length', async () => {
@@ -144,6 +148,190 @@ describe('BUS queries', () => {
     });
   });
 
+  it('loads the extended public service detail to include online services', async () => {
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: async () => ({
+        object: {
+          id: 'service-1',
+          name: 'Gewerbe Anmeldung',
+          onlineServices: [{ id: 'os-1', name: 'Digital beantragen' }]
+        }
+      }),
+      ok: true
+    });
+
+    const result = await getPublicService({ areaId: '10004', bus, id: 'service-1' });
+
+    expectBusFetch(
+      'https://server.int-development.smart-village.app/api/v1/pstExtended/service-1?areaId=10004',
+      {
+        headers: {
+          Accept: 'application/json',
+          'Accept-Language': 'de-DE'
+        },
+        method: 'GET'
+      }
+    );
+    expect(result).toEqual({
+      id: 'service-1',
+      name: 'Gewerbe Anmeldung',
+      onlineServices: [{ id: 'os-1', name: 'Digital beantragen' }]
+    });
+  });
+
+  it('falls back to pst detail when pstExtended is not available on the BUS backend', async () => {
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({
+          object: {
+            id: 'service-1',
+            name: 'Gewerbe Anmeldung',
+            organisationalUnits: [{ id: 'ou-1', name: 'Amt' }]
+          }
+        }),
+        ok: true
+      });
+
+    const result = await getPublicService({ areaId: '10004', bus, id: 'service-1' });
+
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      1,
+      'https://server.int-development.smart-village.app/api/v1/pstExtended/service-1?areaId=10004',
+      expect.any(Object)
+    );
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://server.int-development.smart-village.app/api/v1/pst/service-1?areaId=10004',
+      expect.any(Object)
+    );
+    expect(result).toEqual({
+      id: 'service-1',
+      name: 'Gewerbe Anmeldung',
+      organisationalUnits: [{ id: 'ou-1', name: 'Amt' }]
+    });
+  });
+
+  it('loads a paginated public service page and reads total-item-count from response headers', async () => {
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      headers: {
+        get: (headerName) =>
+          headerName.toLowerCase() === 'total-item-count' ? '2357' : undefined
+      },
+      json: async () => ({
+        results: [
+          {
+            object: {
+              id: 'service-1',
+              name: 'Gewerbe Anmeldung'
+            }
+          }
+        ]
+      }),
+      ok: true
+    });
+
+    const result = await findPublicServicesPage({
+      areaId: '10004',
+      bus,
+      limit: 500,
+      offset: 500,
+      searchWord: 'unternehmen'
+    });
+
+    expectBusFetch(
+      'https://server.int-development.smart-village.app/api/v1/pstExtended/find?areaId=10004&limit=500&offset=500&searchWord=unternehmen&selectAttributes=id,name,teaser',
+      {
+        headers: {
+          Accept: 'application/json',
+          'Accept-Language': 'de-DE'
+        },
+        method: 'GET'
+      }
+    );
+    expect(result).toEqual({
+      items: [
+        {
+          id: 'service-1',
+          name: 'Gewerbe Anmeldung'
+        }
+      ],
+      totalItemCount: 2357
+    });
+  });
+
+  it('uses pstExtended/find for free BUS search terms including phrases with spaces', async () => {
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      headers: {
+        get: (headerName) =>
+          headerName.toLowerCase() === 'total-item-count' ? '1' : undefined
+      },
+      json: async () => ({
+        results: [
+          {
+            object: {
+              id: 'service-2',
+              name: 'Neues Unternehmen anmelden'
+            }
+          }
+        ]
+      }),
+      ok: true
+    });
+
+    const result = await findPublicServicesPage({
+      areaId: '10004',
+      bus,
+      searchWord: 'Neues Unternehmen oder'
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://server.int-development.smart-village.app/api/v1/pstExtended/find?areaId=10004&limit=500&offset=0&searchWord=Neues%20Unternehmen%20oder&selectAttributes=id,name,teaser',
+      expect.any(Object)
+    );
+    expect(result).toEqual({
+      items: [
+        {
+          id: 'service-2',
+          name: 'Neues Unternehmen anmelden'
+        }
+      ],
+      totalItemCount: 1
+    });
+  });
+
+  it('aborts BUS requests that exceed the client timeout', async () => {
+    jest.useFakeTimers();
+    jest.spyOn(globalThis, 'fetch').mockImplementation((_, options = {}) => {
+      const { signal } = options;
+
+      return new Promise((_, reject) => {
+        signal?.addEventListener('abort', () => {
+          const abortError = new Error('Request aborted');
+          abortError.name = 'AbortError';
+          reject(abortError);
+        });
+      });
+    });
+
+    const requestPromise = findPublicServicesPage({
+      areaId: '10004',
+      bus,
+      searchWord: 'unternehmen'
+    });
+
+    jest.advanceTimersByTime(BUS_REQUEST_TIMEOUT_MS);
+
+    await expect(requestPromise).rejects.toThrow(
+      'BUS API request timed out for https://server.int-development.smart-village.app/api/v1/pstExtended/find?areaId=10004&limit=500&offset=0&searchWord=unternehmen&selectAttributes=id,name,teaser'
+    );
+  });
+
   it('returns null when the political area detail is invalid', async () => {
     mockFetchJson({});
 
@@ -201,7 +389,7 @@ describe('BUS queries', () => {
     });
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
-      'https://server.int-development.smart-village.app/api/v1/pstCategory/find?searchWord=Lebenslagen%20f%C3%BCr%20B%C3%BCrgerinnen%20und%20B%C3%BCrger&limit=1000&areaId=09162000&selectAttributes[]=id&selectAttributes[]=name',
+      'https://server.int-development.smart-village.app/api/v1/pstCategory/find?searchWord=Lebenslagen%20f%C3%BCr%20B%C3%BCrgerinnen%20und%20B%C3%BCrger&limit=500&areaId=09162000&selectAttributes[]=id&selectAttributes[]=name',
       expect.any(Object)
     );
     expect(result).toEqual({
@@ -241,7 +429,7 @@ describe('BUS queries', () => {
     });
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
-      'https://server.int-development.smart-village.app/api/v1/pstCategory/find?parentId=247228741&limit=1000&areaId=09162000&selectAttributes[]=id&selectAttributes[]=name&selectAttributes[]=description&selectAttributes[]=parentId&selectAttributes[]=position&selectAttributes[]=image&selectAttributes[]=publicServiceTypes',
+      'https://server.int-development.smart-village.app/api/v1/pstCategory/find?parentId=247228741&limit=500&areaId=09162000&selectAttributes[]=id&selectAttributes[]=name&selectAttributes[]=description&selectAttributes[]=parentId&selectAttributes[]=position&selectAttributes[]=image&selectAttributes[]=publicServiceTypes',
       expect.any(Object)
     );
     expect(result).toEqual([
@@ -294,10 +482,38 @@ describe('BUS queries', () => {
 
     const result = await findBusCategoryRoot({
       bus,
-      searchWord: ' Lebenslagen für Bürgerinnen und Bürger '
+      searchWord: 'Lebenslagen für Bürgerinnen und Bürger'
     });
 
     expect(result).toBeNull();
+  });
+
+  it('matches the lebenslagen root when the searchWord contains surrounding whitespace', async () => {
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: async () => ({
+        results: [
+          {
+            object: {
+              id: '247228741',
+              name: 'Lebenslagen für Bürgerinnen und Bürger',
+              publicServiceTypes: []
+            }
+          }
+        ]
+      }),
+      ok: true
+    });
+
+    const result = await findBusCategoryRoot({
+      bus,
+      searchWord: ' Lebenslagen für Bürgerinnen und Bürger '
+    });
+
+    expect(result).toEqual({
+      id: '247228741',
+      name: 'Lebenslagen für Bürgerinnen und Bürger',
+      publicServiceTypes: []
+    });
   });
 
   it('returns null when lebenslagen root results are malformed', async () => {

--- a/__tests__/queries/bus.test.js
+++ b/__tests__/queries/bus.test.js
@@ -1,11 +1,11 @@
 import {
-  BUS_REQUEST_TIMEOUT_MS,
-  findBusCategoryChildren,
-  findBusCategoryRoot,
-  findPublicServicesPage,
-  getPoliticalArea,
-  getPublicService,
-  searchPoliticalAreas
+    BUS_REQUEST_TIMEOUT_MS,
+    findBusCategoryChildren,
+    findBusCategoryRoot,
+    findPublicServicesPage,
+    getPoliticalArea,
+    getPublicService,
+    searchPoliticalAreas
 } from '../../src/queries/bus';
 
 const bus = {
@@ -219,8 +219,7 @@ describe('BUS queries', () => {
   it('loads a paginated public service page and reads total-item-count from response headers', async () => {
     jest.spyOn(globalThis, 'fetch').mockResolvedValue({
       headers: {
-        get: (headerName) =>
-          headerName.toLowerCase() === 'total-item-count' ? '2357' : undefined
+        get: (headerName) => (headerName.toLowerCase() === 'total-item-count' ? '2357' : undefined)
       },
       json: async () => ({
         results: [
@@ -244,7 +243,7 @@ describe('BUS queries', () => {
     });
 
     expectBusFetch(
-      'https://server.int-development.smart-village.app/api/v1/pstExtended/find?areaId=10004&limit=500&offset=500&searchWord=unternehmen&selectAttributes=id,name,teaser',
+      'https://server.int-development.smart-village.app/api/v1/pstExtended/find?areaId=10004&limit=500&offset=500&searchWord=unternehmen&selectAttributes=id,name',
       {
         headers: {
           Accept: 'application/json',
@@ -264,11 +263,47 @@ describe('BUS queries', () => {
     });
   });
 
+  it('uses the same attribute set for the unfiltered BUS base list import', async () => {
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      headers: {
+        get: (headerName) => (headerName.toLowerCase() === 'total-item-count' ? '2357' : undefined)
+      },
+      json: async () => ({
+        results: [
+          {
+            object: {
+              id: 'service-1',
+              name: 'Gewerbe Anmeldung'
+            }
+          }
+        ]
+      }),
+      ok: true
+    });
+
+    await findPublicServicesPage({
+      areaId: '10004',
+      bus,
+      limit: 500,
+      offset: 0
+    });
+
+    expectBusFetch(
+      'https://server.int-development.smart-village.app/api/v1/pst/find?areaId=10004&limit=500&offset=0&searchWord=&selectAttributes=id,name',
+      {
+        headers: {
+          Accept: 'application/json',
+          'Accept-Language': 'de-DE'
+        },
+        method: 'GET'
+      }
+    );
+  });
+
   it('uses pstExtended/find for free BUS search terms including phrases with spaces', async () => {
     jest.spyOn(globalThis, 'fetch').mockResolvedValue({
       headers: {
-        get: (headerName) =>
-          headerName.toLowerCase() === 'total-item-count' ? '1' : undefined
+        get: (headerName) => (headerName.toLowerCase() === 'total-item-count' ? '1' : undefined)
       },
       json: async () => ({
         results: [
@@ -291,7 +326,7 @@ describe('BUS queries', () => {
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     expect(globalThis.fetch).toHaveBeenCalledWith(
-      'https://server.int-development.smart-village.app/api/v1/pstExtended/find?areaId=10004&limit=500&offset=0&searchWord=Neues%20Unternehmen%20oder&selectAttributes=id,name,teaser',
+      'https://server.int-development.smart-village.app/api/v1/pstExtended/find?areaId=10004&limit=500&offset=0&searchWord=Neues%20Unternehmen%20oder&selectAttributes=id,name',
       expect.any(Object)
     );
     expect(result).toEqual({
@@ -328,7 +363,7 @@ describe('BUS queries', () => {
     jest.advanceTimersByTime(BUS_REQUEST_TIMEOUT_MS);
 
     await expect(requestPromise).rejects.toThrow(
-      'BUS API request timed out for https://server.int-development.smart-village.app/api/v1/pstExtended/find?areaId=10004&limit=500&offset=0&searchWord=unternehmen&selectAttributes=id,name,teaser'
+      'BUS API request timed out for https://server.int-development.smart-village.app/api/v1/pstExtended/find?areaId=10004&limit=500&offset=0&searchWord=unternehmen&selectAttributes=id,name'
     );
   });
 
@@ -389,7 +424,7 @@ describe('BUS queries', () => {
     });
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
-      'https://server.int-development.smart-village.app/api/v1/pstCategory/find?searchWord=Lebenslagen%20f%C3%BCr%20B%C3%BCrgerinnen%20und%20B%C3%BCrger&limit=500&areaId=09162000&selectAttributes[]=id&selectAttributes[]=name',
+      'https://server.int-development.smart-village.app/api/v1/pstCategory/find?searchWord=Lebenslagen%20f%C3%BCr%20B%C3%BCrgerinnen%20und%20B%C3%BCrger&limit=500&areaId=09162000&selectAttributes=id,name',
       expect.any(Object)
     );
     expect(result).toEqual({
@@ -429,7 +464,7 @@ describe('BUS queries', () => {
     });
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
-      'https://server.int-development.smart-village.app/api/v1/pstCategory/find?parentId=247228741&limit=500&areaId=09162000&selectAttributes[]=id&selectAttributes[]=name&selectAttributes[]=description&selectAttributes[]=parentId&selectAttributes[]=position&selectAttributes[]=image&selectAttributes[]=publicServiceTypes',
+      'https://server.int-development.smart-village.app/api/v1/pstCategory/find?parentId=247228741&limit=500&areaId=09162000&selectAttributes=id,name,description,parentId,position,image,publicServiceTypes',
       expect.any(Object)
     );
     expect(result).toEqual([

--- a/__tests__/screens/BUS/CategoryScreen.test.js
+++ b/__tests__/screens/BUS/CategoryScreen.test.js
@@ -3,10 +3,10 @@ import { ScrollView, Text } from 'react-native';
 import renderer from 'react-test-renderer';
 
 import { ServiceList } from '../../../src/components/BUS/ServiceList';
-import * as hooks from '../../../src/hooks';
 import { shareMessage } from '../../../src/helpers/BUS/shareHelper';
-import { IndexScreen } from '../../../src/screens/BUS/IndexScreen';
+import * as hooks from '../../../src/hooks';
 import { CategoryScreen } from '../../../src/screens/BUS/CategoryScreen';
+import { IndexScreen } from '../../../src/screens/BUS/IndexScreen';
 import { SettingsContext } from '../../../src/SettingsProvider';
 import { ScreenName } from '../../../src/types/Navigation';
 
@@ -1058,7 +1058,9 @@ describe('BUS IndexScreen', () => {
     const [verticalListProps] = mockVerticalList.mock.calls[0];
 
     expect(
-      verticalListProps.data.find((item) => item.routeName === 'BusDetail' && item.title === 'Nicht verfuegbar')
+      verticalListProps.data.find(
+        (item) => item.routeName === 'BusDetail' && item.title === 'Nicht verfuegbar'
+      )
     ).toEqual(
       expect.objectContaining({
         id: 'missing-root-service',
@@ -1072,6 +1074,7 @@ describe('BUS IndexScreen', () => {
 describe('BUS ServiceList', () => {
   const navigation = { navigate: jest.fn(), push: jest.fn() };
   const setArea = jest.fn();
+  const mountedComponents = [];
   const LIFE_SITUATIONS_EMPTY_STATE_MESSAGE =
     'Für diese Lebenslage sind derzeit keine Unterkategorien oder Leistungen verfügbar.';
   const SEARCH_FILTER = { id: 3, title: 'Suche', selected: true };
@@ -1097,6 +1100,7 @@ describe('BUS ServiceList', () => {
   };
 
   beforeEach(() => {
+    mountedComponents.length = 0;
     mockBusIndexFilter.mockClear();
     mockVerticalList.mockClear();
     navigation.navigate.mockClear();
@@ -1109,6 +1113,15 @@ describe('BUS ServiceList', () => {
       isError: false,
       isFetchingNextPage: false,
       isLoading: false
+    });
+  });
+
+  afterEach(() => {
+    renderer.act(() => {
+      while (mountedComponents.length) {
+        const component = mountedComponents.pop();
+        component.unmount();
+      }
     });
   });
 
@@ -1134,6 +1147,7 @@ describe('BUS ServiceList', () => {
     renderer.act(() => {
       component = renderer.create(<ServiceList {...createServiceListProps(props)} />);
     });
+    mountedComponents.push(component);
 
     return component;
   };
@@ -1201,6 +1215,42 @@ describe('BUS ServiceList', () => {
     const verticalListProps = getLatestVerticalListProps();
 
     expect(verticalListProps).toEqual(expect.objectContaining({ data: [], isLoading: true }));
+  });
+
+  it('clears previous A-Z results after an area change when the new area has no matching letter entries', () => {
+    const component = renderServiceList({
+      selectedFilter: A_Z_FILTER
+    });
+
+    selectAZFilter('A');
+
+    renderer.act(() => {
+      getLatestIndexFilterProps().setListItems([
+        {
+          id: 'service-a',
+          title: 'Anmeldung',
+          routeName: 'BusDetail',
+          params: { areaId: '09162000', data: { name: 'Anmeldung' } }
+        }
+      ]);
+    });
+
+    expect(getLatestVerticalListProps().data).toEqual([
+      expect.objectContaining({
+        id: 'service-a',
+        title: 'Anmeldung'
+      })
+    ]);
+
+    updateServiceList(component, {
+      areaId: '11000000',
+      areaName: 'Neuort',
+      results: [],
+      selectedFilter: A_Z_FILTER,
+      top10: []
+    });
+
+    expect(getLatestVerticalListProps().data).toEqual([]);
   });
 
   it('does not show stale life situations while the new area is still loading', () => {
@@ -1431,6 +1481,7 @@ describe('BUS ServiceList', () => {
       fetchNextServicesPage,
       hasNextServicesPage: true,
       isFetchingNextServicesPage: false,
+      isServicesLoading: false,
       selectedFilter: A_Z_FILTER,
       top10: []
     });
@@ -1469,6 +1520,48 @@ describe('BUS ServiceList', () => {
 
     expect(fetchNextServicesPage).toHaveBeenCalledTimes(1);
     warnSpy.mockRestore();
+  });
+
+  it('does not mark the A-Z import complete before the first service page for the area has loaded', async () => {
+    const fetchNextServicesPage = jest.fn().mockResolvedValue({
+      data: {
+        pages: [
+          {
+            items: [{ id: 'service-a', name: 'Anmeldung' }],
+            totalItemCount: 1
+          }
+        ]
+      }
+    });
+
+    const component = renderServiceList({
+      fetchNextServicesPage,
+      hasNextServicesPage: false,
+      isServicesLoading: true,
+      selectedFilter: A_Z_FILTER
+    });
+
+    selectAZFilter('A');
+
+    await renderer.act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchNextServicesPage).not.toHaveBeenCalled();
+
+    updateServiceList(component, {
+      fetchNextServicesPage,
+      hasNextServicesPage: true,
+      isServicesLoading: false,
+      selectedFilter: A_Z_FILTER,
+      top10: []
+    });
+
+    await renderer.act(async () => {
+      await flushAtoZImport();
+    });
+
+    expect(fetchNextServicesPage).toHaveBeenCalledTimes(1);
   });
 
   it('stops the A-Z import when the backend reports no loading progress anymore', async () => {
@@ -1512,6 +1605,42 @@ describe('BUS ServiceList', () => {
     expect(fetchNextServicesPage).toHaveBeenCalledTimes(2);
     expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
+  });
+
+  it('restarts the A-Z full import after switching to another letter in the same area', async () => {
+    const fetchNextServicesPage = jest.fn().mockResolvedValue({
+      data: {
+        pages: [
+          {
+            items: [{ id: 'service-a', name: 'Anmeldung' }],
+            totalItemCount: 1
+          }
+        ]
+      }
+    });
+
+    renderServiceList({
+      fetchNextServicesPage,
+      hasNextServicesPage: true,
+      selectedFilter: A_Z_FILTER
+    });
+
+    selectAZFilter('A');
+
+    await renderer.act(async () => {
+      await flushAtoZImport();
+    });
+
+    expect(fetchNextServicesPage).toHaveBeenCalledTimes(1);
+
+    selectAZFilter('B');
+
+    await renderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchNextServicesPage).toHaveBeenCalledTimes(2);
   });
 
   it('does not render the life situations empty state when no area is selected', () => {

--- a/__tests__/screens/BUS/CategoryScreen.test.js
+++ b/__tests__/screens/BUS/CategoryScreen.test.js
@@ -11,6 +11,7 @@ import { SettingsContext } from '../../../src/SettingsProvider';
 import { ScreenName } from '../../../src/types/Navigation';
 
 const mockIndexFilterWrapperAndList = jest.fn();
+const mockBusIndexFilter = jest.fn();
 const mockVerticalList = jest.fn();
 const getLatestVerticalListProps = () =>
   mockVerticalList.mock.calls[mockVerticalList.mock.calls.length - 1][0];
@@ -19,6 +20,7 @@ jest.mock('../../../src/hooks', () => ({
   useBusCategoryChildren: jest.fn(),
   useBusInitialArea: jest.fn(),
   useBusLifeSituationsRoot: jest.fn(),
+  useBusServiceSearch: jest.fn(),
   useBusServices: jest.fn(),
   useBusTop10: jest.fn(),
   useMatomoTrackScreenView: jest.fn()
@@ -135,7 +137,11 @@ jest.mock('../../../src/components/BUS/LifeSituationListItem', () => {
 jest.mock('../../../src/components/BUS/IndexFilter', () => {
   const { View: RNView } = jest.requireActual('react-native');
 
-  const IndexFilter = () => <RNView />;
+  const IndexFilter = (props) => {
+    mockBusIndexFilter(props);
+
+    return <RNView />;
+  };
 
   IndexFilter.propTypes = {};
 
@@ -436,7 +442,7 @@ describe('BUS CategoryScreen', () => {
     });
   });
 
-  it('does not render unresolved direct service refs for the current area', () => {
+  it('renders direct service refs even when they are not part of the currently loaded area services', () => {
     hooks.useBusCategoryChildren.mockReturnValue({
       data: [],
       isError: false,
@@ -453,11 +459,11 @@ describe('BUS CategoryScreen', () => {
 
     const component = renderScreen();
 
-    expect(() =>
+    expect(
       component.root.findByProps({
         accessibilityLabel: '(Meldebescheinigung) button'
       })
-    ).toThrow();
+    ).toBeTruthy();
   });
 
   it('keeps the refreshable container mounted for the empty state', () => {
@@ -721,9 +727,20 @@ describe('BUS IndexScreen', () => {
     });
     hooks.useBusServices.mockReturnValue({
       data: [],
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
       isFetching: false,
+      isFetchingNextPage: false,
       isLoading: false,
       refetch: servicesRefetch
+    });
+    hooks.useBusServiceSearch.mockReturnValue({
+      data: [],
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetching: false,
+      isFetchingNextPage: false,
+      isLoading: false
     });
     hooks.useBusTop10.mockReturnValue({
       data: [],
@@ -1018,7 +1035,7 @@ describe('BUS IndexScreen', () => {
     );
   });
 
-  it('omits unresolved root direct service refs for the current area', () => {
+  it('keeps unresolved root direct service refs visible in the list', () => {
     hooks.useBusLifeSituationsRoot.mockReturnValue({
       data: {
         ...rootCategory,
@@ -1042,52 +1059,104 @@ describe('BUS IndexScreen', () => {
 
     expect(
       verticalListProps.data.find((item) => item.routeName === 'BusDetail' && item.title === 'Nicht verfuegbar')
-    ).toBeUndefined();
+    ).toEqual(
+      expect.objectContaining({
+        id: 'missing-root-service',
+        routeName: 'BusDetail',
+        title: 'Nicht verfuegbar'
+      })
+    );
   });
 });
 
 describe('BUS ServiceList', () => {
   const navigation = { navigate: jest.fn(), push: jest.fn() };
   const setArea = jest.fn();
+  const LIFE_SITUATIONS_EMPTY_STATE_MESSAGE =
+    'Für diese Lebenslage sind derzeit keine Unterkategorien oder Leistungen verfügbar.';
+  const SEARCH_FILTER = { id: 3, title: 'Suche', selected: true };
+  const A_Z_FILTER = { id: 4, title: 'A-Z', selected: true };
+  const LIFE_SITUATIONS_FILTER = { id: 2, title: 'Lebenslagen', selected: true };
+  const TOP10_FILTER = { id: 1, title: 'Meistgesucht', selected: true };
+  const TEST_FILTER = { id: 999, title: 'Test', selected: true };
+  const DEFAULT_TOP10 = [
+    {
+      id: 'service-a',
+      title: 'Altes Top10',
+      routeName: 'BusDetail',
+      params: { areaId: '09162000' }
+    }
+  ];
+  const createAZSelection = (value = 'A') => [{ id: 1, value, selected: true }];
+  const flushAtoZImport = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await Promise.resolve();
+  };
 
   beforeEach(() => {
+    mockBusIndexFilter.mockClear();
     mockVerticalList.mockClear();
     navigation.navigate.mockClear();
     navigation.push.mockClear();
     setArea.mockClear();
+    hooks.useBusServiceSearch.mockReturnValue({
+      data: [],
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isError: false,
+      isFetchingNextPage: false,
+      isLoading: false
+    });
+  });
+
+  const createServiceListProps = (props = {}) => ({
+    areaId: '09162000',
+    areaName: 'Testort',
+    initialAreaId: '09162000',
+    initialAreaName: 'Testort',
+    isListLoading: false,
+    lifeSituationsEmptyStateMessage: LIFE_SITUATIONS_EMPTY_STATE_MESSAGE,
+    lifeSituations: [],
+    navigation,
+    results: [],
+    selectedFilter: TOP10_FILTER,
+    setArea,
+    top10: DEFAULT_TOP10,
+    ...props
   });
 
   const renderServiceList = (props = {}) => {
     let component;
 
     renderer.act(() => {
-      component = renderer.create(
-        <ServiceList
-          areaId="09162000"
-          areaName="Testort"
-          initialAreaId="09162000"
-          initialAreaName="Testort"
-          isListLoading={false}
-          lifeSituationsEmptyStateMessage="Für diese Lebenslage sind derzeit keine Unterkategorien oder Leistungen verfügbar."
-          lifeSituations={[]}
-          navigation={navigation}
-          results={[]}
-          selectedFilter={{ id: 1, title: 'Meistgesucht', selected: true }}
-          setArea={setArea}
-          top10={[
-            {
-              id: 'service-a',
-              title: 'Altes Top10',
-              routeName: 'BusDetail',
-              params: { areaId: '09162000' }
-            }
-          ]}
-          {...props}
-        />
-      );
+      component = renderer.create(<ServiceList {...createServiceListProps(props)} />);
     });
 
     return component;
+  };
+
+  const updateServiceList = (component, props = {}) => {
+    renderer.act(() => {
+      component.update(<ServiceList {...createServiceListProps(props)} />);
+    });
+  };
+
+  const getLatestIndexFilterProps = () =>
+    mockBusIndexFilter.mock.calls[mockBusIndexFilter.mock.calls.length - 1][0];
+
+  const setSearchInput = (value) => {
+    renderer.act(() => {
+      getLatestIndexFilterProps().setSearchData(value);
+    });
+  };
+
+  const selectAZFilter = (value = 'A') => {
+    renderer.act(() => {
+      getLatestIndexFilterProps().setAZFilterData(createAZSelection(value));
+    });
   };
 
   it('does not show stale TOP10 data after an area switch while the new area is still loading', () => {
@@ -1101,30 +1170,10 @@ describe('BUS ServiceList', () => {
       })
     ]);
 
-    renderer.act(() => {
-      component.update(
-        <ServiceList
-          areaId="11000000"
-          areaName="Neuort"
-          initialAreaId="09162000"
-          initialAreaName="Testort"
-          isListLoading
-          lifeSituationsEmptyStateMessage="Für diese Lebenslage sind derzeit keine Unterkategorien oder Leistungen verfügbar."
-          lifeSituations={[]}
-          navigation={navigation}
-          results={[]}
-          selectedFilter={{ id: 1, title: 'Meistgesucht', selected: true }}
-          setArea={setArea}
-          top10={[
-            {
-              id: 'service-a',
-              title: 'Altes Top10',
-              routeName: 'BusDetail',
-              params: { areaId: '09162000' }
-            }
-          ]}
-        />
-      );
+    updateServiceList(component, {
+      areaId: '11000000',
+      areaName: 'Neuort',
+      isListLoading: true
     });
 
     [verticalListProps] = mockVerticalList.mock.calls[mockVerticalList.mock.calls.length - 1];
@@ -1146,7 +1195,7 @@ describe('BUS ServiceList', () => {
           params: { areaId: '09162000' }
         }
       ],
-      selectedFilter: { id: 4, title: 'A-Z', selected: true }
+      selectedFilter: A_Z_FILTER
     });
 
     const verticalListProps = getLatestVerticalListProps();
@@ -1167,7 +1216,7 @@ describe('BUS ServiceList', () => {
           params: { areaId: '09162000' }
         }
       ],
-      selectedFilter: { id: 2, title: 'Lebenslagen', selected: true }
+      selectedFilter: LIFE_SITUATIONS_FILTER
     });
 
     const verticalListProps = getLatestVerticalListProps();
@@ -1187,7 +1236,7 @@ describe('BUS ServiceList', () => {
           params: { areaId: '09162000' }
         }
       ],
-      selectedFilter: { id: 3, title: 'Suche', selected: true }
+      selectedFilter: SEARCH_FILTER
     });
 
     const verticalListProps = getLatestVerticalListProps();
@@ -1195,18 +1244,335 @@ describe('BUS ServiceList', () => {
     expect(verticalListProps.data).toEqual([]);
   });
 
+  it('maps backend BUS search results to clickable list items', () => {
+    jest.useFakeTimers();
+    hooks.useBusServiceSearch.mockReturnValue({
+      data: [
+        {
+          id: 'service-search-1',
+          name: 'Gewerbe anmelden'
+        }
+      ],
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isError: false,
+      isFetchingNextPage: false,
+      isLoading: false
+    });
+
+    renderServiceList({ selectedFilter: SEARCH_FILTER });
+
+    setSearchInput('Gewerbe');
+
+    renderer.act(() => {
+      jest.advanceTimersByTime(400);
+    });
+
+    const verticalListProps = getLatestVerticalListProps();
+
+    expect(verticalListProps.data).toEqual([
+      expect.objectContaining({
+        id: 'service-search-1',
+        routeName: 'BusDetail',
+        title: 'Gewerbe anmelden',
+        params: expect.objectContaining({
+          areaId: '09162000',
+          title: 'Gewerbe anmelden'
+        })
+      })
+    ]);
+    renderer.act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('debounces BUS search input before updating the backend query term', () => {
+    jest.useFakeTimers();
+    renderServiceList({ selectedFilter: SEARCH_FILTER });
+
+    expect(hooks.useBusServiceSearch).toHaveBeenLastCalledWith('09162000', '');
+
+    setSearchInput('Unternehmen');
+
+    expect(hooks.useBusServiceSearch).toHaveBeenLastCalledWith('09162000', '');
+
+    renderer.act(() => {
+      jest.advanceTimersByTime(400);
+    });
+
+    expect(hooks.useBusServiceSearch).toHaveBeenLastCalledWith('09162000', 'Unternehmen');
+    renderer.act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('does not show the BUS search spinner while the input is still debouncing', () => {
+    jest.useFakeTimers();
+    renderServiceList({ selectedFilter: SEARCH_FILTER });
+
+    setSearchInput('Unternehmen');
+
+    expect(getLatestVerticalListProps().isLoading).toBe(false);
+
+    renderer.act(() => {
+      jest.advanceTimersByTime(400);
+    });
+
+    renderer.act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('clears a pending BUS search term when the selected area changes', () => {
+    jest.useFakeTimers();
+    let component = renderServiceList({
+      selectedFilter: SEARCH_FILTER
+    });
+
+    setSearchInput('Unternehmen');
+
+    renderer.act(() => {
+      jest.advanceTimersByTime(400);
+    });
+
+    expect(hooks.useBusServiceSearch).toHaveBeenLastCalledWith('09162000', 'Unternehmen');
+
+    updateServiceList(component, {
+      areaId: '11000000',
+      areaName: 'Neuort',
+      selectedFilter: SEARCH_FILTER,
+      top10: []
+    });
+
+    expect(hooks.useBusServiceSearch).toHaveBeenLastCalledWith('11000000', '');
+    renderer.act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('keeps the previous BUS search results visible while a new input is still debouncing', () => {
+    jest.useFakeTimers();
+    hooks.useBusServiceSearch.mockReturnValue({
+      data: [
+        {
+          id: 'service-search-1',
+          name: 'Gewerbe anmelden'
+        }
+      ],
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isError: false,
+      isFetchingNextPage: false,
+      isLoading: false
+    });
+
+    renderServiceList({ selectedFilter: SEARCH_FILTER });
+
+    setSearchInput('Gewerbe');
+
+    renderer.act(() => {
+      jest.advanceTimersByTime(400);
+    });
+
+    expect(getLatestVerticalListProps().data).toEqual([
+      expect.objectContaining({
+        id: 'service-search-1',
+        title: 'Gewerbe anmelden'
+      })
+    ]);
+
+    setSearchInput('Gewerbe a');
+
+    expect(getLatestVerticalListProps().data).toEqual([
+      expect.objectContaining({
+        id: 'service-search-1',
+        title: 'Gewerbe anmelden'
+      })
+    ]);
+
+    renderer.act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('continues the A-Z import after a temporary next-page fetch is already in flight', async () => {
+    const fetchNextServicesPage = jest.fn().mockResolvedValue({
+      data: {
+        pages: [
+          {
+            items: [{ id: 'service-a', name: 'Anmeldung' }],
+            totalItemCount: 1
+          }
+        ]
+      }
+    });
+
+    let component = renderServiceList({
+      fetchNextServicesPage,
+      hasNextServicesPage: true,
+      isFetchingNextServicesPage: true,
+      selectedFilter: A_Z_FILTER
+    });
+
+    selectAZFilter();
+
+    await renderer.act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchNextServicesPage).not.toHaveBeenCalled();
+
+    updateServiceList(component, {
+      fetchNextServicesPage,
+      hasNextServicesPage: true,
+      isFetchingNextServicesPage: false,
+      selectedFilter: A_Z_FILTER,
+      top10: []
+    });
+
+    await renderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchNextServicesPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not restart the A-Z import loop after a failed page load', async () => {
+    const fetchNextServicesPage = jest.fn().mockRejectedValue(new Error('timeout'));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const component = renderServiceList({
+      fetchNextServicesPage,
+      hasNextServicesPage: true,
+      selectedFilter: A_Z_FILTER
+    });
+
+    selectAZFilter();
+
+    await renderer.act(async () => {
+      await flushAtoZImport();
+    });
+
+    expect(fetchNextServicesPage).toHaveBeenCalledTimes(1);
+    updateServiceList(component, {
+      fetchNextServicesPage,
+      hasNextServicesPage: true,
+      selectedFilter: A_Z_FILTER,
+      top10: []
+    });
+
+    expect(fetchNextServicesPage).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('stops the A-Z import when the backend reports no loading progress anymore', async () => {
+    const fetchNextServicesPage = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: {
+          pages: [
+            {
+              items: [{ id: 'service-a', name: 'Anmeldung' }],
+              totalItemCount: 2
+            }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        data: {
+          pages: [
+            {
+              items: [{ id: 'service-a', name: 'Anmeldung' }],
+              totalItemCount: 2
+            }
+          ]
+        }
+      })
+      .mockRejectedValueOnce(new Error('should not request more pages without progress'));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    renderServiceList({
+      fetchNextServicesPage,
+      hasNextServicesPage: true,
+      selectedFilter: A_Z_FILTER
+    });
+
+    selectAZFilter();
+
+    await renderer.act(async () => {
+      await flushAtoZImport();
+    });
+
+    expect(fetchNextServicesPage).toHaveBeenCalledTimes(2);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
   it('does not render the life situations empty state when no area is selected', () => {
     renderServiceList({
       areaId: undefined,
       areaName: '',
-      lifeSituationsEmptyStateMessage:
-        'Für diese Lebenslage sind derzeit keine Unterkategorien oder Leistungen verfügbar.',
-      selectedFilter: { id: 2, title: 'Lebenslagen', selected: true }
+      lifeSituationsEmptyStateMessage: LIFE_SITUATIONS_EMPTY_STATE_MESSAGE,
+      selectedFilter: LIFE_SITUATIONS_FILTER
     });
 
     const verticalListProps = getLatestVerticalListProps();
 
     expect(verticalListProps.data).toEqual([]);
     expect(verticalListProps.ListEmptyComponent).toBeNull();
+  });
+
+  it('updates filtered items when the title changes for the same service id', () => {
+    jest.useFakeTimers();
+    renderServiceList({
+      selectedFilter: TEST_FILTER
+    });
+
+    renderer.act(() => {
+      getLatestIndexFilterProps().setListItems([
+        {
+          id: 'service-a',
+          title: 'Anmeldung Alt',
+          routeName: 'BusDetail',
+          params: { areaId: '09162000', data: { name: 'Anmeldung Alt' } }
+        }
+      ]);
+    });
+
+    expect(getLatestVerticalListProps().data).toEqual([
+      expect.objectContaining({
+        id: 'service-a',
+        title: 'Anmeldung Alt'
+      })
+    ]);
+
+    renderer.act(() => {
+      getLatestIndexFilterProps().setListItems([
+        {
+          id: 'service-a',
+          title: 'Anmeldung Aktualisiert',
+          routeName: 'BusDetail',
+          params: { areaId: '09162000', data: { name: 'Anmeldung Aktualisiert' } }
+        }
+      ]);
+    });
+
+    expect(getLatestVerticalListProps().data).toEqual([
+      expect.objectContaining({
+        id: 'service-a',
+        title: 'Anmeldung Aktualisiert'
+      })
+    ]);
+
+    renderer.act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
   });
 });

--- a/__tests__/screens/BUS/DetailScreen.test.js
+++ b/__tests__/screens/BUS/DetailScreen.test.js
@@ -1,0 +1,201 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+const mockTextBlock = jest.fn();
+const mockAuthority = jest.fn();
+const mockPersons = jest.fn();
+const mockUseBusService = jest.fn();
+const mockUseMatomoTrackScreenView = jest.fn();
+const mockUseOpenWebScreen = jest.fn(() => jest.fn());
+
+jest.mock('../../../src/hooks', () => ({
+  useBusService: (...args) => mockUseBusService(...args),
+  useMatomoTrackScreenView: (...args) => mockUseMatomoTrackScreenView(...args),
+  useOpenWebScreen: (...args) => mockUseOpenWebScreen(...args)
+}));
+
+jest.mock('../../../src/components', () => {
+  const ActualPropTypes = jest.requireActual('prop-types');
+  const { View: RNView } = jest.requireActual('react-native');
+
+  const BackToTop = () => <RNView />;
+  const Button = () => <RNView />;
+  const SafeAreaViewFlex = ({ children }) => <RNView>{children}</RNView>;
+
+  SafeAreaViewFlex.propTypes = {
+    children: ActualPropTypes.node
+  };
+
+  return { BackToTop, Button, SafeAreaViewFlex };
+});
+
+jest.mock('../../../src/components/BUS/TextBlock', () => {
+  const ActualPropTypes = jest.requireActual('prop-types');
+  const { View: RNView } = jest.requireActual('react-native');
+
+  const TextBlock = (props) => {
+    mockTextBlock(props);
+
+    return <RNView />;
+  };
+
+  TextBlock.propTypes = {
+    bottomDivider: ActualPropTypes.bool,
+    openWebScreen: ActualPropTypes.func,
+    textBlock: ActualPropTypes.object
+  };
+
+  return { TextBlock };
+});
+
+jest.mock('../../../src/components/BUS/Authority', () => {
+  const ActualPropTypes = jest.requireActual('prop-types');
+  const { View: RNView } = jest.requireActual('react-native');
+
+  const Authority = (props) => {
+    mockAuthority(props);
+
+    return <RNView />;
+  };
+
+  Authority.propTypes = {
+    bottomDivider: ActualPropTypes.bool,
+    data: ActualPropTypes.object,
+    openWebScreen: ActualPropTypes.func
+  };
+
+  return { Authority };
+});
+
+jest.mock('../../../src/components/BUS/Persons', () => {
+  const ActualPropTypes = jest.requireActual('prop-types');
+  const { View: RNView } = jest.requireActual('react-native');
+
+  const Persons = (props) => {
+    mockPersons(props);
+
+    return <RNView />;
+  };
+
+  Persons.propTypes = {
+    data: ActualPropTypes.object,
+    openWebScreen: ActualPropTypes.func
+  };
+
+  return { Persons };
+});
+
+jest.mock('../../../src/components/FeedbackFooter', () => ({
+  FeedbackFooter: () => {
+    const { View: RNView } = jest.requireActual('react-native');
+
+    return <RNView />;
+  }
+}));
+
+jest.mock('../../../src/components/LoadingSpinner', () => ({
+  LoadingSpinner: () => {
+    const { View: RNView } = jest.requireActual('react-native');
+
+    return <RNView />;
+  }
+}));
+
+jest.mock('../../../src/SettingsProvider', () => {
+  const ReactActual = jest.requireActual('react');
+
+  return {
+    SettingsContext: ReactActual.createContext({
+      globalSettings: {
+        settings: {
+          bus: {}
+        }
+      }
+    })
+  };
+});
+
+jest.mock('../../../src/config', () => ({
+  colors: {
+    refreshControl: '#00f'
+  },
+  consts: {
+    MATOMO_TRACKING: {
+      SCREEN_VIEW: {
+        BUS: 'BUS'
+      }
+    }
+  },
+  device: {
+    height: 1000
+  },
+  normalize: (value) => value
+}));
+
+jest.mock('../../../src/helpers', () => ({
+  matomoTrackingString: () => 'BUS',
+  openLink: jest.fn()
+}));
+
+describe('BUS DetailScreen', () => {
+  const route = {
+    params: {
+      areaId: '09162000',
+      data: {
+        id: 'service-1'
+      },
+      rootRouteName: 'BUS',
+      title: 'Meldebescheinigung'
+    }
+  };
+
+  beforeEach(() => {
+    mockTextBlock.mockClear();
+    mockAuthority.mockClear();
+    mockPersons.mockClear();
+    mockUseMatomoTrackScreenView.mockClear();
+    mockUseOpenWebScreen.mockClear();
+
+    mockUseBusService.mockReturnValue({
+      data: {
+        id: 'service-1',
+        organisationalUnits: [{ id: 'ou-1', name: 'Buergeramt' }],
+        persons: [{ id: 'person-1' }],
+        textBlocks: [
+          {
+            type: { id: 'tb-1', name: 'Kurztext' },
+            text: 'Kurzbeschreibung'
+          },
+          {
+            type: { id: 'tb-2', name: 'Volltext' },
+            text: 'Ausfuehrlich'
+          },
+          {
+            type: { id: 'tb-3', name: 'Formulare' },
+            text: 'Formulare'
+          }
+        ]
+      },
+      isLoading: false,
+      refetch: jest.fn()
+    });
+  });
+
+  it('renders Kurztext and Volltext first without forcing a divider between accordion groups', () => {
+    const { DetailScreen } = require('../../../src/screens/BUS/DetailScreen');
+
+    act(() => {
+      renderer.create(<DetailScreen route={route} />);
+    });
+
+    expect(mockTextBlock.mock.calls.map(([props]) => props.textBlock.type.name)).toEqual([
+      'Kurztext',
+      'Volltext',
+      'Formulare'
+    ]);
+
+    expect(mockTextBlock.mock.calls[0][0].bottomDivider).toBe(false);
+    expect(mockTextBlock.mock.calls[1][0].bottomDivider).toBe(false);
+    expect(mockAuthority.mock.calls[0][0].bottomDivider).toBe(false);
+  });
+});

--- a/src/components/BUS/AreaAutocomplete.tsx
+++ b/src/components/BUS/AreaAutocomplete.tsx
@@ -20,6 +20,7 @@ type SelectionArea = {
 type AreaAutocompleteProps = {
   areaId?: string;
   areaName?: string;
+  blurSignal?: number;
   initialAreaId?: string;
   initialAreaName?: string;
   onSelectArea: (area: SelectionArea) => void;
@@ -141,6 +142,7 @@ const SearchBarSearchIcon = ({ inputValue }: SearchIconProps) =>
 export const AreaAutocomplete = memo(function AreaAutocomplete({
   areaId,
   areaName,
+  blurSignal = 0,
   initialAreaId,
   initialAreaName,
   onSelectArea
@@ -214,6 +216,13 @@ export const AreaAutocomplete = memo(function AreaAutocomplete({
 
     return () => clearTimeout(timeoutId);
   }, [areaName]);
+
+  useEffect(() => {
+    if (!blurSignal) return;
+
+    setIsFocused(false);
+    searchBarRef.current?.blur?.();
+  }, [blurSignal]);
 
   const shouldHideResults = !isFocused || !shouldSearch;
   const hasDifferentSelection = !!initialAreaId && `${areaId}` !== `${initialAreaId}`;

--- a/src/components/BUS/IndexFilter.js
+++ b/src/components/BUS/IndexFilter.js
@@ -24,19 +24,8 @@ const initialCategoryFilterData = [
 ];
 /* *** */
 
-/* A-Z filter initial data */
-const alphabet = [...Array(26)].map((value, index) => String.fromCharCode(index + 65));
-const umlauts = ['Ä', 'Ö', 'Ü'];
-const alphabetWithUmlauts = [...alphabet, ...umlauts];
-
-const initialAZFilterData = alphabetWithUmlauts.map((value, index) => ({
-  id: index + 1,
-  value,
-  selected: false
-}));
-/* *** */
-
 export const IndexFilter = ({
+  AZFilterData,
   areaId,
   areaName,
   initialAreaId,
@@ -44,13 +33,14 @@ export const IndexFilter = ({
   listItems,
   loading,
   results,
+  searchData,
   selectedFilter,
   setArea,
-  setListItems
+  setAZFilterData,
+  setListItems,
+  setSearchData
 }) => {
-  const [serviceSearchData, setServiceSearchData] = useState('');
   const [categoryFilterData, setCategoryFilterData] = useState(initialCategoryFilterData);
-  const [AZFilterData, setAZFilterData] = useState(initialAZFilterData);
   const listItemsCount = listItems.length;
   const renderAreaAutocomplete = () => (
     <AreaAutocomplete
@@ -80,8 +70,8 @@ export const IndexFilter = ({
         return (
           <WrapperVertical>
             <TextSearch
-              data={serviceSearchData}
-              setData={setServiceSearchData}
+              data={searchData}
+              setData={setSearchData}
               placeholder={texts.bus.textSearch.placeholder}
               label={texts.bus.textSearch.label}
             />
@@ -119,12 +109,6 @@ export const IndexFilter = ({
         break;
       }
       case 3:
-        setListItems(
-          search({
-            results,
-            keyword: serviceSearchData
-          })
-        );
         break;
       case 4: {
         const character = (AZFilterData.find((item) => item.selected) || {}).value;
@@ -142,16 +126,7 @@ export const IndexFilter = ({
       default:
         break;
     }
-  }, [
-    AZFilterData,
-    areaId,
-    categoryFilterData,
-    loading,
-    results,
-    selectedFilter.id,
-    serviceSearchData,
-    setListItems
-  ]);
+  }, [AZFilterData, areaId, categoryFilterData, loading, results, selectedFilter.id, setListItems]);
 
   return (
     <View>
@@ -181,6 +156,7 @@ const styles = StyleSheet.create({
 });
 
 IndexFilter.propTypes = {
+  AZFilterData: PropTypes.array.isRequired,
   areaId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   areaName: PropTypes.string,
   initialAreaId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -188,7 +164,10 @@ IndexFilter.propTypes = {
   listItems: PropTypes.array.isRequired,
   loading: PropTypes.bool.isRequired,
   results: PropTypes.array.isRequired,
+  searchData: PropTypes.string.isRequired,
   selectedFilter: PropTypes.object.isRequired,
   setArea: PropTypes.func.isRequired,
-  setListItems: PropTypes.func.isRequired
+  setAZFilterData: PropTypes.func.isRequired,
+  setListItems: PropTypes.func.isRequired,
+  setSearchData: PropTypes.func.isRequired
 };

--- a/src/components/BUS/IndexFilter.js
+++ b/src/components/BUS/IndexFilter.js
@@ -28,6 +28,8 @@ export const IndexFilter = ({
   AZFilterData,
   areaId,
   areaName,
+  blurAreaSignal = 0,
+  blurSearchSignal = 0,
   initialAreaId,
   initialAreaName,
   listItems,
@@ -46,6 +48,7 @@ export const IndexFilter = ({
     <AreaAutocomplete
       areaId={areaId}
       areaName={areaName}
+      blurSignal={blurAreaSignal}
       initialAreaId={initialAreaId}
       initialAreaName={initialAreaName}
       onSelectArea={setArea}
@@ -70,6 +73,7 @@ export const IndexFilter = ({
         return (
           <WrapperVertical>
             <TextSearch
+              blurSignal={blurSearchSignal}
               data={searchData}
               setData={setSearchData}
               placeholder={texts.bus.textSearch.placeholder}
@@ -159,6 +163,8 @@ IndexFilter.propTypes = {
   AZFilterData: PropTypes.array.isRequired,
   areaId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   areaName: PropTypes.string,
+  blurAreaSignal: PropTypes.number,
+  blurSearchSignal: PropTypes.number,
   initialAreaId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   initialAreaName: PropTypes.string,
   listItems: PropTypes.array.isRequired,

--- a/src/components/BUS/LifeSituationsList.tsx
+++ b/src/components/BUS/LifeSituationsList.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo, useRef, useState } from 'react';
-import { ScrollView, StyleSheet, View, type RefreshControlProps } from 'react-native';
+import { Keyboard, ScrollView, StyleSheet, View, type RefreshControlProps } from 'react-native';
 
 import { device, normalize, texts } from '../../config';
-import { resolveBusCategoryServices } from '../../helpers/busListHelper';
 import { shareMessage } from '../../helpers/BUS/shareHelper';
+import { resolveBusCategoryServices } from '../../helpers/busListHelper';
 import type { AreaId, BusCategory, BusServiceListItem } from '../../types';
 import { ScreenName } from '../../types/Navigation';
 import { BackToTop } from '../BackToTop';
@@ -168,14 +168,16 @@ export const LifeSituationsList = ({
               imageUrl={childCategory?.image?.url ?? undefined}
               title={childCategory?.name ?? ''}
               subtitle={childCategory?.description ?? undefined}
-              onPress={() =>
+              onPress={() => {
+                Keyboard.dismiss();
+
                 navigation.push(ScreenName.BusCategory, {
                   areaId,
                   category: childCategory,
                   isRootCategory: false,
                   title: childCategory?.name ?? ''
-                })
-              }
+                });
+              }}
             />
           );
         }
@@ -187,7 +189,9 @@ export const LifeSituationsList = ({
             key={`${item.type}-${service?.id ?? index}`}
             bottomDivider={bottomDivider}
             title={service?.name ?? ''}
-            onPress={() =>
+            onPress={() => {
+              Keyboard.dismiss();
+
               navigation.push(ScreenName.BusDetail, {
                 areaId,
                 title: service?.name ?? '',
@@ -198,8 +202,8 @@ export const LifeSituationsList = ({
                   message: shareMessage(service)
                 },
                 data: service
-              })
-            }
+              });
+            }}
           />
         );
       })}

--- a/src/components/BUS/LifeSituationsList.tsx
+++ b/src/components/BUS/LifeSituationsList.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useRef, useState } from 'react';
 import { ScrollView, StyleSheet, View, type RefreshControlProps } from 'react-native';
 
 import { device, normalize, texts } from '../../config';
+import { resolveBusCategoryServices } from '../../helpers/busListHelper';
 import { shareMessage } from '../../helpers/BUS/shareHelper';
 import type { AreaId, BusCategory, BusServiceListItem } from '../../types';
 import { ScreenName } from '../../types/Navigation';
@@ -39,13 +40,11 @@ type LifeSituationsListProps = {
   isError?: boolean;
   isLoading?: boolean;
   isRootCategory?: boolean;
-  isServicesLoading?: boolean;
   navigation: BusNavigation;
   refreshControl?: React.ReactElement<RefreshControlProps>;
   services?: BusServiceListItem[];
 };
 
-const normalizeName = (value?: string | null) => `${value ?? ''}`.trim().toLowerCase();
 const getSortPosition = (value?: string | number) => {
   const numericValue = Number(value);
 
@@ -54,7 +53,7 @@ const getSortPosition = (value?: string | number) => {
 const hasCategoryListData = (childCategory?: BusCategory) =>
   childCategory?.id !== null &&
   childCategory?.id !== undefined &&
-  !!normalizeName(childCategory?.name);
+  !!`${childCategory?.name ?? ''}`.trim();
 
 const shouldShowLoadingSpinner = ({
   hasListData,
@@ -66,45 +65,13 @@ const shouldShowLoadingSpinner = ({
   isResolvingServices: boolean;
 }) => (isLoading || isResolvingServices) && !hasListData;
 
-const getResolvedServices = ({
-  category,
-  services = []
-}: {
-  category?: BusCategory;
-  services?: BusServiceListItem[];
-}) => {
-  const servicesById = new Map(
-    services
-      .filter((service) => service?.id !== null && service?.id !== undefined)
-      .map((service) => [`${service.id}`, service] as const)
-  );
-  const servicesByName = new Map(
-    services
-      .filter((service) => !!normalizeName(service?.name))
-      .map((service) => [normalizeName(service.name), service] as const)
-  );
-
-  return (category?.publicServiceTypes ?? [])
-    .map((serviceReference) => {
-      const serviceId = serviceReference?.id;
-      const serviceName = serviceReference?.name;
-
-      return (
-        servicesById.get(`${serviceId ?? ''}`) || servicesByName.get(normalizeName(serviceName))
-      );
-    })
-    .filter((service): service is BusServiceListItem => !!service);
-};
-
 const getListData = ({
   category,
   childCategories = [],
-  isServicesLoading = false,
   services = []
 }: {
   category?: BusCategory;
   childCategories?: BusCategory[];
-  isServicesLoading?: boolean;
   services?: BusServiceListItem[];
 }) => {
   const categories: CategoryListItem[] = childCategories
@@ -117,13 +84,16 @@ const getListData = ({
         return positionDifference;
       }
 
-      return normalizeName(firstCategory.name).localeCompare(normalizeName(secondCategory.name));
+      return `${firstCategory.name ?? ''}`
+        .trim()
+        .toLowerCase()
+        .localeCompare(`${secondCategory.name ?? ''}`.trim().toLowerCase());
     })
     .map((childCategory) => ({
       data: childCategory,
       type: ITEM_TYPES.CATEGORY
     }));
-  const resolvedServices = isServicesLoading ? [] : getResolvedServices({ category, services });
+  const resolvedServices = resolveBusCategoryServices(category, services);
   const serviceItems: ServiceListItem[] = resolvedServices.map((service) => ({
     data: service,
     type: ITEM_TYPES.SERVICE
@@ -142,17 +112,15 @@ export const LifeSituationsList = ({
   isError = false,
   isLoading = false,
   isRootCategory = false,
-  isServicesLoading = false,
   navigation,
   refreshControl,
   services = []
 }: LifeSituationsListProps) => {
   const scrollViewRef = useRef<ScrollView | null>(null);
   const [showBackToTop, setShowBackToTop] = useState(false);
-  const isResolvingServices = isServicesLoading && !!category?.publicServiceTypes?.length;
   const listData = useMemo(
-    () => getListData({ category, childCategories, services, isServicesLoading }),
-    [category, childCategories, services, isServicesLoading]
+    () => getListData({ category, childCategories, services }),
+    [category, childCategories, services]
   );
   const hasListData = !!listData.length;
   const emptyStateMessage = isError
@@ -162,7 +130,7 @@ export const LifeSituationsList = ({
     : texts.bus.emptyStates.lifeSituations;
   const shouldRenderLoadingSpinner = shouldShowLoadingSpinner({
     isLoading,
-    isResolvingServices,
+    isResolvingServices: false,
     hasListData
   });
 
@@ -179,7 +147,7 @@ export const LifeSituationsList = ({
     >
       {shouldRenderLoadingSpinner ? <LoadingSpinner loading /> : null}
 
-      {!isLoading && !isResolvingServices && !hasListData ? (
+      {!isLoading && !hasListData ? (
         <View style={styles.emptyState}>
           <RegularText placeholder small center>
             {emptyStateMessage}

--- a/src/components/BUS/Persons.js
+++ b/src/components/BUS/Persons.js
@@ -11,11 +11,11 @@ import { InfoBox, Wrapper } from '../Wrapper';
 import { Block } from './Block';
 import { getAddress, getContact } from './helpers';
 
-export const Persons = ({ data, openWebScreen }) => {
+export const Persons = ({ data, bottomDivider, openWebScreen }) => {
   const { persons } = data;
 
   return (
-    <Block title={texts.bus.employees}>
+    <Block title={texts.bus.employees} bottomDivider={bottomDivider}>
       {persons.map((person) => {
         const {
           id,
@@ -77,6 +77,7 @@ const styles = StyleSheet.create({
 });
 
 Persons.propTypes = {
+  bottomDivider: PropTypes.bool,
   data: PropTypes.object.isRequired,
   openWebScreen: PropTypes.func.isRequired
 };

--- a/src/components/BUS/ServiceList.js
+++ b/src/components/BUS/ServiceList.js
@@ -3,12 +3,12 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import { colors, consts, normalize, texts } from '../../config';
-import { BUS_MIN_SEARCH_LENGTH, BUS_SEARCH_DEBOUNCE_MS, useBusServiceSearch } from '../../hooks';
 import { mapBusServicesToListItems } from '../../helpers/busListHelper';
+import { BUS_MIN_SEARCH_LENGTH, BUS_SEARCH_DEBOUNCE_MS, useBusServiceSearch } from '../../hooks';
 import { EmptyMessage } from '../EmptyMessage';
-import { VerticalList } from '../VerticalList';
 import { IndexFilterWrapper } from '../IndexFilterElement';
 import { RegularText } from '../Text';
+import { VerticalList } from '../VerticalList';
 import { WrapperHorizontal, WrapperVertical } from '../Wrapper';
 
 import { AreaAutocomplete } from './AreaAutocomplete';
@@ -42,8 +42,7 @@ const createAZImportState = () => ({
 const areListItemsEqual = (leftItems = [], rightItems = []) =>
   leftItems.length === rightItems.length &&
   leftItems.every(
-    (item, index) =>
-      item?.id === rightItems[index]?.id && item?.title === rightItems[index]?.title
+    (item, index) => item?.id === rightItems[index]?.id && item?.title === rightItems[index]?.title
   );
 const getActiveAZImportState = ({
   activeFilterId,
@@ -153,6 +152,7 @@ const getFetchMoreData = ({
 const LifeSituationsHeader = ({
   areaId,
   areaName,
+  blurAreaSignal = 0,
   initialAreaId,
   initialAreaName,
   listItemsCount,
@@ -164,6 +164,7 @@ const LifeSituationsHeader = ({
         <AreaAutocomplete
           areaId={areaId}
           areaName={areaName}
+          blurSignal={blurAreaSignal}
           initialAreaId={initialAreaId}
           initialAreaName={initialAreaName}
           onSelectArea={setArea}
@@ -181,6 +182,7 @@ const LifeSituationsHeader = ({
 LifeSituationsHeader.propTypes = {
   areaId: areaIdPropType,
   areaName: PropTypes.string,
+  blurAreaSignal: PropTypes.number,
   initialAreaId: areaIdPropType,
   initialAreaName: PropTypes.string,
   listItemsCount: PropTypes.number.isRequired,
@@ -211,6 +213,7 @@ export const ServiceList = ({
   initialAreaName,
   isFetchingNextServicesPage = false,
   isListLoading,
+  isServicesLoading = false,
   lifeSituationsEmptyStateMessage,
   lifeSituations = [],
   navigation,
@@ -222,10 +225,14 @@ export const ServiceList = ({
   top10
 }) => {
   const activeFilter = selectedFilter || { id: FILTER_IDS.SEARCH };
+  const [areaBlurSignal, setAreaBlurSignal] = useState(0);
   const [searchData, setSearchData] = useState('');
+  const [searchBlurSignal, setSearchBlurSignal] = useState(0);
   const [debouncedSearchData, setDebouncedSearchData] = useState('');
   const [AZFilterData, setAZFilterData] = useState(initialAZFilterData);
   const [AZImportState, setAZImportState] = useState(createAZImportState);
+  // Triggers the async A-Z import effect in a controlled way and guards against stale runs.
+  const [AZImportRequest, setAZImportRequest] = useState(null);
   const [filteredListState, setFilteredListState] = useState({
     areaId,
     filterId: activeFilter.id,
@@ -311,6 +318,23 @@ export const ServiceList = ({
     isSearchDebouncing,
     selectedFilterId: activeFilter.id
   });
+  const handleSetAZFilterData = useCallback((nextData) => {
+    setAreaBlurSignal((currentValue) => currentValue + 1);
+    setAZFilterData(nextData);
+  }, []);
+
+  useEffect(() => {
+    if (typeof navigation?.addListener !== 'function') {
+      return undefined;
+    }
+
+    return navigation.addListener('focus', () => {
+      if (activeFilter.id === FILTER_IDS.SEARCH) {
+        setSearchBlurSignal((currentValue) => currentValue + 1);
+      }
+    });
+  }, [activeFilter.id, navigation]);
+
   useEffect(() => {
     const timeoutId = setTimeout(() => {
       setDebouncedSearchData(searchData);
@@ -325,6 +349,16 @@ export const ServiceList = ({
   }, [areaId]);
 
   useEffect(() => {
+    setAZImportState(createAZImportState());
+    setAZImportRequest(null);
+    setFilteredListState((currentState) => ({
+      ...currentState,
+      areaId,
+      items: []
+    }));
+  }, [areaId]);
+
+  useEffect(() => {
     if (!fetchNextServicesPage) {
       return;
     }
@@ -333,28 +367,57 @@ export const ServiceList = ({
       return;
     }
 
+    if (isServicesLoading) {
+      return;
+    }
+
     if (isFetchingNextServicesPage) {
       return;
     }
 
-    const isNewSelection = activeAZImportState.key !== activeAZImportKey;
+    const hasCompletedAreaImport = activeAZImportState.status === AZ_IMPORT_STATUS.COMPLETE;
 
     if (!hasNextServicesPage) {
+      if (!hasCompletedAreaImport) {
+        setAZImportState({
+          key: activeAZImportKey,
+          status: AZ_IMPORT_STATUS.COMPLETE
+        });
+      }
       return;
     }
 
-    if (!isNewSelection && activeAZImportState.status !== AZ_IMPORT_STATUS.IDLE) {
+    if (hasCompletedAreaImport || activeAZImportState.status !== AZ_IMPORT_STATUS.IDLE) {
+      return;
+    }
+
+    setAZImportState({
+      key: activeAZImportKey,
+      status: AZ_IMPORT_STATUS.LOADING
+    });
+    setAZImportRequest((currentRequest) => ({
+      key: activeAZImportKey,
+      sequence: (currentRequest?.sequence ?? 0) + 1
+    }));
+  }, [
+    activeAZImportKey,
+    activeAZImportState.status,
+    activeFilter.id,
+    fetchNextServicesPage,
+    hasNextServicesPage,
+    isFetchingNextServicesPage,
+    isServicesLoading,
+    selectedAZCharacter
+  ]);
+
+  useEffect(() => {
+    if (!AZImportRequest || !fetchNextServicesPage || AZImportRequest.key !== activeAZImportKey) {
       return;
     }
 
     let isCancelled = false;
 
     const loadAllServicePagesForAZ = async () => {
-      setAZImportState({
-        key: activeAZImportKey,
-        status: AZ_IMPORT_STATUS.LOADING
-      });
-
       try {
         let shouldContinue = true;
         let previousLoadedItemsCount = -1;
@@ -382,7 +445,7 @@ export const ServiceList = ({
 
         if (!isCancelled) {
           setAZImportState({
-            key: activeAZImportKey,
+            key: AZImportRequest.key,
             status: AZ_IMPORT_STATUS.COMPLETE
           });
         }
@@ -391,7 +454,7 @@ export const ServiceList = ({
 
         if (!isCancelled) {
           setAZImportState({
-            key: activeAZImportKey,
+            key: AZImportRequest.key,
             status: AZ_IMPORT_STATUS.ERROR
           });
         }
@@ -403,19 +466,14 @@ export const ServiceList = ({
     return () => {
       isCancelled = true;
     };
-  }, [
-    activeFilter.id,
-    activeAZImportKey,
-    fetchNextServicesPage,
-    hasNextServicesPage,
-    isFetchingNextServicesPage
-  ]);
+  }, [AZImportRequest, activeAZImportKey, fetchNextServicesPage]);
 
   const listHeaderComponent =
     activeFilter.id === FILTER_IDS.LIFE_SITUATIONS ? (
       <LifeSituationsHeader
         areaId={areaId}
         areaName={areaName}
+        blurAreaSignal={areaBlurSignal}
         initialAreaId={initialAreaId}
         initialAreaName={initialAreaName}
         listItemsCount={listItems.length}
@@ -425,6 +483,8 @@ export const ServiceList = ({
       <IndexFilter
         AZFilterData={AZFilterData}
         selectedFilter={activeFilter}
+        blurAreaSignal={areaBlurSignal}
+        blurSearchSignal={searchBlurSignal}
         results={results}
         areaId={areaId}
         areaName={areaName}
@@ -434,7 +494,7 @@ export const ServiceList = ({
         setArea={setArea}
         loading={listLoading}
         listItems={listItems}
-        setAZFilterData={setAZFilterData}
+        setAZFilterData={handleSetAZFilterData}
         setSearchData={setSearchData}
         setListItems={setFilteredListItems}
       />
@@ -454,9 +514,7 @@ export const ServiceList = ({
       />
     );
   } else if (hasLifeSituationsEmptyState) {
-    listEmptyComponent = (
-      <LifeSituationsEmptyState message={lifeSituationsEmptyStateMessage} />
-    );
+    listEmptyComponent = <LifeSituationsEmptyState message={lifeSituationsEmptyStateMessage} />;
   }
 
   return (
@@ -487,6 +545,7 @@ ServiceList.propTypes = {
   initialAreaName: PropTypes.string,
   isFetchingNextServicesPage: PropTypes.bool,
   isListLoading: PropTypes.bool.isRequired,
+  isServicesLoading: PropTypes.bool,
   isServicesError: PropTypes.bool,
   lifeSituationsEmptyStateMessage: PropTypes.string,
   lifeSituations: PropTypes.array,

--- a/src/components/BUS/ServiceList.js
+++ b/src/components/BUS/ServiceList.js
@@ -1,8 +1,11 @@
 import PropTypes from 'prop-types';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import { colors, consts, normalize } from '../../config';
+import { colors, consts, normalize, texts } from '../../config';
+import { BUS_MIN_SEARCH_LENGTH, BUS_SEARCH_DEBOUNCE_MS, useBusServiceSearch } from '../../hooks';
+import { mapBusServicesToListItems } from '../../helpers/busListHelper';
+import { EmptyMessage } from '../EmptyMessage';
 import { VerticalList } from '../VerticalList';
 import { IndexFilterWrapper } from '../IndexFilterElement';
 import { RegularText } from '../Text';
@@ -13,16 +16,52 @@ import { IndexFilter } from './IndexFilter';
 
 const FILTER_IDS = {
   TOP10: 1,
-  LIFE_SITUATIONS: 2
+  LIFE_SITUATIONS: 2,
+  SEARCH: 3,
+  ATOZ: 4
 };
 const { LIST_TYPES } = consts;
 const areaIdPropType = PropTypes.oneOfType([PropTypes.string, PropTypes.number]);
+const alphabet = Array.from({ length: 26 }, (_, index) => String.fromCodePoint(index + 65));
+const umlauts = ['Ä', 'Ö', 'Ü'];
+const initialAZFilterData = [...alphabet, ...umlauts].map((value, index) => ({
+  id: index + 1,
+  value,
+  selected: false
+}));
+const AZ_IMPORT_STATUS = {
+  COMPLETE: 'complete',
+  ERROR: 'error',
+  IDLE: 'idle',
+  LOADING: 'loading'
+};
+const createAZImportState = () => ({
+  key: null,
+  status: AZ_IMPORT_STATUS.IDLE
+});
+const areListItemsEqual = (leftItems = [], rightItems = []) =>
+  leftItems.length === rightItems.length &&
+  leftItems.every(
+    (item, index) =>
+      item?.id === rightItems[index]?.id && item?.title === rightItems[index]?.title
+  );
+const getActiveAZImportState = ({
+  activeFilterId,
+  activeImportKey,
+  importState,
+  selectedAZCharacter
+}) =>
+  activeFilterId === FILTER_IDS.ATOZ && !!selectedAZCharacter && importState.key === activeImportKey
+    ? importState
+    : createAZImportState();
 
 const getVisibleListItems = ({
   areaId,
   filteredListState,
   isListLoading,
   lifeSituations,
+  searchResults,
+  selectedAZCharacter,
   selectedFilterId,
   top10
 }) => {
@@ -38,9 +77,77 @@ const getVisibleListItems = ({
     return lifeSituations;
   }
 
+  if (selectedFilterId === FILTER_IDS.SEARCH) {
+    return searchResults;
+  }
+
+  if (selectedFilterId === FILTER_IDS.ATOZ && !selectedAZCharacter) {
+    return [];
+  }
+
   return filteredListState.areaId === areaId && filteredListState.filterId === selectedFilterId
     ? filteredListState.items
     : [];
+};
+const getHasSearchError = ({
+  activeFilterId,
+  isSearchDebouncing,
+  isSearchError,
+  trimmedDebouncedSearchData
+}) =>
+  activeFilterId === FILTER_IDS.SEARCH &&
+  trimmedDebouncedSearchData.length >= BUS_MIN_SEARCH_LENGTH &&
+  !isSearchDebouncing &&
+  isSearchError;
+const getHasAZError = ({
+  activeFilterId,
+  activeAZImportState,
+  isServicesError,
+  results,
+  selectedAZCharacter
+}) =>
+  activeFilterId === FILTER_IDS.ATOZ &&
+  !!selectedAZCharacter &&
+  (activeAZImportState.status === AZ_IMPORT_STATUS.ERROR || (!!isServicesError && !results.length));
+const getListLoading = ({
+  activeFilterId,
+  hasAZError,
+  isAZImportLoading,
+  isListLoading,
+  isLoadingSearchResults,
+  searchResults
+}) => {
+  if (activeFilterId === FILTER_IDS.SEARCH) {
+    return isLoadingSearchResults && !searchResults.length;
+  }
+
+  if (activeFilterId === FILTER_IDS.ATOZ) {
+    return !hasAZError && (isListLoading || isAZImportLoading);
+  }
+
+  return isListLoading;
+};
+const getFetchMoreData = ({
+  fetchNextSearchPage,
+  hasNextSearchPage,
+  isFetchingNextSearchPage,
+  isSearchDebouncing,
+  selectedFilterId
+}) => {
+  if (selectedFilterId !== FILTER_IDS.SEARCH) {
+    return undefined;
+  }
+
+  return async () => {
+    if (!hasNextSearchPage || isFetchingNextSearchPage || isSearchDebouncing) {
+      return { data: [] };
+    }
+
+    const nextPageResult = await fetchNextSearchPage();
+    const lastPage = nextPageResult?.data?.pages?.slice(-1)[0];
+
+    return { data: lastPage?.items ?? [] };
+  };
 };
 
 const LifeSituationsHeader = ({
@@ -94,44 +201,215 @@ LifeSituationsEmptyState.propTypes = {
   message: PropTypes.string.isRequired
 };
 
+/* eslint-disable complexity */
 export const ServiceList = ({
   areaId,
   areaName,
+  fetchNextServicesPage,
+  hasNextServicesPage,
   initialAreaId,
   initialAreaName,
+  isFetchingNextServicesPage = false,
   isListLoading,
   lifeSituationsEmptyStateMessage,
   lifeSituations = [],
   navigation,
   refreshControl,
   results = [],
+  isServicesError = false,
   selectedFilter,
   setArea,
   top10
 }) => {
-  const activeFilter = selectedFilter || { id: 3 };
+  const activeFilter = selectedFilter || { id: FILTER_IDS.SEARCH };
+  const [searchData, setSearchData] = useState('');
+  const [debouncedSearchData, setDebouncedSearchData] = useState('');
+  const [AZFilterData, setAZFilterData] = useState(initialAZFilterData);
+  const [AZImportState, setAZImportState] = useState(createAZImportState);
   const [filteredListState, setFilteredListState] = useState({
     areaId,
     filterId: activeFilter.id,
     items: []
   });
+  const {
+    data: searchResults = [],
+    fetchNextPage: fetchNextSearchPage,
+    hasNextPage: hasNextSearchPage,
+    isError: isSearchError,
+    isFetchingNextPage: isFetchingNextSearchPage,
+    isLoading: isLoadingSearchResults
+  } = useBusServiceSearch(areaId, debouncedSearchData);
   const setFilteredListItems = useCallback(
     (items) =>
-      setFilteredListState({
-        areaId,
-        filterId: activeFilter.id,
-        items
+      setFilteredListState((currentState) => {
+        if (
+          currentState.areaId === areaId &&
+          currentState.filterId === activeFilter.id &&
+          areListItemsEqual(currentState.items, items)
+        ) {
+          return currentState;
+        }
+
+        return {
+          ...currentState,
+          areaId,
+          filterId: activeFilter.id,
+          items
+        };
       }),
     [activeFilter.id, areaId]
   );
+  const selectedAZCharacter = AZFilterData.find((item) => item.selected)?.value;
+  const activeAZImportKey = `${areaId ?? ''}:${selectedAZCharacter ?? ''}`;
+  const activeAZImportState = getActiveAZImportState({
+    activeFilterId: activeFilter.id,
+    activeImportKey: activeAZImportKey,
+    importState: AZImportState,
+    selectedAZCharacter
+  });
+  const isSearchDebouncing = searchData !== debouncedSearchData;
+  const trimmedDebouncedSearchData = debouncedSearchData.trim();
+  const searchListItems = trimmedDebouncedSearchData.length
+    ? mapBusServicesToListItems(areaId, searchResults)
+    : [];
+  const isAZImportLoading = activeAZImportState.status === AZ_IMPORT_STATUS.LOADING;
+  const hasSearchError = getHasSearchError({
+    activeFilterId: activeFilter.id,
+    isSearchDebouncing,
+    isSearchError,
+    trimmedDebouncedSearchData
+  });
+  const hasAZError = getHasAZError({
+    activeAZImportState,
+    activeFilterId: activeFilter.id,
+    isServicesError,
+    results,
+    selectedAZCharacter
+  });
+  const listLoading = getListLoading({
+    activeFilterId: activeFilter.id,
+    hasAZError,
+    isAZImportLoading,
+    isListLoading,
+    isLoadingSearchResults,
+    searchResults
+  });
   const listItems = getVisibleListItems({
     areaId,
     filteredListState,
-    isListLoading,
+    isListLoading: listLoading,
     lifeSituations,
+    searchResults: searchListItems,
+    selectedAZCharacter,
     selectedFilterId: activeFilter.id,
     top10
   });
+  const fetchMoreData = getFetchMoreData({
+    fetchNextSearchPage,
+    hasNextSearchPage,
+    isFetchingNextSearchPage,
+    isSearchDebouncing,
+    selectedFilterId: activeFilter.id
+  });
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedSearchData(searchData);
+    }, BUS_SEARCH_DEBOUNCE_MS);
+
+    return () => clearTimeout(timeoutId);
+  }, [searchData]);
+
+  useEffect(() => {
+    setSearchData('');
+    setDebouncedSearchData('');
+  }, [areaId]);
+
+  useEffect(() => {
+    if (!fetchNextServicesPage) {
+      return;
+    }
+
+    if (activeFilter.id !== FILTER_IDS.ATOZ || !selectedAZCharacter) {
+      return;
+    }
+
+    if (isFetchingNextServicesPage) {
+      return;
+    }
+
+    const isNewSelection = activeAZImportState.key !== activeAZImportKey;
+
+    if (!hasNextServicesPage) {
+      return;
+    }
+
+    if (!isNewSelection && activeAZImportState.status !== AZ_IMPORT_STATUS.IDLE) {
+      return;
+    }
+
+    let isCancelled = false;
+
+    const loadAllServicePagesForAZ = async () => {
+      setAZImportState({
+        key: activeAZImportKey,
+        status: AZ_IMPORT_STATUS.LOADING
+      });
+
+      try {
+        let shouldContinue = true;
+        let previousLoadedItemsCount = -1;
+
+        while (shouldContinue) {
+          const nextPageResult = await fetchNextServicesPage();
+
+          if (isCancelled) {
+            break;
+          }
+
+          const pages = nextPageResult?.data?.pages ?? [];
+          const lastPage = pages[pages.length - 1];
+          const loadedItemsCount = pages.reduce(
+            (count, page) => count + (page?.items?.length ?? 0),
+            0
+          );
+
+          const hasLoadedMoreItems = loadedItemsCount > previousLoadedItemsCount;
+          previousLoadedItemsCount = loadedItemsCount;
+
+          shouldContinue =
+            hasLoadedMoreItems && loadedItemsCount < (lastPage?.totalItemCount ?? loadedItemsCount);
+        }
+
+        if (!isCancelled) {
+          setAZImportState({
+            key: activeAZImportKey,
+            status: AZ_IMPORT_STATUS.COMPLETE
+          });
+        }
+      } catch (error) {
+        console.warn('BUS A-Z full import failed', error);
+
+        if (!isCancelled) {
+          setAZImportState({
+            key: activeAZImportKey,
+            status: AZ_IMPORT_STATUS.ERROR
+          });
+        }
+      }
+    };
+
+    loadAllServicePagesForAZ();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [
+    activeFilter.id,
+    activeAZImportKey,
+    fetchNextServicesPage,
+    hasNextServicesPage,
+    isFetchingNextServicesPage
+  ]);
 
   const listHeaderComponent =
     activeFilter.id === FILTER_IDS.LIFE_SITUATIONS ? (
@@ -145,26 +423,41 @@ export const ServiceList = ({
       />
     ) : (
       <IndexFilter
+        AZFilterData={AZFilterData}
         selectedFilter={activeFilter}
         results={results}
-        listItems={listItems}
-        setListItems={setFilteredListItems}
         areaId={areaId}
         areaName={areaName}
         initialAreaId={initialAreaId}
         initialAreaName={initialAreaName}
+        searchData={searchData}
         setArea={setArea}
-        loading={isListLoading}
+        loading={listLoading}
+        listItems={listItems}
+        setAZFilterData={setAZFilterData}
+        setSearchData={setSearchData}
+        setListItems={setFilteredListItems}
       />
     );
-
-  const listEmptyComponent =
+  const hasLifeSituationsEmptyState =
     activeFilter.id === FILTER_IDS.LIFE_SITUATIONS &&
     !!areaId &&
     !isListLoading &&
-    !!lifeSituationsEmptyStateMessage ? (
+    !!lifeSituationsEmptyStateMessage;
+  let listEmptyComponent = null;
+
+  if (hasSearchError || hasAZError) {
+    listEmptyComponent = (
+      <EmptyMessage
+        title={hasSearchError ? texts.bus.emptyStates.search : texts.bus.emptyStates.services}
+        showIcon={false}
+      />
+    );
+  } else if (hasLifeSituationsEmptyState) {
+    listEmptyComponent = (
       <LifeSituationsEmptyState message={lifeSituationsEmptyStateMessage} />
-    ) : null;
+    );
+  }
 
   return (
     <VerticalList
@@ -176,19 +469,25 @@ export const ServiceList = ({
       noSubtitle={activeFilter.id !== FILTER_IDS.LIFE_SITUATIONS}
       ListEmptyComponent={listEmptyComponent}
       ListHeaderComponent={listHeaderComponent}
-      isLoading={isListLoading}
+      fetchMoreData={fetchMoreData}
+      isLoading={listLoading}
       showBackToTop
       refreshControl={refreshControl}
     />
   );
 };
+/* eslint-enable complexity */
 
 ServiceList.propTypes = {
   areaId: areaIdPropType,
   areaName: PropTypes.string,
+  fetchNextServicesPage: PropTypes.func,
+  hasNextServicesPage: PropTypes.bool,
   initialAreaId: areaIdPropType,
   initialAreaName: PropTypes.string,
+  isFetchingNextServicesPage: PropTypes.bool,
   isListLoading: PropTypes.bool.isRequired,
+  isServicesError: PropTypes.bool,
   lifeSituationsEmptyStateMessage: PropTypes.string,
   lifeSituations: PropTypes.array,
   navigation: PropTypes.object.isRequired,

--- a/src/components/BUS/TextSearch.js
+++ b/src/components/BUS/TextSearch.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { memo } from 'react';
+import React, { memo, useEffect, useRef } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import { SearchBar } from 'react-native-elements';
 
@@ -31,8 +31,17 @@ ClearIcon.propTypes = {
   onPress: PropTypes.func.isRequired
 };
 
-export const TextSearch = memo(({ data, setData, label, placeholder }) => {
+export const TextSearch = memo(({ blurSignal = 0, data, setData, label, placeholder }) => {
+  const inputRef = useRef(null);
   const clearSearch = () => setData('');
+
+  useEffect(() => {
+    if (!blurSignal) {
+      return;
+    }
+
+    inputRef.current?.blur?.();
+  }, [blurSignal]);
 
   return (
     <View>
@@ -41,6 +50,7 @@ export const TextSearch = memo(({ data, setData, label, placeholder }) => {
       </WrapperHorizontal>
       <SearchBar
         clearIcon={() => <ClearIcon onPress={clearSearch} />}
+        inputRef={inputRef}
         value={data}
         onChangeText={(value) => setData(value)}
         onClearText={clearSearch}
@@ -92,6 +102,7 @@ const styles = StyleSheet.create({
 
 TextSearch.displayName = 'TextSearch';
 TextSearch.propTypes = {
+  blurSignal: PropTypes.number,
   data: PropTypes.string.isRequired,
   setData: PropTypes.func.isRequired,
   label: PropTypes.string,

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -114,7 +114,8 @@ const styles = StyleSheet.create({
     backgroundColor: colors.primary
   },
   bigButton: {
-    height: normalize(56)
+    minHeight: normalize(56),
+    paddingVertical: normalize(10)
   },
   bigButtonRadius: {
     borderRadius: normalize(8)
@@ -123,7 +124,10 @@ const styles = StyleSheet.create({
     fontSize: normalize(14)
   },
   button: {
-    height: normalize(48)
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: normalize(48),
+    paddingVertical: normalize(8)
   },
   buttonDisabled: {
     backgroundColor: colors.placeholder
@@ -170,13 +174,15 @@ const styles = StyleSheet.create({
     backgroundColor: colors.error
   },
   smallButton: {
-    height: normalize(40)
+    minHeight: normalize(40),
+    paddingVertical: normalize(6)
   },
   smallButtonRadius: {
     borderRadius: normalize(40)
   },
   smallestButton: {
-    height: normalize(32)
+    minHeight: normalize(32),
+    paddingVertical: normalize(4)
   },
   smallestButtonRadius: {
     borderRadius: normalize(32)
@@ -191,7 +197,8 @@ const styles = StyleSheet.create({
     color: colors.lightestText,
     fontFamily: 'bold',
     fontSize: normalize(14),
-    fontWeight: '600'
+    fontWeight: '600',
+    textAlign: 'center'
   },
   titleInvert: {
     color: colors.primary

--- a/src/components/VerticalList.js
+++ b/src/components/VerticalList.js
@@ -60,8 +60,9 @@ export const VerticalList = ({
       // if there is a pagination, the end of the list is reached, when no more data is returned
       // from partially fetching, so we need to check the data to determine the lists end
       const { data: moreData } = await fetchMoreData();
+      const moreItems = query ? moreData?.[query] ?? [] : moreData ?? [];
 
-      setListEndReached(!moreData[query].length);
+      setListEndReached(!moreItems.length);
     } else {
       setListEndReached(true);
     }

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -88,7 +88,9 @@ export const texts = {
       lifeSituations:
         'Für diese Lebenslage sind derzeit keine Unterkategorien oder Leistungen verfügbar.',
       lifeSituationsNested: 'Diese Lebenslage konnte derzeit nicht geladen werden.',
-      lifeSituationsRoot: 'Die Lebenslagen konnten derzeit nicht geladen werden.'
+      lifeSituationsRoot: 'Die Lebenslagen konnten derzeit nicht geladen werden.',
+      search: 'Die Suchergebnisse konnten derzeit nicht geladen werden.',
+      services: 'Die Dienstleistungen konnten derzeit nicht geladen werden.'
     },
     employees: 'Ansprechpartner',
     initialFilter: {

--- a/src/helpers/busDetailHelper.js
+++ b/src/helpers/busDetailHelper.js
@@ -1,0 +1,130 @@
+import _sortBy from 'lodash/sortBy';
+
+const TEXT_BLOCKS_SORTER = {
+  Kurztext: 0,
+  Volltext: 1,
+  Ansprechpartner: 2,
+  'Erforderliche Unterlagen': 3,
+  Voraussetzungen: 4,
+  Bearbeitungsdauer: 5,
+  Verfahrensablauf: 6,
+  Formulare: 7,
+  Fristen: 8,
+  'Kosten (Gebühren, Auslagen, etc.)': 9,
+  'Rechtsgrundlage(n)': 10,
+  'Hinweise (Besonderheiten)': 11,
+  Urheber: 12,
+  'Weiterführende Informationen': 13,
+  Ansprechpunkt: 14,
+  'Zuständige Stelle': 15
+};
+
+const HIDDEN_TEXT_BLOCKS = new Set([
+  'TEASER',
+  'FACHLICH FREIGEGEBEN DURCH',
+  'FACHLICH FREIGEGEBEN AM',
+  'TYPISIERUNG',
+  'STATUS KATALOGEINTRAG',
+  'STATUS BIBLIOTHEKSEINTRAG'
+]);
+
+const FIRST_TEXT_BLOCKS = new Set(['KURZTEXT', 'VOLLTEXT']);
+const COMMUNICATION_PROTOCOLS = {
+  EMAIL: 'mailto:',
+  TELEFON: 'tel:',
+  WWW: ''
+};
+
+const toArray = (value) => (Array.isArray(value) ? value.filter(Boolean) : []);
+
+const getActionName = (action) =>
+  action?.name || action?.title || action?.publicName || action?.label || action?.description;
+
+const getActionLinks = (action) => {
+  const directLinks = toArray(action?.links).map((link) => ({
+    name: getActionName(link),
+    url: link?.url || link?.href || link?.uri
+  }));
+  const urlLinks = [action?.url, action?.href, action?.uri, action?.portalLink]
+    .filter(Boolean)
+    .map((url) => ({ url }));
+  const communicationLinks = toArray(action?.communications)
+    .map((communication) => {
+      const protocol = COMMUNICATION_PROTOCOLS[communication?.type?.key];
+      const value = communication?.value?.trim();
+
+      if (!value || protocol === undefined) {
+        return null;
+      }
+
+      return {
+        url: `${protocol}${value}`
+      };
+    })
+    .filter(Boolean);
+
+  return [...directLinks, ...urlLinks, ...communicationLinks].filter((link) => !!link.url);
+};
+
+const normalizeTopAction = (action, kind) => {
+  const name = getActionName(action);
+  const links = getActionLinks(action);
+
+  if (!links.length || (!name && kind !== 'form')) {
+    return null;
+  }
+
+  return {
+    kind,
+    links,
+    name
+  };
+};
+
+const getTopLevelOnlineServices = (service = {}) => {
+  return [
+    ...toArray(service.onlineServices),
+    ...toArray(service.onlinedienste),
+    ...toArray(service.onlineDienste),
+    ...toArray(service.onlineDienstleistungen)
+  ];
+};
+
+export const getBusTopActions = (service = {}) => {
+  const onlineServices = getTopLevelOnlineServices(service)
+    .map((onlineService) => normalizeTopAction(onlineService, 'onlineService'))
+    .filter(Boolean);
+  const forms = toArray(service.organisationalUnits)
+    .flatMap((organisationalUnit) => toArray(organisationalUnit?.forms))
+    .map((form) => normalizeTopAction(form, 'form'))
+    .filter(Boolean);
+
+  return [...onlineServices, ...forms];
+};
+
+export const getBusVisibleTextBlocks = (service = {}) => {
+  return _sortBy(
+    toArray(service.textBlocks).map((textBlock) => textBlock?.textBlock || textBlock),
+    (textBlock) => {
+      return TEXT_BLOCKS_SORTER[textBlock?.type?.name];
+    }
+  )
+    .filter((textBlock) => {
+      const typeName = textBlock?.type?.name?.toUpperCase();
+
+      return !typeName || !HIDDEN_TEXT_BLOCKS.has(typeName);
+    });
+};
+
+export const splitBusTextBlocks = (service = {}) => {
+  const visibleTextBlocks = getBusVisibleTextBlocks(service);
+
+  return {
+    firstTextBlocks: visibleTextBlocks.filter((textBlock) =>
+      FIRST_TEXT_BLOCKS.has(textBlock?.type?.name?.toUpperCase())
+    ),
+    sortedTextBlocks: visibleTextBlocks.filter(
+      (textBlock) => !FIRST_TEXT_BLOCKS.has(textBlock?.type?.name?.toUpperCase())
+    )
+  };
+};

--- a/src/helpers/busListHelper.js
+++ b/src/helpers/busListHelper.js
@@ -1,0 +1,58 @@
+import _filter from 'lodash/filter';
+import _sortBy from 'lodash/sortBy';
+
+import { shareMessage } from './BUS/shareHelper';
+
+const normalizeName = (value) => `${value ?? ''}`.trim().toLowerCase();
+
+export const resolveBusCategoryServices = (category, services = []) => {
+  const servicesById = new Map(
+    services
+      .filter((service) => service?.id !== null && service?.id !== undefined)
+      .map((service) => [`${service.id}`, service])
+  );
+  const servicesByName = new Map(
+    services
+      .filter((service) => !!normalizeName(service?.name))
+      .map((service) => [normalizeName(service.name), service])
+  );
+
+  return (category?.publicServiceTypes ?? [])
+    .map((serviceReference) => {
+      const serviceId = serviceReference?.id;
+      const serviceName = serviceReference?.name;
+
+      return (
+        servicesById.get(`${serviceId ?? ''}`) ||
+        servicesByName.get(normalizeName(serviceName)) || {
+          id: serviceId,
+          name: serviceName
+        }
+      );
+    })
+    .filter(
+      (service) =>
+        service?.id !== null && service?.id !== undefined && !!normalizeName(service?.name)
+    );
+};
+
+export const mapBusServicesToListItems = (areaId, services = []) =>
+  _sortBy(
+    _filter(services, (busService) => !!busService?.name),
+    (busService) => busService.name.toUpperCase()
+  ).map((busService) => ({
+    id: busService.id,
+    title: busService.name,
+    routeName: 'BusDetail',
+    params: {
+      areaId,
+      title: busService.name,
+      query: '',
+      queryVariables: {},
+      rootRouteName: 'BUS',
+      shareContent: {
+        message: shareMessage(busService)
+      },
+      data: busService
+    }
+  }));

--- a/src/helpers/busListHelper.js
+++ b/src/helpers/busListHelper.js
@@ -1,5 +1,8 @@
 import _filter from 'lodash/filter';
 import _sortBy from 'lodash/sortBy';
+import { Keyboard } from 'react-native';
+
+import { ScreenName } from '../types';
 
 import { shareMessage } from './BUS/shareHelper';
 
@@ -42,8 +45,22 @@ export const mapBusServicesToListItems = (areaId, services = []) =>
     (busService) => busService.name.toUpperCase()
   ).map((busService) => ({
     id: busService.id,
+    onPress: (navigation) => {
+      Keyboard.dismiss();
+      navigation?.push(ScreenName.BusDetail, {
+        areaId,
+        title: busService.name,
+        query: '',
+        queryVariables: {},
+        rootRouteName: 'BUS',
+        shareContent: {
+          message: shareMessage(busService)
+        },
+        data: busService
+      });
+    },
     title: busService.name,
-    routeName: 'BusDetail',
+    routeName: ScreenName.BusDetail,
     params: {
       areaId,
       title: busService.name,

--- a/src/hooks/bus.ts
+++ b/src/hooks/bus.ts
@@ -1,11 +1,12 @@
 import _sortBy from 'lodash/sortBy';
 import { useContext } from 'react';
-import { useQuery } from 'react-query';
+import { useInfiniteQuery, useQuery } from 'react-query';
 
 import {
+  DEFAULT_LIST_LIMIT,
   findBusCategoryChildren,
   findBusCategoryRoot,
-  findPublicServices,
+  findPublicServicesPage,
   getPoliticalArea,
   getPublicService,
   searchPoliticalAreas
@@ -31,6 +32,7 @@ const BUS_QUERY_KEYS = {
   LIFE_SITUATIONS_ROOT: 'life-situations-root',
   ROOT: 'bus',
   SERVICE: 'service',
+  SERVICE_SEARCH: 'service-search',
   SERVICES: 'services',
   INITIAL_AREA: 'initial-area',
   TOP10: 'top10'
@@ -40,6 +42,13 @@ export const DEFAULT_BUS_LIFE_SITUATIONS_ROOT_SEARCH_WORD =
   'Lebenslagen für Bürgerinnen und Bürger';
 export const BUS_MIN_SEARCH_LENGTH = 3;
 export const BUS_SEARCH_DEBOUNCE_MS = 400;
+const BUS_QUERY_RETRY_COUNT = 0;
+
+const flattenServicePages = (pages?: { items?: BusServiceListItem[] }[]) =>
+  _sortBy(
+    (pages ?? []).flatMap((page) => page?.items ?? []),
+    (item) => item.name?.toUpperCase()
+  );
 
 // Avoid leaking the raw API key into React Query devtools while still changing the cache key
 // when credentials change.
@@ -78,6 +87,7 @@ const useBusSettings = (): BusSettings => {
 export const useBusAreas = (searchTerm: string = '', isEnabled: boolean = true) => {
   const bus = useBusSettings();
   const hasBusConfig = !!bus.uri;
+  const busQueryConfigKey = getBusQueryConfigKey(bus);
   const isQueryEnabled =
     isEnabled && hasBusConfig && searchTerm.trim().length >= BUS_MIN_SEARCH_LENGTH;
 
@@ -85,7 +95,7 @@ export const useBusAreas = (searchTerm: string = '', isEnabled: boolean = true) 
     BusAreaSearchResult[],
     Error
   >(
-    [BUS_QUERY_KEYS.ROOT, BUS_QUERY_KEYS.AREAS, searchTerm],
+    [BUS_QUERY_KEYS.ROOT, BUS_QUERY_KEYS.AREAS, searchTerm, busQueryConfigKey],
     () => searchPoliticalAreas({ searchTerm, bus }),
     {
       enabled: isQueryEnabled,
@@ -166,17 +176,107 @@ export const useBusServices = (areaId: AreaId) => {
   const hasBusConfig = !!bus.uri && !!areaId;
   const busQueryConfigKey = getBusQueryConfigKey(bus);
 
-  const { data, isFetching, isLoading, refetch } = useQuery<BusServiceListItem[]>(
+  const {
+    data,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isError,
+    isFetching,
+    isFetchingNextPage,
+    isLoading,
+    refetch
+  } = useInfiniteQuery(
     [BUS_QUERY_KEYS.ROOT, BUS_QUERY_KEYS.SERVICES, areaId, busQueryConfigKey],
-    () => findPublicServices({ areaId, bus }),
+    ({ pageParam = 0 }) =>
+      findPublicServicesPage({
+        areaId,
+        bus,
+        limit: DEFAULT_LIST_LIMIT,
+        offset: pageParam
+      }),
     {
-      enabled: hasBusConfig
+      enabled: hasBusConfig,
+      retry: BUS_QUERY_RETRY_COUNT,
+      getNextPageParam: (lastPage, pages) => {
+        const loadedItemsCount = pages.reduce(
+          (count, page) => count + (page?.items?.length ?? 0),
+          0
+        );
+
+        return loadedItemsCount < lastPage.totalItemCount ? loadedItemsCount : undefined;
+      }
     }
   );
 
   return {
-    data: _sortBy(data ?? [], (item) => item.name?.toUpperCase()),
+    data: flattenServicePages(data?.pages),
+    error,
+    fetchNextPage,
+    hasNextPage: !!hasNextPage,
+    isError,
     isFetching,
+    isFetchingNextPage,
+    isLoading,
+    refetch
+  };
+};
+
+export const useBusServiceSearch = (areaId: AreaId, searchTerm: string = '') => {
+  const bus = useBusSettings();
+  const trimmedSearchTerm = searchTerm.trim();
+  const hasBusConfig = !!bus.uri && !!areaId;
+  const isQueryEnabled = hasBusConfig && trimmedSearchTerm.length >= BUS_MIN_SEARCH_LENGTH;
+  const busQueryConfigKey = getBusQueryConfigKey(bus);
+
+  const {
+    data,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isError,
+    isFetching,
+    isFetchingNextPage,
+    isLoading,
+    refetch
+  } = useInfiniteQuery(
+    [
+      BUS_QUERY_KEYS.ROOT,
+      BUS_QUERY_KEYS.SERVICE_SEARCH,
+      areaId,
+      trimmedSearchTerm,
+      busQueryConfigKey
+    ],
+    ({ pageParam = 0 }) =>
+      findPublicServicesPage({
+        areaId,
+        bus,
+        limit: DEFAULT_LIST_LIMIT,
+        offset: pageParam,
+        searchWord: trimmedSearchTerm
+      }),
+    {
+      enabled: isQueryEnabled,
+      retry: BUS_QUERY_RETRY_COUNT,
+      getNextPageParam: (lastPage, pages) => {
+        const loadedItemsCount = pages.reduce(
+          (count, page) => count + (page?.items?.length ?? 0),
+          0
+        );
+
+        return loadedItemsCount < lastPage.totalItemCount ? loadedItemsCount : undefined;
+      }
+    }
+  );
+
+  return {
+    data: flattenServicePages(data?.pages),
+    error,
+    fetchNextPage,
+    hasNextPage: !!hasNextPage,
+    isError,
+    isFetching,
+    isFetchingNextPage,
     isLoading,
     refetch
   };

--- a/src/queries/bus.js
+++ b/src/queries/bus.js
@@ -1,9 +1,10 @@
 export const DEFAULT_LIST_LIMIT = 500;
 export const BUS_REQUEST_TIMEOUT_MS = 15000;
-const ROOT_CATEGORY_SELECT_ATTRIBUTES = ['id', 'name']
-  .map((attribute) => `&selectAttributes[]=${attribute}`)
-  .join('');
-const CHILD_CATEGORY_SELECT_ATTRIBUTES = [
+const buildSelectAttributesQuery = (attributes) =>
+  attributes.length ? `&selectAttributes=${attributes.join(',')}` : '';
+
+const ROOT_CATEGORY_SELECT_ATTRIBUTES = buildSelectAttributesQuery(['id', 'name']);
+const CHILD_CATEGORY_SELECT_ATTRIBUTES = buildSelectAttributesQuery([
   'id',
   'name',
   'description',
@@ -11,9 +12,7 @@ const CHILD_CATEGORY_SELECT_ATTRIBUTES = [
   'position',
   'image',
   'publicServiceTypes'
-]
-  .map((attribute) => `&selectAttributes[]=${attribute}`)
-  .join('');
+]);
 
 const createRequestOptions = (apiKey) => ({
   headers: {
@@ -73,24 +72,14 @@ const BUS_LEGACY_DETAIL_FALLBACK_STATUSES = new Set([404, 405, 501]);
 const normalizePublicServiceSearchWord = (searchWord) =>
   `${searchWord ?? ''}`.trim().replace(/\s+/g, ' ');
 
-const buildPublicServiceFindUrl = ({
-  areaId,
-  baseUrl,
-  limit,
-  offset,
-  searchWord,
-  endpoint,
-  useCommaSeparatedSelectAttributes = false
-}) => {
+const buildPublicServiceFindUrl = ({ areaId, baseUrl, limit, offset, searchWord, endpoint }) => {
   const encodedSearchWord = encodeURIComponent(normalizePublicServiceSearchWord(searchWord));
   const encodedOffset = encodeURIComponent(offset);
   const encodedLimit = encodeURIComponent(limit);
   const commonQuery = `?areaId=${encodeURIComponent(
     areaId
   )}&limit=${encodedLimit}&offset=${encodedOffset}`;
-  const selectAttributes = useCommaSeparatedSelectAttributes
-    ? '&selectAttributes=id,name,teaser'
-    : ['&selectAttributes[]=id', '&selectAttributes[]=name', '&selectAttributes[]=teaser'].join('');
+  const selectAttributes = buildSelectAttributesQuery(['id', 'name']);
 
   return `${baseUrl}/${endpoint}${commonQuery}&searchWord=${encodedSearchWord}${selectAttributes}`;
 };
@@ -127,8 +116,7 @@ export const findPublicServicesPage = async ({
     endpoint,
     limit,
     offset,
-    searchWord: normalizedSearchWord,
-    useCommaSeparatedSelectAttributes: !!normalizedSearchWord
+    searchWord: normalizedSearchWord
   });
   const { headers, payload } = await requestJson(requestUrl, apiKey);
   const items = (payload?.results || []).map((item) => item?.object).filter(Boolean);
@@ -187,7 +175,10 @@ export const getPublicService = async ({ areaId, bus, id }) => {
       throw error;
     }
 
-    ({ payload } = await requestJson(`${baseUrl}/pst/${encodedId}?areaId=${encodedAreaId}`, apiKey));
+    ({ payload } = await requestJson(
+      `${baseUrl}/pst/${encodedId}?areaId=${encodedAreaId}`,
+      apiKey
+    ));
   }
 
   return payload?.object || payload;

--- a/src/queries/bus.js
+++ b/src/queries/bus.js
@@ -1,4 +1,5 @@
-const DEFAULT_LIST_LIMIT = 1000;
+export const DEFAULT_LIST_LIMIT = 500;
+export const BUS_REQUEST_TIMEOUT_MS = 15000;
 const ROOT_CATEGORY_SELECT_ATTRIBUTES = ['id', 'name']
   .map((attribute) => `&selectAttributes[]=${attribute}`)
   .join('');
@@ -24,13 +25,74 @@ const createRequestOptions = (apiKey) => ({
 });
 
 const requestJson = async (url, apiKey) => {
-  const response = await fetch(url, createRequestOptions(apiKey));
+  const controller = new AbortController();
+  let timeoutId;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => {
+      controller.abort();
+      const timeoutError = new Error(`BUS API request timed out for ${url}`);
+      timeoutError.code = 'BUS_API_TIMEOUT';
+      reject(timeoutError);
+    }, BUS_REQUEST_TIMEOUT_MS);
+  });
 
-  if (!response.ok) {
-    throw new Error(`BUS API request failed (${response.status}) for ${url}`);
+  try {
+    const response = await Promise.race([
+      fetch(url, {
+        ...createRequestOptions(apiKey),
+        signal: controller.signal
+      }),
+      timeoutPromise
+    ]);
+
+    if (!response.ok) {
+      const requestError = new Error(`BUS API request failed (${response.status}) for ${url}`);
+      requestError.status = response.status;
+      throw requestError;
+    }
+
+    return {
+      headers: response.headers,
+      payload: await response.json()
+    };
+  } catch (error) {
+    if (error?.name === 'AbortError' && error?.code !== 'BUS_API_TIMEOUT') {
+      const abortError = new Error(`BUS API request timed out for ${url}`);
+      abortError.code = 'BUS_API_TIMEOUT';
+      throw abortError;
+    }
+
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
   }
+};
 
-  return response.json();
+const BUS_LEGACY_DETAIL_FALLBACK_STATUSES = new Set([404, 405, 501]);
+
+const normalizePublicServiceSearchWord = (searchWord) =>
+  `${searchWord ?? ''}`.trim().replace(/\s+/g, ' ');
+
+const buildPublicServiceFindUrl = ({
+  areaId,
+  baseUrl,
+  limit,
+  offset,
+  searchWord,
+  endpoint,
+  useCommaSeparatedSelectAttributes = false
+}) => {
+  const encodedSearchWord = encodeURIComponent(normalizePublicServiceSearchWord(searchWord));
+  const encodedOffset = encodeURIComponent(offset);
+  const encodedLimit = encodeURIComponent(limit);
+  const commonQuery = `?areaId=${encodeURIComponent(
+    areaId
+  )}&limit=${encodedLimit}&offset=${encodedOffset}`;
+  const selectAttributes = useCommaSeparatedSelectAttributes
+    ? '&selectAttributes=id,name,teaser'
+    : ['&selectAttributes[]=id', '&selectAttributes[]=name', '&selectAttributes[]=teaser'].join('');
+
+  return `${baseUrl}/${endpoint}${commonQuery}&searchWord=${encodedSearchWord}${selectAttributes}`;
 };
 
 const mapPoliticalArea = (area) => {
@@ -44,23 +106,35 @@ const mapPoliticalArea = (area) => {
 };
 
 export const findPublicServices = async ({ areaId, bus, searchWord = '' }) => {
+  const { items } = await findPublicServicesPage({ areaId, bus, searchWord });
+
+  return items;
+};
+
+export const findPublicServicesPage = async ({
+  areaId,
+  bus,
+  limit = DEFAULT_LIST_LIMIT,
+  offset = 0,
+  searchWord = ''
+}) => {
   const { apiKey, uri: baseUrl } = bus;
-  const encodedSearchWord = encodeURIComponent(searchWord);
-  const commonQuery = `?areaId=${encodeURIComponent(areaId)}&limit=${DEFAULT_LIST_LIMIT}`;
-  const selectAttributes = [
-    '&selectAttributes[]=id',
-    '&selectAttributes[]=externalId',
-    '&selectAttributes[]=name',
-    '&selectAttributes[]=teaser'
-  ].join('');
+  const normalizedSearchWord = normalizePublicServiceSearchWord(searchWord);
+  const endpoint = normalizedSearchWord ? 'pstExtended/find' : 'pst/find';
+  const requestUrl = buildPublicServiceFindUrl({
+    areaId,
+    baseUrl,
+    endpoint,
+    limit,
+    offset,
+    searchWord: normalizedSearchWord,
+    useCommaSeparatedSelectAttributes: !!normalizedSearchWord
+  });
+  const { headers, payload } = await requestJson(requestUrl, apiKey);
+  const items = (payload?.results || []).map((item) => item?.object).filter(Boolean);
+  const totalItemCount = Number(headers?.get?.('total-item-count')) || items.length;
 
-  const payload = await requestJson(
-    `${baseUrl}/pst/find${commonQuery}&searchWord=${encodedSearchWord}${selectAttributes}`,
-    apiKey
-  );
-  const services = (payload?.results || []).map((item) => item?.object);
-
-  return services;
+  return { items, totalItemCount };
 };
 
 export const findBusCategoryRoot = async ({ areaId, bus, searchWord }) => {
@@ -71,7 +145,7 @@ export const findBusCategoryRoot = async ({ areaId, bus, searchWord }) => {
 
   const encodedSearchWord = encodeURIComponent(normalizedSearchWord);
   const areaIdQuery = areaId ? `&areaId=${encodeURIComponent(areaId)}` : '';
-  const payload = await requestJson(
+  const { payload } = await requestJson(
     `${baseUrl}/pstCategory/find?searchWord=${encodedSearchWord}&limit=${DEFAULT_LIST_LIMIT}${areaIdQuery}${ROOT_CATEGORY_SELECT_ATTRIBUTES}`,
     apiKey
   );
@@ -88,7 +162,7 @@ export const findBusCategoryChildren = async ({ areaId, bus, parentId }) => {
   const { apiKey, uri: baseUrl } = bus;
   const encodedParentId = encodeURIComponent(parentId);
   const areaIdQuery = areaId ? `&areaId=${encodeURIComponent(areaId)}` : '';
-  const payload = await requestJson(
+  const { payload } = await requestJson(
     `${baseUrl}/pstCategory/find?parentId=${encodedParentId}&limit=${DEFAULT_LIST_LIMIT}${areaIdQuery}${CHILD_CATEGORY_SELECT_ATTRIBUTES}`,
     apiKey
   );
@@ -101,7 +175,20 @@ export const getPublicService = async ({ areaId, bus, id }) => {
   const { apiKey, uri: baseUrl } = bus;
   const encodedAreaId = encodeURIComponent(areaId);
   const encodedId = encodeURIComponent(id);
-  const payload = await requestJson(`${baseUrl}/pst/${encodedId}?areaId=${encodedAreaId}`, apiKey);
+  let payload;
+
+  try {
+    ({ payload } = await requestJson(
+      `${baseUrl}/pstExtended/${encodedId}?areaId=${encodedAreaId}`,
+      apiKey
+    ));
+  } catch (error) {
+    if (!BUS_LEGACY_DETAIL_FALLBACK_STATUSES.has(error?.status)) {
+      throw error;
+    }
+
+    ({ payload } = await requestJson(`${baseUrl}/pst/${encodedId}?areaId=${encodedAreaId}`, apiKey));
+  }
 
   return payload?.object || payload;
 };
@@ -109,7 +196,7 @@ export const getPublicService = async ({ areaId, bus, id }) => {
 export const getPoliticalArea = async ({ areaId, bus }) => {
   const { apiKey, uri: baseUrl } = bus;
   const encodedAreaId = encodeURIComponent(areaId);
-  const payload = await requestJson(`${baseUrl}/political-area/${encodedAreaId}`, apiKey);
+  const { payload } = await requestJson(`${baseUrl}/political-area/${encodedAreaId}`, apiKey);
 
   return mapPoliticalArea(payload);
 };
@@ -130,7 +217,10 @@ export const searchPoliticalAreas = async ({ searchTerm = '', bus }) => {
   const searchWordsQuery = sanitizedSearchWords
     .map((word) => `searchWords=${encodeURIComponent(word + '*')}`)
     .join('&');
-  const payload = await requestJson(`${baseUrl}/political-area/search?${searchWordsQuery}`, apiKey);
+  const { payload } = await requestJson(
+    `${baseUrl}/political-area/search?${searchWordsQuery}`,
+    apiKey
+  );
 
   return Array.isArray(payload?.values) ? payload.values : [];
 };

--- a/src/screens/BUS/DetailScreen.js
+++ b/src/screens/BUS/DetailScreen.js
@@ -1,5 +1,3 @@
-import _remove from 'lodash/remove';
-import _sortBy from 'lodash/sortBy';
 import PropTypes from 'prop-types';
 import React, { useContext, useRef, useState } from 'react';
 import { RefreshControl, ScrollView, StyleSheet, View } from 'react-native';
@@ -12,31 +10,13 @@ import { FeedbackFooter } from '../../components/FeedbackFooter';
 import { LoadingSpinner } from '../../components/LoadingSpinner';
 import { colors, consts, device, normalize } from '../../config';
 import { matomoTrackingString, openLink } from '../../helpers';
+import { getBusTopActions, splitBusTextBlocks } from '../../helpers/busDetailHelper';
 import { useBusService, useMatomoTrackScreenView, useOpenWebScreen } from '../../hooks';
 import { SettingsContext } from '../../SettingsProvider';
 
 const { MATOMO_TRACKING } = consts;
 
 const uniqueId = (name) => name.split('').reduce((a, b) => ((a << 5) - a + b.charCodeAt(0)) | 0, 0);
-
-const TEXT_BLOCKS_SORTER = {
-  Kurztext: 0,
-  Volltext: 1,
-  Ansprechpartner: 2,
-  'Erforderliche Unterlagen': 3,
-  Voraussetzungen: 4,
-  Bearbeitungsdauer: 5,
-  Verfahrensablauf: 6,
-  Formulare: 7,
-  Fristen: 8,
-  'Kosten (Gebühren, Auslagen, etc.)': 9,
-  'Rechtsgrundlage(n)': 10,
-  'Hinweise (Besonderheiten)': 11,
-  Urheber: 12,
-  'Weiterführende Informationen': 13,
-  Ansprechpunkt: 14,
-  'Zuständige Stelle': 15
-};
 
 const FormButton = ({ headerTitle, link, name, rootRouteName }) => {
   const { url } = link;
@@ -56,50 +36,18 @@ const renderForm = (headerTitle, form, rootRouteName) => {
   const { links, name } = form;
 
   return links.map((link) => {
+    const buttonTitle = name || link?.name || 'Formular öffnen';
+
     return (
       <FormButton
         headerTitle={headerTitle}
         key={link.url}
         link={link}
-        name={name}
+        name={buttonTitle}
         rootRouteName={rootRouteName}
       />
     );
   });
-};
-
-const parseTextBlocks = (service) => {
-  const { textBlocks } = service;
-  let firstTextBlocks;
-  let sortedTextBlocks;
-
-  if (textBlocks) {
-    sortedTextBlocks = _sortBy(textBlocks, (textBlock) => {
-      return TEXT_BLOCKS_SORTER[textBlock.type.name];
-    });
-
-    // filter text blocks we want to render before authorities and persons
-    firstTextBlocks = _remove(sortedTextBlocks, (textBlock) => {
-      return (
-        textBlock.type.name.toUpperCase() === 'KURZTEXT' ||
-        textBlock.type.name.toUpperCase() === 'VOLLTEXT'
-      );
-    });
-
-    // filter text blocks, we do not want to render
-    _remove(sortedTextBlocks, (textBlock) => {
-      return (
-        textBlock.type.name.toUpperCase() === 'TEASER' ||
-        textBlock.type.name.toUpperCase() === 'FACHLICH FREIGEGEBEN DURCH' ||
-        textBlock.type.name.toUpperCase() === 'FACHLICH FREIGEGEBEN AM' ||
-        textBlock.type.name.toUpperCase() === 'TYPISIERUNG' ||
-        textBlock.type.name.toUpperCase() === 'STATUS KATALOGEINTRAG' ||
-        textBlock.type.name.toUpperCase() === 'STATUS BIBLIOTHEKSEINTRAG'
-      );
-    });
-  }
-
-  return { firstTextBlocks, sortedTextBlocks };
 };
 
 // eslint-disable-next-line complexity
@@ -143,10 +91,11 @@ export const DetailScreen = ({ route }) => {
   if (!service) return null;
 
   const { organisationalUnits, persons } = service;
-
-  const forms = organisationalUnits?.map((ou) => ou.forms).flat();
-
-  const { firstTextBlocks, sortedTextBlocks } = parseTextBlocks(service);
+  const topActions = getBusTopActions(service);
+  const { firstTextBlocks, sortedTextBlocks } = splitBusTextBlocks(service);
+  const hasAuthorities = !!organisationalUnits?.length;
+  const hasPersons = !!persons?.length;
+  const hasSortedTextBlocks = !!sortedTextBlocks?.length;
 
   return (
     <SafeAreaViewFlex>
@@ -164,9 +113,9 @@ export const DetailScreen = ({ route }) => {
           />
         }
       >
-        {!!forms?.length && (
+        {!!topActions.length && (
           <View style={styles.formContainer}>
-            {forms.map((form) => renderForm(headerTitle, form, rootRouteName))}
+            {topActions.map((action) => renderForm(headerTitle, action, rootRouteName))}
           </View>
         )}
 
@@ -176,7 +125,12 @@ export const DetailScreen = ({ route }) => {
           return (
             <TextBlock
               key={textBlock.type?.id || uniqueId(textBlock.type.name)}
-              bottomDivider={index == firstTextBlocks.length - 1}
+              bottomDivider={
+                index == firstTextBlocks.length - 1 &&
+                !hasAuthorities &&
+                !hasPersons &&
+                !hasSortedTextBlocks
+              }
               textBlock={textBlock}
               openWebScreen={openWebScreen}
             />
@@ -187,13 +141,19 @@ export const DetailScreen = ({ route }) => {
           <Authority
             key={ou.id}
             data={ou}
-            bottomDivider={index == organisationalUnits.length - 1}
+            bottomDivider={
+              index == organisationalUnits.length - 1 && !hasPersons && !hasSortedTextBlocks
+            }
             openWebScreen={openWebScreen}
           />
         ))}
 
         {!!persons?.length && (
-          <Persons data={{ id: details.id, persons }} openWebScreen={openWebScreen} />
+          <Persons
+            data={{ id: details.id, persons }}
+            bottomDivider={!hasSortedTextBlocks}
+            openWebScreen={openWebScreen}
+          />
         )}
 
         {sortedTextBlocks?.map((textBlock, index) => {

--- a/src/screens/BUS/IndexScreen.js
+++ b/src/screens/BUS/IndexScreen.js
@@ -1,7 +1,7 @@
 import _sortBy from 'lodash/sortBy';
 import PropTypes from 'prop-types';
 import React, { useContext, useMemo, useState } from 'react';
-import { RefreshControl } from 'react-native';
+import { Keyboard, RefreshControl } from 'react-native';
 
 import {
   DefaultKeyboardAvoidingView,
@@ -10,9 +10,9 @@ import {
 } from '../../components';
 import { ServiceList } from '../../components/BUS/ServiceList';
 import { colors, consts, texts } from '../../config';
-import { mapBusServicesToListItems, resolveBusCategoryServices } from '../../helpers/busListHelper';
 import { runAsyncTasksSafely, spaceNewLines } from '../../helpers';
 import { shareMessage } from '../../helpers/BUS/shareHelper';
+import { mapBusServicesToListItems, resolveBusCategoryServices } from '../../helpers/busListHelper';
 import {
   useBusCategoryChildren,
   useBusInitialArea,
@@ -22,6 +22,7 @@ import {
   useMatomoTrackScreenView
 } from '../../hooks';
 import { SettingsContext } from '../../SettingsProvider';
+import { ScreenName } from '../../types';
 
 const { MATOMO_TRACKING } = consts;
 
@@ -103,6 +104,15 @@ const getLifeSituationsItems = (areaId, category, childCategories = [], services
     ]
   ).map((childCategory) => ({
     id: childCategory.id,
+    onPress: (navigation) => {
+      Keyboard.dismiss();
+      navigation?.push(ScreenName.BusCategory, {
+        areaId,
+        category: childCategory,
+        isRootCategory: false,
+        title: childCategory.name
+      });
+    },
     picture: childCategory?.image?.url ? { url: childCategory.image.url } : undefined,
     subtitle: spaceNewLines(childCategory.description),
     title: childCategory.name,
@@ -118,8 +128,22 @@ const getLifeSituationsItems = (areaId, category, childCategories = [], services
     .filter((service) => hasValue(service?.id) && hasValue(service?.name))
     .map((service) => ({
       id: service.id,
+      onPress: (navigation) => {
+        Keyboard.dismiss();
+        navigation?.push(ScreenName.BusDetail, {
+          areaId,
+          title: service.name,
+          query: '',
+          queryVariables: {},
+          rootRouteName: 'BUS',
+          shareContent: {
+            message: shareMessage(service)
+          },
+          data: service
+        });
+      },
       title: service.name,
-      routeName: 'BusDetail',
+      routeName: ScreenName.BusDetail,
       params: {
         areaId,
         title: service.name,
@@ -267,6 +291,7 @@ export const IndexScreen = ({ navigation }) => {
           initialAreaId={initialAreaId}
           initialAreaName={initialAreaName}
           isFetchingNextServicesPage={isFetchingNextServicesPage}
+          isServicesLoading={isLoadingServices}
           isServicesError={isServicesError}
           setArea={(area) => {
             setAreaId(area.id);

--- a/src/screens/BUS/IndexScreen.js
+++ b/src/screens/BUS/IndexScreen.js
@@ -1,4 +1,3 @@
-import _filter from 'lodash/filter';
 import _sortBy from 'lodash/sortBy';
 import PropTypes from 'prop-types';
 import React, { useContext, useMemo, useState } from 'react';
@@ -11,6 +10,7 @@ import {
 } from '../../components';
 import { ServiceList } from '../../components/BUS/ServiceList';
 import { colors, consts, texts } from '../../config';
+import { mapBusServicesToListItems, resolveBusCategoryServices } from '../../helpers/busListHelper';
 import { runAsyncTasksSafely, spaceNewLines } from '../../helpers';
 import { shareMessage } from '../../helpers/BUS/shareHelper';
 import {
@@ -50,8 +50,6 @@ const FILTER_SETTING_IDS = {
 };
 
 const hasValue = (value) => value !== null && value !== undefined && `${value}`.trim().length > 0;
-const normalizeName = (value) => `${value ?? ''}`.trim().toLowerCase();
-
 const getFilterEntry = (id) => {
   switch (id) {
     case FILTER_IDS.TOP10:
@@ -86,51 +84,6 @@ const getEffectiveInitialFilter = (configuredFilter = []) => {
     }));
 };
 
-const getListItems = (areaId, data) =>
-  _sortBy(
-    _filter(data, (busService) => !!busService?.name),
-    (busService) => busService.name.toUpperCase()
-  ).map((busService) => ({
-    id: busService.id,
-    title: busService.name,
-    routeName: 'BusDetail',
-    params: {
-      areaId,
-      title: busService.name,
-      query: '',
-      queryVariables: {},
-      rootRouteName: 'BUS',
-      shareContent: {
-        message: shareMessage(busService)
-      },
-      data: busService
-    }
-  }));
-
-const getResolvedLifeSituationServices = (category, services = []) => {
-  const servicesById = new Map(
-    services
-      .filter((service) => service?.id !== null && service?.id !== undefined)
-      .map((service) => [`${service.id}`, service])
-  );
-  const servicesByName = new Map(
-    services
-      .filter((service) => !!normalizeName(service?.name))
-      .map((service) => [normalizeName(service.name), service])
-  );
-
-  return (category?.publicServiceTypes ?? [])
-    .map((serviceReference) => {
-      const serviceId = serviceReference?.id;
-      const serviceName = serviceReference?.name;
-
-      return (
-        servicesById.get(`${serviceId ?? ''}`) || servicesByName.get(normalizeName(serviceName))
-      );
-    })
-    .filter(Boolean);
-};
-
 const getLifeSituationsItems = (areaId, category, childCategories = [], services = []) => {
   const hasValidCategoryId = hasValue(category?.id);
   if (!hasValidCategoryId) {
@@ -161,7 +114,7 @@ const getLifeSituationsItems = (areaId, category, childCategories = [], services
       title: childCategory.name
     }
   }));
-  const serviceItems = getResolvedLifeSituationServices(category, services)
+  const serviceItems = resolveBusCategoryServices(category, services)
     .filter((service) => hasValue(service?.id) && hasValue(service?.name))
     .map((service) => ({
       id: service.id,
@@ -242,7 +195,11 @@ export const IndexScreen = ({ navigation }) => {
   } = useBusCategoryChildren(lifeSituationsRoot?.id, areaId);
   const {
     data: services = [],
+    fetchNextPage: fetchNextServicesPage,
+    hasNextPage: hasNextServicesPage,
+    isError: isServicesError,
     isFetching: isFetchingServices,
+    isFetchingNextPage: isFetchingNextServicesPage,
     isLoading: isLoadingServices,
     refetch: refetchServices
   } = useBusServices(areaId);
@@ -279,19 +236,19 @@ export const IndexScreen = ({ navigation }) => {
   const lifeSituationsEmptyStateMessage = isLifeSituationsError
     ? texts.bus.emptyStates.lifeSituationsRoot
     : texts.bus.emptyStates.lifeSituations;
-  const top10 = getListItems(areaId, top10Services);
+  const top10 = mapBusServicesToListItems(areaId, top10Services);
   const isListLoading = getIsListLoading({
     hasLifeSituationsRoot,
     isFetchingLifeSituationChildren,
     isFetchingLifeSituationsRoot,
-    isFetchingServices,
+    isFetchingServices: isFetchingServices && !services.length,
     isLoadingLifeSituationChildren,
     isLoadingLifeSituationsRoot,
     isLoadingServices,
     isLoadingTop10,
     selectedFilterId: selectedFilter?.id
   });
-  const results = getListItems(areaId, services);
+  const results = mapBusServicesToListItems(areaId, services);
 
   return (
     <SafeAreaViewFlex>
@@ -305,8 +262,12 @@ export const IndexScreen = ({ navigation }) => {
           results={results}
           areaId={areaId}
           areaName={resolvedAreaName}
+          fetchNextServicesPage={fetchNextServicesPage}
+          hasNextServicesPage={hasNextServicesPage}
           initialAreaId={initialAreaId}
           initialAreaName={initialAreaName}
+          isFetchingNextServicesPage={isFetchingNextServicesPage}
+          isServicesError={isServicesError}
           setArea={(area) => {
             setAreaId(area.id);
             setAreaName(area.label);

--- a/src/types/Bus.ts
+++ b/src/types/Bus.ts
@@ -80,12 +80,22 @@ export type BusAddress = {
 };
 
 export type BusFormLink = {
+  name?: string;
   url?: string;
 };
 
 export type BusForm = {
   links?: BusFormLink[];
   name?: string;
+};
+
+export type BusOnlineService = {
+  communications?: BusCommunication[];
+  links?: BusFormLink[];
+  name?: string;
+  publicName?: string;
+  title?: string;
+  url?: string;
 };
 
 export type BusOrganisationalUnit = {
@@ -110,6 +120,7 @@ export type BusPerson = {
 };
 
 export type BusServiceDetail = BusServiceListItem & {
+  onlineServices?: BusOnlineService[];
   organisationalUnits?: BusOrganisationalUnit[];
   persons?: BusPerson[];
   textBlocks?: BusTextBlockContainer[];


### PR DESCRIPTION
This PR improves the BUS service browsing experience by adding paginated loading, backend-powered service search, and more resilient service resolution across category and index views.

## Changes

- added paginated BUS service loading with `useInfiniteQuery`
- introduced backend BUS service search with debounced input handling
- added request timeout handling and normalized search query building in `src/queries/bus.js`
- extracted shared BUS list mapping and service resolution into `src/helpers/busListHelper.js`
- kept unresolved direct service references visible via fallback resolution by `id` or `name`
- improved BUS list empty and error states for search and service loading
- refined BUS detail rendering for forms, text blocks, and divider behavior
- expanded test coverage for hooks, queries, category flows, service search, and detail screen rendering

## Why

- large BUS service datasets needed incremental loading instead of fetching everything at once
- service search needed to use the backend endpoint for more complete and scalable results
- category-linked services needed to remain accessible even when the full local service list was not loaded yet
- BUS requests needed a client-side timeout to fail predictably on slow upstream responses
- the updated tests were added to prevent regressions in pagination, fallback resolution, and detail rendering
