### PR TITLE
fix(bus): enrich authority and service detail data

### DIFF
--- a/__tests__/components/BUS/Authority.test.js
+++ b/__tests__/components/BUS/Authority.test.js
@@ -1,0 +1,152 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { Text } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+
+import { Authority } from '../../../src/components/BUS/Authority';
+
+jest.mock('../../../src/config', () => ({
+  texts: {
+    bus: {
+      authority: {
+        accessibility: 'Barrierefreiheit',
+        elevator: 'Aufzug vorhanden',
+        openingTime: 'Öffnungszeiten',
+        paymentMethod: 'Zahlungsweise',
+        paymentMethods: 'Zahlungsdaten',
+        transportation: 'Verkehrsanbindung',
+        wheelchairAccessible: 'Rollstuhlgerecht'
+      }
+    }
+  }
+}));
+
+jest.mock('../../../src/helpers', () => ({
+  trimNewLines: (value) => value
+}));
+
+jest.mock('../../../src/components/HtmlView', () => ({
+  HtmlView: ({ html }) => {
+    const { Text: MockText } = jest.requireActual('react-native');
+
+    return <MockText>{html}</MockText>;
+  }
+}));
+
+jest.mock('../../../src/components/infoCard', () => ({
+  InfoCard: () => {
+    const { View: MockView } = jest.requireActual('react-native');
+
+    return <MockView />;
+  }
+}));
+
+jest.mock('../../../src/components/Text', () => ({
+  BoldText: ({ children }) => {
+    const { Text: MockText } = jest.requireActual('react-native');
+
+    return <MockText>{children}</MockText>;
+  },
+  RegularText: ({ children }) => {
+    const { Text: MockText } = jest.requireActual('react-native');
+
+    return <MockText>{children}</MockText>;
+  }
+}));
+
+jest.mock('../../../src/components/Wrapper', () => ({
+  Wrapper: ({ children }) => {
+    const { View: MockView } = jest.requireActual('react-native');
+
+    return <MockView>{children}</MockView>;
+  }
+}));
+
+jest.mock('../../../src/components/BUS/Block', () => ({
+  Block: ({ children }) => {
+    const { View: MockView } = jest.requireActual('react-native');
+
+    return <MockView>{children}</MockView>;
+  }
+}));
+
+const collectText = (children) => {
+  if (typeof children === 'string') {
+    return children;
+  }
+
+  if (Array.isArray(children)) {
+    return children.map(collectText).join('');
+  }
+
+  return '';
+};
+
+describe('Authority', () => {
+  it('renders transportation stops alongside accessibility details', () => {
+    let component;
+
+    act(() => {
+      component = renderer.create(
+        <Authority
+          bottomDivider={false}
+          openWebScreen={jest.fn()}
+          data={{
+            name: 'Buergeramt',
+            addresses: [
+              {
+                area: { name: 'Perleberg' },
+                elevator: true,
+                transportationStops: [
+                  {
+                    name: 'Perleberg, Landkreis',
+                    lines: [{ name: '975', type: { key: 'BUS', name: 'Bus' } }]
+                  },
+                  {
+                    name: 'Perleberg, Landkreis',
+                    lines: [{ name: '950', type: { key: 'BUS', name: 'Bus' } }]
+                  }
+                ],
+                wheelchairAccessible: true
+              }
+            ],
+            paymentMethods: [
+              {
+                id: '100006331',
+                key: '3010000',
+                name: 'Überweisung',
+                notPublic: false
+              },
+              {
+                id: '100058904',
+                key: '3000000',
+                name: 'Bargeldlose Zahlung',
+                notPublic: false
+              }
+            ]
+          }}
+        />
+      );
+    });
+
+    const textValues = component.root
+      .findAllByType(Text)
+      .map((node) => collectText(node.props.children));
+
+    expect(textValues).toEqual(
+      expect.arrayContaining([
+        'Verkehrsanbindung',
+        'Perleberg, Landkreis',
+        'Bus: 975',
+        'Bus: 950',
+        'Barrierefreiheit',
+        'Aufzug vorhanden: ja',
+        'Rollstuhlgerecht: ja',
+        'Zahlungsdaten',
+        'Zahlungsweise:',
+        'Überweisung',
+        'Bargeldlose Zahlung'
+      ])
+    );
+  });
+});

--- a/__tests__/helpers/busDetailHelper.test.js
+++ b/__tests__/helpers/busDetailHelper.test.js
@@ -52,14 +52,10 @@ describe('busDetailHelper', () => {
           name: 'Status prüfen'
         }
       ],
-      organisationalUnits: [
+      forms: [
         {
-          forms: [
-            {
-              links: [{ url: 'https://example.org/form-1' }],
-              name: 'PDF Formular'
-            }
-          ]
+          links: [{ url: 'https://example.org/form-1' }],
+          name: 'PDF Formular'
         }
       ]
     };
@@ -85,13 +81,9 @@ describe('busDetailHelper', () => {
 
   it('keeps form actions even when a form has no explicit name', () => {
     const service = {
-      organisationalUnits: [
+      forms: [
         {
-          forms: [
-            {
-              links: [{ name: 'PDF herunterladen', url: 'https://example.org/form-1' }]
-            }
-          ]
+          links: [{ name: 'PDF herunterladen', url: 'https://example.org/form-1' }]
         }
       ]
     };
@@ -136,10 +128,7 @@ describe('busDetailHelper', () => {
   it('keeps the Formulare text block visible in the accordion', () => {
     const textBlocks = [KURZTEXT_BLOCK, FORMULARE_BLOCK, TEASER_BLOCK];
 
-    expect(getBusVisibleTextBlocks({ textBlocks })).toEqual([
-      KURZTEXT_BLOCK,
-      FORMULARE_BLOCK
-    ]);
+    expect(getBusVisibleTextBlocks({ textBlocks })).toEqual([KURZTEXT_BLOCK, FORMULARE_BLOCK]);
   });
 
   it('keeps legacy hidden BUS metadata blocks hidden after unwrapping nested text blocks', () => {
@@ -163,10 +152,9 @@ describe('busDetailHelper', () => {
       text: 'Freitext ohne Typ'
     };
 
-    expect(getBusVisibleTextBlocks({ textBlocks: [KURZTEXT_BLOCK, textBlockWithoutTypeName] })).toEqual([
-      KURZTEXT_BLOCK,
-      textBlockWithoutTypeName
-    ]);
+    expect(
+      getBusVisibleTextBlocks({ textBlocks: [KURZTEXT_BLOCK, textBlockWithoutTypeName] })
+    ).toEqual([KURZTEXT_BLOCK, textBlockWithoutTypeName]);
   });
 
   it('keeps Kurztext and Volltext as the first two accordion blocks', () => {

--- a/__tests__/hooks/bus.test.ts
+++ b/__tests__/hooks/bus.test.ts
@@ -14,6 +14,9 @@ jest.mock('../../src/queries/bus', () => ({
   findBusCategoryRoot: jest.fn(),
   findPublicServicesPage: jest.fn(),
   findPublicServices: jest.fn(),
+  getBusServiceForms: jest.fn(),
+  getBusServiceOrganisationalUnits: jest.fn(),
+  getBusServicePersons: jest.fn(),
   getPublicService: jest.fn(),
   searchPoliticalAreas: jest.fn()
 }));
@@ -37,6 +40,7 @@ import {
   useBusAreas,
   useBusCategoryChildren,
   useBusLifeSituationsRoot,
+  useBusService,
   useBusServiceSearch,
   useBusServices
 } from '../../src/hooks/bus';
@@ -44,6 +48,10 @@ import {
   findBusCategoryChildren,
   findBusCategoryRoot,
   findPublicServicesPage,
+  getBusServiceForms,
+  getBusServiceOrganisationalUnits,
+  getBusServicePersons,
+  getPublicService,
   searchPoliticalAreas
 } from '../../src/queries/bus';
 
@@ -53,6 +61,10 @@ const mockedUseQuery = jest.mocked(useQuery);
 const mockedFindBusCategoryChildren = jest.mocked(findBusCategoryChildren);
 const mockedFindBusCategoryRoot = jest.mocked(findBusCategoryRoot);
 const mockedFindPublicServicesPage = jest.mocked(findPublicServicesPage);
+const mockedGetBusServiceForms = jest.mocked(getBusServiceForms);
+const mockedGetBusServiceOrganisationalUnits = jest.mocked(getBusServiceOrganisationalUnits);
+const mockedGetBusServicePersons = jest.mocked(getBusServicePersons);
+const mockedGetPublicService = jest.mocked(getPublicService);
 const mockedSearchPoliticalAreas = jest.mocked(searchPoliticalAreas);
 const defaultBusSettings = {
   uri: 'https://one.example'
@@ -484,5 +496,80 @@ describe('useBusServiceSearch', () => {
 
     expect(result?.isError).toBe(true);
     expect(result?.error).toEqual(expect.any(Error));
+  });
+});
+
+describe('useBusService', () => {
+  it('loads and enriches the BUS service detail with organisational units and persons', async () => {
+    mockedUseContext.mockReturnValue(createSettingsContextValue());
+    mockEnabledUseQuery();
+
+    mockedGetPublicService.mockResolvedValue({
+      id: 'service-1',
+      name: 'Gewerbe Anmeldung'
+    } as never);
+    mockedGetBusServiceForms.mockResolvedValue([{ id: 'form-1', name: 'PDF Formular' }] as never);
+    mockedGetBusServiceOrganisationalUnits.mockResolvedValue([
+      { id: 'ou-1', name: 'Amt 1' }
+    ] as never);
+    mockedGetBusServicePersons.mockResolvedValue([{ id: 'person-1', firstName: 'Ada' }] as never);
+
+    await renderHook(() => useBusService({ areaId: '09162000', id: 'service-1' }), true);
+
+    expect(mockedGetPublicService).toHaveBeenCalledWith({
+      areaId: '09162000',
+      bus: {
+        uri: 'https://one.example'
+      },
+      id: 'service-1'
+    });
+    expect(mockedGetBusServiceForms).toHaveBeenCalledWith({
+      areaId: '09162000',
+      bus: {
+        uri: 'https://one.example'
+      },
+      id: 'service-1'
+    });
+    expect(mockedGetBusServiceOrganisationalUnits).toHaveBeenCalledWith({
+      areaId: '09162000',
+      bus: {
+        uri: 'https://one.example'
+      },
+      id: 'service-1'
+    });
+    expect(mockedGetBusServicePersons).toHaveBeenCalledWith({
+      areaId: '09162000',
+      bus: {
+        uri: 'https://one.example'
+      },
+      id: 'service-1'
+    });
+  });
+
+  it('returns empty arrays for organisational units and persons when the BUS endpoints are empty', async () => {
+    mockedUseContext.mockReturnValue(createSettingsContextValue());
+    mockedUseQuery.mockReturnValue({
+      ...createUseQueryResult(),
+      data: {
+        forms: [],
+        id: 'service-1',
+        name: 'Gewerbe Anmeldung',
+        organisationalUnits: [],
+        persons: []
+      }
+    } as never);
+
+    let result;
+    await renderHook(() => {
+      result = useBusService({ areaId: '09162000', id: 'service-1' });
+    });
+
+    expect(result?.data).toEqual({
+      forms: [],
+      id: 'service-1',
+      name: 'Gewerbe Anmeldung',
+      organisationalUnits: [],
+      persons: []
+    });
   });
 });

--- a/__tests__/queries/bus.test.js
+++ b/__tests__/queries/bus.test.js
@@ -1,11 +1,14 @@
 import {
-    BUS_REQUEST_TIMEOUT_MS,
-    findBusCategoryChildren,
-    findBusCategoryRoot,
-    findPublicServicesPage,
-    getPoliticalArea,
-    getPublicService,
-    searchPoliticalAreas
+  BUS_REQUEST_TIMEOUT_MS,
+  findBusCategoryChildren,
+  findBusCategoryRoot,
+  findPublicServicesPage,
+  getBusServiceForms,
+  getBusServiceOrganisationalUnits,
+  getBusServicePersons,
+  getPoliticalArea,
+  getPublicService,
+  searchPoliticalAreas
 } from '../../src/queries/bus';
 
 const bus = {
@@ -13,11 +16,50 @@ const bus = {
   uri: 'https://server.int-development.smart-village.app/api/v1'
 };
 
-const mockFetchJson = (payload) =>
-  jest.spyOn(globalThis, 'fetch').mockResolvedValue({
-    json: async () => payload,
-    ok: true
+const createTotalCountHeaders = (totalItemCount) => ({
+  get: (headerName) =>
+    headerName.toLowerCase() === 'total-item-count' ? String(totalItemCount) : undefined
+});
+
+const createBusOkResponse = ({ payload, totalItemCount }) => ({
+  headers: totalItemCount === undefined ? undefined : createTotalCountHeaders(totalItemCount),
+  json: async () => payload,
+  ok: true
+});
+
+const createFindPayload = (items, extraPayload = {}) => ({
+  ...extraPayload,
+  results: items.map((object) => ({ object }))
+});
+
+const mockFetchOk = ({ payload, totalItemCount }) =>
+  jest
+    .spyOn(globalThis, 'fetch')
+    .mockResolvedValue(createBusOkResponse({ payload, totalItemCount }));
+
+const mockFetchJson = (payload) => mockFetchOk({ payload });
+
+const mockFindResponse = ({ items, totalItemCount, extraPayload }) =>
+  createBusOkResponse({ payload: createFindPayload(items, extraPayload), totalItemCount });
+
+const mockFetchFindOnce = ({ items, totalItemCount, extraPayload }) =>
+  jest
+    .spyOn(globalThis, 'fetch')
+    .mockResolvedValue(mockFindResponse({ items, totalItemCount, extraPayload }));
+
+const mockFetchFindSequence = ({ pages, totalItemCount }) => {
+  const fetchSpy = jest.spyOn(globalThis, 'fetch');
+
+  pages.forEach((items) => {
+    fetchSpy.mockResolvedValueOnce(mockFindResponse({ items, totalItemCount }));
   });
+
+  return fetchSpy;
+};
+
+const expectBusFetchNthCall = (callNumber, url) => {
+  expect(globalThis.fetch).toHaveBeenNthCalledWith(callNumber, url, expect.any(Object));
+};
 
 const expectBusFetch = (url, options = {}) => {
   const { headers, ...restOptions } = options;
@@ -217,21 +259,9 @@ describe('BUS queries', () => {
   });
 
   it('loads a paginated public service page and reads total-item-count from response headers', async () => {
-    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
-      headers: {
-        get: (headerName) => (headerName.toLowerCase() === 'total-item-count' ? '2357' : undefined)
-      },
-      json: async () => ({
-        results: [
-          {
-            object: {
-              id: 'service-1',
-              name: 'Gewerbe Anmeldung'
-            }
-          }
-        ]
-      }),
-      ok: true
+    mockFetchFindOnce({
+      items: [{ id: 'service-1', name: 'Gewerbe Anmeldung' }],
+      totalItemCount: 2357
     });
 
     const result = await findPublicServicesPage({
@@ -263,22 +293,135 @@ describe('BUS queries', () => {
     });
   });
 
-  it('uses the same attribute set for the unfiltered BUS base list import', async () => {
-    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
-      headers: {
-        get: (headerName) => (headerName.toLowerCase() === 'total-item-count' ? '2357' : undefined)
+  it('uses totalCount from the payload when the response headers do not provide a total', async () => {
+    mockFetchFindOnce({
+      extraPayload: { count: 1, totalCount: 17 },
+      items: [{ id: 'service-1', name: 'Gewerbe Anmeldung' }]
+    });
+
+    const result = await findPublicServicesPage({
+      areaId: '10004',
+      bus,
+      limit: 500,
+      offset: 0
+    });
+
+    expect(result).toEqual({
+      items: [
+        {
+          id: 'service-1',
+          name: 'Gewerbe Anmeldung'
+        }
+      ],
+      totalItemCount: 17
+    });
+  });
+
+  it('aggregates all paginated organisational units for a BUS service', async () => {
+    mockFetchFindSequence({
+      pages: [[{ id: 'ou-1', name: 'Amt 1' }], [{ id: 'ou-2', name: 'Amt 2' }]],
+      totalItemCount: 2
+    });
+
+    const result = await getBusServiceOrganisationalUnits({
+      areaId: '10004',
+      bus,
+      id: 'service-1'
+    });
+
+    expectBusFetchNthCall(
+      1,
+      'https://server.int-development.smart-village.app/api/v1/ou/findByCompetence?areaId=10004&pstId=service-1&limit=500&offset=0'
+    );
+    expectBusFetchNthCall(
+      2,
+      'https://server.int-development.smart-village.app/api/v1/ou/findByCompetence?areaId=10004&pstId=service-1&limit=500&offset=1'
+    );
+    expect(result).toEqual([
+      {
+        id: 'ou-1',
+        name: 'Amt 1'
       },
-      json: async () => ({
-        results: [
-          {
-            object: {
-              id: 'service-1',
-              name: 'Gewerbe Anmeldung'
-            }
-          }
-        ]
-      }),
-      ok: true
+      {
+        id: 'ou-2',
+        name: 'Amt 2'
+      }
+    ]);
+  });
+
+  it('aggregates all paginated persons for a BUS service', async () => {
+    mockFetchFindSequence({
+      pages: [
+        [
+          { id: 'person-1', firstName: 'Ada' },
+          { id: 'person-2', firstName: 'Linus' }
+        ],
+        [{ id: 'person-3', firstName: 'Grace' }]
+      ],
+      totalItemCount: 3
+    });
+
+    const result = await getBusServicePersons({ areaId: '10004', bus, id: 'service-1', limit: 2 });
+
+    expectBusFetchNthCall(
+      1,
+      'https://server.int-development.smart-village.app/api/v1/person/find?areaId=10004&pstId=service-1&limit=2&offset=0'
+    );
+    expectBusFetchNthCall(
+      2,
+      'https://server.int-development.smart-village.app/api/v1/person/find?areaId=10004&pstId=service-1&limit=2&offset=2'
+    );
+    expect(result).toEqual([
+      {
+        id: 'person-1',
+        firstName: 'Ada'
+      },
+      {
+        id: 'person-2',
+        firstName: 'Linus'
+      },
+      {
+        id: 'person-3',
+        firstName: 'Grace'
+      }
+    ]);
+  });
+
+  it('aggregates all paginated forms for a BUS service', async () => {
+    mockFetchFindSequence({
+      pages: [
+        [{ id: 'form-1', name: 'PDF Formular' }],
+        [{ id: 'form-2', name: 'Online Formular' }]
+      ],
+      totalItemCount: 2
+    });
+
+    const result = await getBusServiceForms({ areaId: '10004', bus, id: 'service-1' });
+
+    expectBusFetchNthCall(
+      1,
+      'https://server.int-development.smart-village.app/api/v1/form/find?areaId=10004&pstId=service-1&limit=500&offset=0'
+    );
+    expectBusFetchNthCall(
+      2,
+      'https://server.int-development.smart-village.app/api/v1/form/find?areaId=10004&pstId=service-1&limit=500&offset=1'
+    );
+    expect(result).toEqual([
+      {
+        id: 'form-1',
+        name: 'PDF Formular'
+      },
+      {
+        id: 'form-2',
+        name: 'Online Formular'
+      }
+    ]);
+  });
+
+  it('uses the same attribute set for the unfiltered BUS base list import', async () => {
+    mockFetchFindOnce({
+      items: [{ id: 'service-1', name: 'Gewerbe Anmeldung' }],
+      totalItemCount: 2357
     });
 
     await findPublicServicesPage({
@@ -301,21 +444,9 @@ describe('BUS queries', () => {
   });
 
   it('uses pstExtended/find for free BUS search terms including phrases with spaces', async () => {
-    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
-      headers: {
-        get: (headerName) => (headerName.toLowerCase() === 'total-item-count' ? '1' : undefined)
-      },
-      json: async () => ({
-        results: [
-          {
-            object: {
-              id: 'service-2',
-              name: 'Neues Unternehmen anmelden'
-            }
-          }
-        ]
-      }),
-      ok: true
+    mockFetchFindOnce({
+      items: [{ id: 'service-2', name: 'Neues Unternehmen anmelden' }],
+      totalItemCount: 1
     });
 
     const result = await findPublicServicesPage({

--- a/src/components/BUS/Authority.js
+++ b/src/components/BUS/Authority.js
@@ -12,53 +12,149 @@ import { Wrapper } from '../Wrapper';
 import { Block } from './Block';
 import { getAddress, getContact } from './helpers';
 
+const getTransportationLineLabel = (line) => {
+  const typeLabel = line?.type?.name || line?.type?.key || 'Linie';
+
+  return line?.name ? `${typeLabel}: ${line.name}` : typeLabel;
+};
+
+const getTransportationStopLines = (transportationStop) =>
+  (transportationStop?.lines ?? []).map(getTransportationLineLabel).filter(Boolean);
+
+const renderTransportationStops = (transportationStops) => (
+  <View>
+    <BoldText>{texts.bus.authority.transportation}</BoldText>
+    {transportationStops.map((transportationStop, index) => {
+      const lineLabels = getTransportationStopLines(transportationStop);
+
+      return (
+        <View key={`${transportationStop?.name || 'stop'}-${index}`} style={styles.infoBlock}>
+          {!!transportationStop?.name && <BoldText small>{transportationStop.name}</BoldText>}
+          {lineLabels.map((lineLabel, lineIndex) => (
+            <RegularText key={`${transportationStop?.name || 'stop'}-${index}-${lineIndex}`}>
+              {lineLabel}
+            </RegularText>
+          ))}
+        </View>
+      );
+    })}
+  </View>
+);
+
+const renderAccessibilityInfo = ({ elevator, wheelchairAccessible, hasTransportationStops }) => {
+  if (elevator === undefined && wheelchairAccessible === undefined) {
+    return null;
+  }
+
+  return (
+    <View style={hasTransportationStops ? styles.infoBlock : undefined}>
+      <BoldText>{texts.bus.authority.accessibility}</BoldText>
+      {elevator !== undefined && (
+        <RegularText>{`${texts.bus.authority.elevator}: ${elevator ? 'ja' : 'nein'}`}</RegularText>
+      )}
+      {wheelchairAccessible !== undefined && (
+        <RegularText>
+          {`${texts.bus.authority.wheelchairAccessible}: ${wheelchairAccessible ? 'ja' : 'nein'}`}
+        </RegularText>
+      )}
+    </View>
+  );
+};
+
+const renderPaymentMethods = ({ hasPreviousDetails, paymentMethods }) => {
+  if (!paymentMethods?.length) {
+    return null;
+  }
+
+  return (
+    <View style={hasPreviousDetails ? styles.infoBlock : undefined}>
+      <BoldText>{texts.bus.authority.paymentMethods}</BoldText>
+      <RegularText>{`${texts.bus.authority.paymentMethod}:`}</RegularText>
+      {paymentMethods
+        .filter((paymentMethod) => !paymentMethod?.notPublic && !!paymentMethod?.name)
+        .map((paymentMethod) => (
+          <RegularText key={paymentMethod.id || paymentMethod.key || paymentMethod.name}>
+            {paymentMethod.name}
+          </RegularText>
+        ))}
+    </View>
+  );
+};
+
+const renderAdditionalDetails = ({
+  openingHours,
+  openWebScreen,
+  transportationStops,
+  elevator,
+  wheelchairAccessible,
+  paymentMethods
+}) => {
+  const hasTransportationStops = !!transportationStops.length;
+  const hasAccessibilityDetails = elevator !== undefined || wheelchairAccessible !== undefined;
+  const hasPaymentMethods = !!paymentMethods.length;
+
+  if (!openingHours && !hasTransportationStops && !hasAccessibilityDetails && !hasPaymentMethods) {
+    return null;
+  }
+
+  return (
+    <Wrapper style={styles.wrapperWithoutTopPadding}>
+      {!!openingHours && (
+        <View>
+          <BoldText>{texts.bus.authority.openingTime}</BoldText>
+          <HtmlView html={trimNewLines(openingHours)} openWebScreen={openWebScreen} />
+        </View>
+      )}
+      {hasTransportationStops && renderTransportationStops(transportationStops)}
+      {renderAccessibilityInfo({
+        elevator,
+        wheelchairAccessible,
+        hasTransportationStops
+      })}
+      {renderPaymentMethods({
+        hasPreviousDetails: hasTransportationStops || hasAccessibilityDetails,
+        paymentMethods
+      })}
+    </Wrapper>
+  );
+};
+
 export const Authority = ({ data, bottomDivider, openWebScreen }) => {
-  const { name, addresses, communications, openingHours } = data;
+  const { name, addresses, communications, openingHours, paymentMethods, transportationStops } =
+    data;
 
   const address = getAddress(addresses);
   const contact = getContact(communications);
 
   const elevator = address?.elevator;
   const wheelchairAccessible = address?.wheelchairAccessible;
+  const authorityTransportationStops = transportationStops ?? address?.transportationStops ?? [];
+  const publicPaymentMethods = (paymentMethods ?? []).filter(
+    (paymentMethod) => !paymentMethod?.notPublic && !!paymentMethod?.name
+  );
 
   return (
     <Block title={name} bottomDivider={bottomDivider}>
-      <Wrapper>
+      <Wrapper style={styles.wrapperWithoutTopPadding}>
         <InfoCard address={address} contact={contact} openWebScreen={openWebScreen} />
       </Wrapper>
 
-      {(!!openingHours || elevator !== undefined || wheelchairAccessible !== undefined) && (
-        <Wrapper style={styles.wrapperWithoutTopPadding}>
-          {!!openingHours && (
-            <View>
-              <BoldText>{texts.bus.authority.openingTime}:</BoldText>
-              <HtmlView html={trimNewLines(openingHours)} openWebScreen={openWebScreen} />
-            </View>
-          )}
-          {elevator !== undefined && (
-            <View>
-              <BoldText>{texts.bus.authority.elevator}:</BoldText>
-              <RegularText>{elevator ? 'ja' : 'nein'}</RegularText>
-            </View>
-          )}
-          {elevator !== undefined && wheelchairAccessible !== undefined && (
-            <View>
-              <RegularText />
-            </View>
-          )}
-          {wheelchairAccessible !== undefined && (
-            <View>
-              <BoldText>{texts.bus.authority.wheelchairAccessible}:</BoldText>
-              <RegularText>{wheelchairAccessible ? 'ja' : 'nein'}</RegularText>
-            </View>
-          )}
-        </Wrapper>
-      )}
+      {renderAdditionalDetails({
+        openingHours,
+        openWebScreen,
+        transportationStops: authorityTransportationStops,
+        elevator,
+        wheelchairAccessible,
+        paymentMethods: publicPaymentMethods
+      })}
     </Block>
   );
 };
 
 const styles = StyleSheet.create({
+  infoBlock: {
+    marginTop: 12
+  },
   wrapperWithoutTopPadding: {
     paddingTop: 0
   }

--- a/src/components/BUS/helpers.js
+++ b/src/components/BUS/helpers.js
@@ -12,12 +12,14 @@ export const getAddress = (addresses) => {
   let address = addresses[0];
 
   const { street, houseNumber, zipcode, area } = address;
+  const streetLine = [street, houseNumber].filter(Boolean).join(' ');
 
   return {
-    street: (!!street || !!houseNumber) && `${address.street} ${address.houseNumber}`,
+    street: streetLine || undefined,
     zip: zipcode,
     city: area?.name,
     elevator: address.elevator,
+    transportationStops: address.transportationStops,
     wheelchairAccessible: address.wheelchairAccessible
   };
 };

--- a/src/components/infoCard/InfoCard.tsx
+++ b/src/components/infoCard/InfoCard.tsx
@@ -54,7 +54,7 @@ export const InfoCard = ({
       </InfoBox>
     )}
 
-    {!!category && !!category.name && (
+    {!!category?.name && (
       <InfoBox>
         <RNEIcon name="list" type="material" color={colors.primary} iconStyle={styles.margin} />
         <RegularText accessibilityLabel={`${consts.a11yLabel.category} (${category.name})`}>
@@ -63,7 +63,7 @@ export const InfoCard = ({
       </InfoBox>
     )}
 
-    <Divider style={styles.divider} />
+    {(!!name || !!category?.name) && <Divider style={styles.divider} />}
 
     {showOpeningTimes && <OpenStatus openingHours={openingHours} />}
 

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -77,8 +77,12 @@ export const texts = {
   backToTop: 'zurück nach oben',
   bus: {
     authority: {
+      accessibility: 'Barrierefreiheit',
       elevator: 'Aufzug vorhanden',
       openingTime: 'Öffnungszeiten',
+      paymentMethod: 'Zahlungsweise',
+      paymentMethods: 'Zahlungsdaten',
+      transportation: 'Verkehrsanbindung',
       wheelchairAccessible: 'Rollstuhlgerecht'
     },
     categoryFilter: {

--- a/src/helpers/busDetailHelper.js
+++ b/src/helpers/busDetailHelper.js
@@ -94,8 +94,7 @@ export const getBusTopActions = (service = {}) => {
   const onlineServices = getTopLevelOnlineServices(service)
     .map((onlineService) => normalizeTopAction(onlineService, 'onlineService'))
     .filter(Boolean);
-  const forms = toArray(service.organisationalUnits)
-    .flatMap((organisationalUnit) => toArray(organisationalUnit?.forms))
+  const forms = toArray(service.forms)
     .map((form) => normalizeTopAction(form, 'form'))
     .filter(Boolean);
 
@@ -108,12 +107,11 @@ export const getBusVisibleTextBlocks = (service = {}) => {
     (textBlock) => {
       return TEXT_BLOCKS_SORTER[textBlock?.type?.name];
     }
-  )
-    .filter((textBlock) => {
-      const typeName = textBlock?.type?.name?.toUpperCase();
+  ).filter((textBlock) => {
+    const typeName = textBlock?.type?.name?.toUpperCase();
 
-      return !typeName || !HIDDEN_TEXT_BLOCKS.has(typeName);
-    });
+    return !typeName || !HIDDEN_TEXT_BLOCKS.has(typeName);
+  });
 };
 
 export const splitBusTextBlocks = (service = {}) => {

--- a/src/hooks/bus.ts
+++ b/src/hooks/bus.ts
@@ -7,6 +7,9 @@ import {
   findBusCategoryChildren,
   findBusCategoryRoot,
   findPublicServicesPage,
+  getBusServiceForms,
+  getBusServiceOrganisationalUnits,
+  getBusServicePersons,
   getPoliticalArea,
   getPublicService,
   searchPoliticalAreas
@@ -43,6 +46,10 @@ export const DEFAULT_BUS_LIFE_SITUATIONS_ROOT_SEARCH_WORD =
 export const BUS_MIN_SEARCH_LENGTH = 3;
 export const BUS_SEARCH_DEBOUNCE_MS = 400;
 const BUS_QUERY_RETRY_COUNT = 0;
+
+const getSettledValueOrFallback = <T>(result: PromiseSettledResult<T>, fallback: T): T => {
+  return result.status === 'fulfilled' ? result.value : fallback;
+};
 
 const flattenServicePages = (pages?: { items?: BusServiceListItem[] }[]) =>
   _sortBy(
@@ -309,7 +316,26 @@ export const useBusService = ({ areaId, id }: BusServiceArgs) => {
 
   const { data, isLoading, refetch } = useQuery<BusServiceDetail | undefined, Error>(
     [BUS_QUERY_KEYS.ROOT, BUS_QUERY_KEYS.SERVICE, areaId, id, busQueryConfigKey],
-    () => getPublicService({ areaId, bus, id }),
+    async () => {
+      const service = await getPublicService({ areaId, bus, id });
+
+      if (service == null) {
+        return;
+      }
+
+      const [formsResult, organisationalUnitsResult, personsResult] = await Promise.allSettled([
+        getBusServiceForms({ areaId, bus, id }),
+        getBusServiceOrganisationalUnits({ areaId, bus, id }),
+        getBusServicePersons({ areaId, bus, id })
+      ]);
+
+      return {
+        ...service,
+        forms: getSettledValueOrFallback(formsResult, []),
+        organisationalUnits: getSettledValueOrFallback(organisationalUnitsResult, []),
+        persons: getSettledValueOrFallback(personsResult, [])
+      };
+    },
     {
       enabled: hasBusConfig && !!id
     }

--- a/src/queries/bus.js
+++ b/src/queries/bus.js
@@ -84,6 +84,67 @@ const buildPublicServiceFindUrl = ({ areaId, baseUrl, limit, offset, searchWord,
   return `${baseUrl}/${endpoint}${commonQuery}&searchWord=${encodedSearchWord}${selectAttributes}`;
 };
 
+const buildRelatedEntityFindUrl = ({ areaId, baseUrl, endpoint, id, limit, offset }) => {
+  return `${baseUrl}/${endpoint}?areaId=${encodeURIComponent(areaId)}&pstId=${encodeURIComponent(
+    id
+  )}&limit=${encodeURIComponent(limit)}&offset=${encodeURIComponent(offset)}`;
+};
+
+const mapPagedResults = ({ headers, payload }) => {
+  const items = (payload?.results || []).map((item) => item?.object).filter(Boolean);
+  const totalItemCount =
+    Number(headers?.get?.('total-item-count')) || Number(payload?.totalCount) || items.length;
+
+  return { items, totalItemCount };
+};
+
+const findPagedRelatedEntityItemsPage = async ({ areaId, bus, endpoint, id, limit, offset }) => {
+  const { apiKey, uri: baseUrl } = bus;
+  const requestUrl = buildRelatedEntityFindUrl({
+    areaId,
+    baseUrl,
+    endpoint,
+    id,
+    limit,
+    offset
+  });
+
+  return mapPagedResults(await requestJson(requestUrl, apiKey));
+};
+
+const findAllPagedRelatedEntityItems = async ({
+  areaId,
+  bus,
+  endpoint,
+  id,
+  limit = DEFAULT_LIST_LIMIT
+}) => {
+  const aggregatedItems = [];
+  let offset = 0;
+  let totalItemCount = 0;
+
+  do {
+    const page = await findPagedRelatedEntityItemsPage({
+      areaId,
+      bus,
+      endpoint,
+      id,
+      limit,
+      offset
+    });
+
+    aggregatedItems.push(...page.items);
+    totalItemCount = page.totalItemCount;
+    offset = aggregatedItems.length;
+
+    if (!page.items.length) {
+      break;
+    }
+  } while (offset < totalItemCount);
+
+  return aggregatedItems;
+};
+
 const mapPoliticalArea = (area) => {
   if (!area?.id && !area?.ags && !(area?.displayName || area?.name || area?.nameShort)) return null;
 
@@ -118,12 +179,36 @@ export const findPublicServicesPage = async ({
     offset,
     searchWord: normalizedSearchWord
   });
-  const { headers, payload } = await requestJson(requestUrl, apiKey);
-  const items = (payload?.results || []).map((item) => item?.object).filter(Boolean);
-  const totalItemCount = Number(headers?.get?.('total-item-count')) || items.length;
 
-  return { items, totalItemCount };
+  return mapPagedResults(await requestJson(requestUrl, apiKey));
 };
+
+export const getBusServiceOrganisationalUnits = async ({ areaId, bus, id, limit }) =>
+  findAllPagedRelatedEntityItems({
+    areaId,
+    bus,
+    endpoint: 'ou/findByCompetence',
+    id,
+    limit
+  });
+
+export const getBusServicePersons = async ({ areaId, bus, id, limit }) =>
+  findAllPagedRelatedEntityItems({
+    areaId,
+    bus,
+    endpoint: 'person/find',
+    id,
+    limit
+  });
+
+export const getBusServiceForms = async ({ areaId, bus, id, limit }) =>
+  findAllPagedRelatedEntityItems({
+    areaId,
+    bus,
+    endpoint: 'form/find',
+    id,
+    limit
+  });
 
 export const findBusCategoryRoot = async ({ areaId, bus, searchWord }) => {
   const { apiKey, uri: baseUrl } = bus;

--- a/src/types/Bus.ts
+++ b/src/types/Bus.ts
@@ -68,6 +68,24 @@ export type BusCommunication = {
   value?: string;
 };
 
+export type BusPaymentMethod = {
+  description?: string;
+  id?: string | number;
+  key?: string;
+  name?: string;
+  notPublic?: boolean;
+};
+
+export type BusTransportationLine = {
+  name?: string;
+  type?: BusType;
+};
+
+export type BusTransportationStop = {
+  lines?: BusTransportationLine[];
+  name?: string;
+};
+
 export type BusAddress = {
   area?: {
     name?: string;
@@ -75,6 +93,7 @@ export type BusAddress = {
   elevator?: boolean;
   houseNumber?: string;
   street?: string;
+  transportationStops?: BusTransportationStop[];
   wheelchairAccessible?: boolean;
   zipcode?: string;
 };
@@ -105,6 +124,8 @@ export type BusOrganisationalUnit = {
   id?: string | number;
   name?: string;
   openingHours?: string;
+  paymentMethods?: BusPaymentMethod[];
+  transportationStops?: BusTransportationStop[];
 };
 
 export type BusPerson = {
@@ -120,6 +141,7 @@ export type BusPerson = {
 };
 
 export type BusServiceDetail = BusServiceListItem & {
+  forms?: BusForm[];
   onlineServices?: BusOnlineService[];
   organisationalUnits?: BusOrganisationalUnit[];
   persons?: BusPerson[];


### PR DESCRIPTION
This PR improves BUS service detail loading and authority rendering.

It enriches the service detail response with related `forms`, `organisationalUnits`, and `persons` from dedicated BUS endpoints, and extends the authority section to show transportation, accessibility, and public payment method information.

## Changes

- added paginated BUS queries for related service entities
- enriched `useBusService` with `forms`, `organisationalUnits`, and `persons`
- updated BUS detail helper logic to use root-level `forms`
- extended authority rendering with:
  - transportation stops and lines
  - accessibility information
  - public payment methods
- added BUS types for `paymentMethods` and `transportationStops`
- adjusted `InfoCard` divider rendering to avoid empty separators
- added and updated tests for queries, hooks, helpers, and authority rendering

## Why

Some BUS detail data was not available in the base service response and had to be fetched separately.

This change was made so:
- service detail screens showed complete related data
- authority information became more useful for users
- pagination and missing response headers were handled more robustly
- the updated payload shape was covered by tests and less likely to regress

## Testing

- added tests for paginated related-entity BUS queries
- added tests for `useBusService` enrichment behavior
- added tests for authority rendering of transportation, accessibility, and payment data
- updated helper tests for the new root-level `forms` structure