### PR TITLE
feat: add the time to the date information in list and detail views

### DIFF
--- a/src/components/DataListSection.tsx
+++ b/src/components/DataListSection.tsx
@@ -36,17 +36,18 @@ const cachePointsOfInterestAndToursListData = (cacheKey: number, listData: unkno
 type Props = {
   additionalData?: unknown[];
   buttonTitle?: string;
+  dateTimeFormat?: string;
   horizontal?: boolean;
   isIndexStartingAt1?: boolean;
   isRandom?: boolean;
   limit?: number;
   linkTitle?: string;
+  listType?: string;
   loading?: boolean;
   navigate?: () => void;
   navigateButton?: () => void;
   navigateLink?: () => void;
   navigation: StackNavigationProp<Record<string, object | undefined>>;
-  listType?: string;
   placeholder?: React.ReactElement;
   query: string;
   queryUpdatedAt?: number;
@@ -62,6 +63,7 @@ type Props = {
 export const DataListSection = ({
   additionalData,
   buttonTitle,
+  dateTimeFormat,
   horizontal,
   isIndexStartingAt1,
   isRandom = false,
@@ -108,6 +110,7 @@ export const DataListSection = ({
       query === QUERY_TYPES.VOLUNTEER.CALENDAR_ALL ||
       query === QUERY_TYPES.VOLUNTEER.CALENDAR_ALL_MY ||
       query === QUERY_TYPES.VOLUNTEER.CONVERSATIONS,
+    dateTimeFormat: dateTimeFormat,
     withTime: query === QUERY_TYPES.EVENT_RECORDS && !queryVariables?.onlyUniqEvents,
     queryKey: query === QUERY_TYPES.VOUCHERS ? QUERY_TYPES.GENERIC_ITEMS : query
   };

--- a/src/components/HomeSection.tsx
+++ b/src/components/HomeSection.tsx
@@ -10,6 +10,7 @@ import { DataListSection } from './DataListSection';
 
 type Props = {
   buttonTitle: string;
+  dateTimeFormat?: string;
   fetchPolicy:
     | 'cache-first'
     | 'network-only'
@@ -30,6 +31,7 @@ type Props = {
 
 export const HomeSection = ({
   buttonTitle,
+  dateTimeFormat,
   isIndexStartingAt1 = false,
   navigate,
   navigation,
@@ -104,6 +106,7 @@ export const HomeSection = ({
     <DataListSection
       additionalData={additionalData}
       buttonTitle={buttonTitle}
+      dateTimeFormat={dateTimeFormat}
       isIndexStartingAt1={isIndexStartingAt1}
       limit={queryVariables?.limit || queryVariables?.take}
       loading={loading}

--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -19,14 +19,20 @@ const { MATOMO_TRACKING } = consts;
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const NewsItem = ({ data, route }) => {
   const { globalSettings } = useContext(SettingsContext);
-  const { showImageRights } = globalSettings || {};
-  const { detailDateFormat } = globalSettings?.settings?.news || {};
+  const { showImageRights, settings = {} } = globalSettings || {};
+  const { detailDateFormat } = settings?.news || {};
   const imageRightsPosition = showImageRights?.newsDetail?.imageRightsPosition;
 
-  const { dataProvider, mainTitle, contentBlocks, publishedAt, sourceUrl, settings, categories } =
-    data;
+  const {
+    dataProvider,
+    mainTitle,
+    contentBlocks,
+    publishedAt,
+    sourceUrl,
+    settings: itemSettings,
+    categories
+  } = data;
 
-  const logo = dataProvider && dataProvider.logo && dataProvider.logo.url;
   const link = sourceUrl && sourceUrl.url;
   const subtitle = dataProvider && dataProvider.name;
   // the title of a news item is either a given main title or the title from the first content block
@@ -89,7 +95,7 @@ export const NewsItem = ({ data, route }) => {
             contentBlock={contentBlock}
             index={index}
             openWebScreen={openWebScreen}
-            settings={settings}
+            settings={itemSettings}
           />
         ))}
 

--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -20,6 +20,7 @@ const { MATOMO_TRACKING } = consts;
 export const NewsItem = ({ data, route }) => {
   const { globalSettings } = useContext(SettingsContext);
   const { showImageRights } = globalSettings || {};
+  const { detailDateFormat } = globalSettings?.settings?.news || {};
   const imageRightsPosition = showImageRights?.newsDetail?.imageRightsPosition;
 
   const { dataProvider, mainTitle, contentBlocks, publishedAt, sourceUrl, settings, categories } =
@@ -70,7 +71,7 @@ export const NewsItem = ({ data, route }) => {
       {!!momentFormatUtcToLocal(publishedAt) && (
         <Wrapper center>
           <WrapperRow center>
-            <RegularText>{momentFormatUtcToLocal(publishedAt)}</RegularText>
+            <RegularText>{momentFormatUtcToLocal(publishedAt, detailDateFormat)}</RegularText>
           </WrapperRow>
         </Wrapper>
       )}

--- a/src/components/screens/NewsItem.js
+++ b/src/components/screens/NewsItem.js
@@ -57,6 +57,9 @@ export const NewsItem = ({ data, route }) => {
   );
 
   const businessAccount = dataProvider?.dataType === 'business_account';
+  const formattedPublishedAt = publishedAt
+    ? momentFormatUtcToLocal(publishedAt, detailDateFormat)
+    : null;
 
   return (
     <View>
@@ -74,10 +77,10 @@ export const NewsItem = ({ data, route }) => {
         <SectionHeader big center title={trimNewLines(title)} />
       </WrapperRow>
 
-      {!!momentFormatUtcToLocal(publishedAt) && (
+      {!!formattedPublishedAt && (
         <Wrapper center>
           <WrapperRow center>
-            <RegularText>{momentFormatUtcToLocal(publishedAt, detailDateFormat)}</RegularText>
+            <RegularText>{formattedPublishedAt}</RegularText>
           </WrapperRow>
         </Wrapper>
       )}

--- a/src/components/screens/Overviews.js
+++ b/src/components/screens/Overviews.js
@@ -106,8 +106,11 @@ export const Overviews = ({ navigation, route }) => {
   const { globalSettings } = useContext(SettingsContext);
   const { filter = {}, sections = {}, settings = {} } = globalSettings;
   const { news: showNewsFilter = false } = filter;
-  const { switchBetweenListAndMap = SWITCH_BETWEEN_LIST_AND_MAP.TOP_FILTER, locationService = {} } =
-    settings;
+  const {
+    switchBetweenListAndMap = SWITCH_BETWEEN_LIST_AND_MAP.TOP_FILTER,
+    locationService = {},
+    news = {}
+  } = settings;
   const {
     categoryListIntroText = texts.categoryList.intro,
     categoryListFooter,
@@ -115,6 +118,7 @@ export const Overviews = ({ navigation, route }) => {
     poiListIntro
   } = sections;
   const query = route.params?.query ?? '';
+  const dateTimeFormat = news?.listDateFormat;
   const { initialFilter = FILTER_TYPES.LIST } = route.params?.queryVariables ?? {};
   const INITIAL_FILTER = [
     {
@@ -198,9 +202,10 @@ export const Overviews = ({ navigation, route }) => {
   const listItems = useMemo(() => {
     let parsedListItems = parseListItemsFromQuery(query, data, titleDetail, {
       bookmarkable,
-      withDate: false,
+      dateTimeFormat,
       queryVariables,
-      subQuery
+      subQuery,
+      withDate: false
     });
 
     if (queryVariables.onlyCurrentlyOpen) {
@@ -233,18 +238,19 @@ export const Overviews = ({ navigation, route }) => {
 
     return parsedListItems;
   }, [
-    query,
-    data,
-    titleDetail,
     bookmarkable,
-    queryVariables,
-    subQuery,
-    sortByDistance,
     currentPosition,
-    radiusSearchByDistance,
+    data,
+    dateTimeFormat,
     isLocationAlertShow,
     locationSettings,
-    navigation
+    navigation,
+    query,
+    queryVariables,
+    radiusSearchByDistance,
+    sortByDistance,
+    subQuery,
+    titleDetail
   ]);
 
   const refresh = useCallback(() => {

--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -153,12 +153,12 @@ const parseGenericItems = (data, skipLastDivider, queryVariables, subQuery, filt
   }));
 };
 
-const parseNewsItems = (data, skipLastDivider, titleDetail, bookmarkable) => {
+const parseNewsItems = (data, skipLastDivider, titleDetail, bookmarkable, dateTimeFormat) => {
   return _uniqBy(
     data?.map((newsItem, index) => ({
       id: newsItem.id,
       overtitle: subtitle(
-        momentFormatUtcToLocal(newsItem.publishedAt),
+        momentFormatUtcToLocal(newsItem.publishedAt, dateTimeFormat),
         newsItem.dataProvider?.name
       ),
       title: newsItem.contentBlocks?.[0]?.title,
@@ -174,15 +174,13 @@ const parseNewsItems = (data, skipLastDivider, titleDetail, bookmarkable) => {
       routeName: ScreenName.Detail,
       params: {
         bookmarkable,
-        title: titleDetail,
-        suffix: newsItem.categories?.[0]?.parent?.id || newsItem.categories?.[0]?.id,
+        details: newsItem,
         query: QUERY_TYPES.NEWS_ITEM,
         queryVariables: { id: `${newsItem.id}` },
         rootRouteName: ROOT_ROUTE_NAMES.NEWS_ITEMS,
-        shareContent: {
-          message: shareMessage(newsItem, QUERY_TYPES.NEWS_ITEM)
-        },
-        details: newsItem
+        shareContent: { message: shareMessage(newsItem, QUERY_TYPES.NEWS_ITEM) },
+        suffix: newsItem.categories?.[0]?.parent?.id || newsItem.categories?.[0]?.id,
+        title: titleDetail
       },
       bottomDivider: !skipLastDivider || index !== data.length - 1
     })),
@@ -374,6 +372,7 @@ export const parseListItemsFromQuery = (query, data, titleDetail = '', options =
   const {
     appDesignSystem,
     bookmarkable = true,
+    dateTimeFormat,
     filterTypes,
     isSectioned = false,
     queryKey,
@@ -390,7 +389,13 @@ export const parseListItemsFromQuery = (query, data, titleDetail = '', options =
     case QUERY_TYPES.GENERIC_ITEMS:
       return parseGenericItems(data[query], skipLastDivider, queryVariables, subQuery, filterTypes);
     case QUERY_TYPES.NEWS_ITEMS:
-      return parseNewsItems(data[query], skipLastDivider, titleDetail, bookmarkable);
+      return parseNewsItems(
+        data[query],
+        skipLastDivider,
+        titleDetail,
+        bookmarkable,
+        dateTimeFormat
+      );
     case QUERY_TYPES.POINT_OF_INTEREST:
     case QUERY_TYPES.POINTS_OF_INTEREST:
       return parsePointOfInterest(data[query], skipLastDivider, queryVariables);

--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -355,6 +355,7 @@ const parseConversations = (data) =>
  * @param {{
  *     appDesignSystem?: any;
  *     bookmarkable?: boolean;
+ *     dateTimeFormat?: string;
  *     filterTypes?: any;
  *     isSectioned?: boolean;
  *     queryKey?: string;

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -343,6 +343,7 @@ export const HomeScreen = ({ navigation, route }) => {
     { type: DEFAULT_HOME_SCREEN_SECTIONS.DISTURBER, show: true, navigation },
     {
       categoriesNews,
+      dateTimeFormat: listDateFormat,
       fetchPolicy,
       limit: limitNews,
       navigation,

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -58,6 +58,7 @@ const renderItem = ({ item }) => {
   const {
     buttonTitle,
     categoriesNews,
+    dateTimeFormat,
     fetchPolicy,
     isDrawer,
     limit,
@@ -117,27 +118,28 @@ const renderItem = ({ item }) => {
     CATEGORIES_INDEX: {
       name: ScreenName.Index,
       params: {
-        title,
         query: QUERY_TYPES.CATEGORIES,
         queryVariables: {},
-        rootRouteName: ROOT_ROUTE_NAMES.POINTS_OF_INTEREST_AND_TOURS
+        rootRouteName: ROOT_ROUTE_NAMES.POINTS_OF_INTEREST_AND_TOURS,
+        title
       }
     },
     EVENT_RECORDS_INDEX: {
       name: ScreenName.Index,
       params: {
-        title,
         query: QUERY_TYPES.EVENT_RECORDS,
         queryVariables: { limit, order: 'listDate_ASC' },
-        rootRouteName: ROOT_ROUTE_NAMES.EVENT_RECORDS
+        rootRouteName: ROOT_ROUTE_NAMES.EVENT_RECORDS,
+        title
       }
     },
     NEWS_ITEMS_INDEX: ({
       categoryId,
-      title,
-      titleDetail,
+      dateTimeFormat,
       indexCategoryIds,
-      rootRouteName = ROOT_ROUTE_NAMES.NEWS_ITEMS
+      rootRouteName = ROOT_ROUTE_NAMES.NEWS_ITEMS,
+      title,
+      titleDetail
     }) => {
       const indexQueryVariables = { limit };
 
@@ -150,11 +152,11 @@ const renderItem = ({ item }) => {
       return {
         name: ScreenName.Index,
         params: {
-          title,
-          titleDetail,
           query: QUERY_TYPES.NEWS_ITEMS,
           queryVariables: indexQueryVariables,
-          rootRouteName
+          rootRouteName,
+          title,
+          titleDetail
         }
       };
     }
@@ -182,16 +184,17 @@ const renderItem = ({ item }) => {
           {...{
             buttonTitle: categoryButton,
             categoryId,
+            dateTimeFormat,
             fetchPolicy,
             navigation,
             navigate: () =>
               navigation.navigate(
                 NAVIGATION.NEWS_ITEMS_INDEX({
                   categoryId,
-                  title,
-                  titleDetail,
                   indexCategoryIds,
-                  rootRouteName
+                  rootRouteName,
+                  title,
+                  titleDetail
                 })
               ),
             placeholder: <NewsSectionPlaceholder navigation={navigation} title={title} />,
@@ -230,6 +233,7 @@ export const HomeScreen = ({ navigation, route }) => {
   const {
     hdvt = {},
     homeScreenConfig = [],
+    settings = {},
     sections = {},
     widgets: widgetConfigs = []
   } = globalSettings;
@@ -252,6 +256,7 @@ export const HomeScreen = ({ navigation, route }) => {
     limitNews = 15,
     limitPointsOfInterestAndTours = 15
   } = sections;
+  const { listDateFormat } = settings?.news || {};
   const { events: showVolunteerEvents = false } = hdvt;
   const [refreshing, setRefreshing] = useState(false);
   const { excludeDataProviderIds, excludeMowasRegionalKeys } = usePermanentFilter();
@@ -392,6 +397,7 @@ export const HomeScreen = ({ navigation, route }) => {
             case QUERY_TYPES.NEWS_ITEMS:
               return {
                 categoriesNews: section.categoriesNews || categoriesNews,
+                dateTimeFormat: listDateFormat,
                 fetchPolicy,
                 limit: section.limitNews ?? limitNews,
                 navigation,

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -135,7 +135,6 @@ const renderItem = ({ item }) => {
     },
     NEWS_ITEMS_INDEX: ({
       categoryId,
-      dateTimeFormat,
       indexCategoryIds,
       rootRouteName = ROOT_ROUTE_NAMES.NEWS_ITEMS,
       title,


### PR DESCRIPTION
With this PR, the time is added to the date section on the list and detail pages for news articles.

```
  "settings": {
    "news": {
      "listDateFormat": "DD.MM.YYYY, HH:mm [Uhr]",
      "detailDateFormat": "DD.MM.YYYY, HH:mm [Uhr]"
    },
...
```

|HomeScreen|IndexScreen|DetailScreen|
|--|--|--|
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-19 at 08 09 35" src="https://github.com/user-attachments/assets/d27f69f0-4160-4ddb-b911-04db33c9d375" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-19 at 08 09 39" src="https://github.com/user-attachments/assets/fa0546c4-72d7-4967-9953-57142fbb7b73" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-19 at 08 09 42" src="https://github.com/user-attachments/assets/a5b7ff23-ad55-4916-a4bf-146f496762ca" />





SVASD-450