### PR TITLE
fix: update request variables for voucher queries

### DIFF
--- a/src/screens/Voucher/VoucherIndexScreen.tsx
+++ b/src/screens/Voucher/VoucherIndexScreen.tsx
@@ -56,7 +56,7 @@ export const VoucherIndexScreen = ({ navigation, route }: StackScreenProps<any>)
   const requestVariables = useMemo(() => {
     const variables = { ...queryVariables };
 
-    if (query === QUERY_TYPES.VOUCHERS) {
+    if (query === QUERY_TYPES.VOUCHERS || query === QUERY_TYPES.VOUCHERS_REDEEMED) {
       variables.memberId = memberId;
     }
 


### PR DESCRIPTION
This PR resolves the issue where all coupons were listed instead of just the ones the user had used.

SVAK-42