### PR TITLE
feat: add a map button to the subcategory list

### DIFF
--- a/src/components/map/ChipFilter.tsx
+++ b/src/components/map/ChipFilter.tsx
@@ -5,12 +5,12 @@ import { useQuery } from 'react-apollo';
 import { FlatList, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { IconUrl, colors, normalize } from '../../config';
+import { IconUrl, colors, consts, normalize } from '../../config';
 import { QUERY_TYPES, getQuery } from '../../queries';
 import { BoldText } from '../Text';
 
 type Props = {
-  pointsOfInterest?: { category: { id: string | number; iconName: string; name: string } }[];
+  pointsOfInterest?: { category: { id: string | number; iconName?: string; name: string } }[];
   queryVariables: {
     category?: string;
     categoryId?: string | number;
@@ -27,7 +27,7 @@ type Props = {
 };
 
 const keyExtractor = (
-  item: { id: string | number; iconName: string; name: string },
+  item: { id: string | number; iconName?: string; name: string },
   index: number
 ) => `index${index}-id${item.id}`;
 
@@ -43,10 +43,7 @@ export const ChipFilter = ({ queryVariables, refetch }: Props) => {
     }
   });
 
-  const filter = _sortBy(
-    data?.categories.filter((item: { iconName: string }) => !!item.iconName),
-    'name'
-  );
+  const filter = _sortBy(data?.categories || [], 'name');
 
   useEffect(() => {
     refetch?.({ limit: undefined, categoryIds });
@@ -92,7 +89,7 @@ export const ChipFilter = ({ queryVariables, refetch }: Props) => {
                   index === filter?.length - 1 && styles.lastChip
                 ]}
               >
-                {!!item.iconName && <IconUrl iconName={item.iconName} />}
+                <IconUrl iconName={item.iconName || consts.MAP.DEFAULT_PIN} />
                 <BoldText small style={styles.category}>
                   {item.name}
                 </BoldText>

--- a/src/components/map/LocationOverview.tsx
+++ b/src/components/map/LocationOverview.tsx
@@ -86,8 +86,13 @@ const mapToMapMarkers = (
         }
       }
 
+      if (item.payload?.iconName) {
+        iconName = item.payload.iconName;
+        activeIconName = item.payload.activeIconName ?? `${item.payload.iconName}Active`;
+      }
+
       return {
-        [item.category?.iconName || MAP.DEFAULT_PIN]: 1,
+        [iconName]: 1,
         iconName,
         activeIconName,
         id: item.id,

--- a/src/components/screens/Overviews.js
+++ b/src/components/screens/Overviews.js
@@ -364,17 +364,7 @@ export const Overviews = ({ navigation, route }) => {
     });
   }, [data, query, queryVariables]);
 
-  if (!query) return null;
-
-  const initialNewsItemsFetch =
-    query === QUERY_TYPES.NEWS_ITEMS &&
-    !Object.prototype.hasOwnProperty.call(queryVariables, 'dataProvider') &&
-    !Object.prototype.hasOwnProperty.call(queryVariables, 'refetch');
-
-  const isShowMapSwitchButton = query === QUERY_TYPES.POINTS_OF_INTEREST;
   const hasNestedPoiCategories = hasNestedPointsOfInterestCategories(categories);
-  const canShowFloatingMapSwitch =
-    isShowMapSwitchButton && (!!listItems?.length || hasNestedPoiCategories);
 
   const locationOverviewQueryVariables = useMemo(() => {
     if (
@@ -399,6 +389,17 @@ export const Overviews = ({ navigation, route }) => {
     };
   }, [categories, hasNestedPoiCategories, query, queryVariables]);
 
+  if (!query) return null;
+
+  const initialNewsItemsFetch =
+    query === QUERY_TYPES.NEWS_ITEMS &&
+    !Object.prototype.hasOwnProperty.call(queryVariables, 'dataProvider') &&
+    !Object.prototype.hasOwnProperty.call(queryVariables, 'refetch');
+
+  const isShowMapSwitchButton = query === QUERY_TYPES.POINTS_OF_INTEREST;
+  const canShowFloatingMapSwitch =
+    isShowMapSwitchButton && (!!listItems?.length || hasNestedPoiCategories);
+
   if ((loading && (!data || initialNewsItemsFetch)) || loadingPosition) {
     return (
       <LoadingContainer>
@@ -407,10 +408,8 @@ export const Overviews = ({ navigation, route }) => {
     );
   }
 
-  const hasMultipleMapCategories =
-    (locationOverviewQueryVariables?.categoryIds?.length || 0) > 1;
-  const hideModalFilter =
-    isShowMapSwitchButton && showMap && hasMultipleMapCategories;
+  const hasMultipleMapCategories = (locationOverviewQueryVariables?.categoryIds?.length || 0) > 1;
+  const hideModalFilter = isShowMapSwitchButton && showMap && hasMultipleMapCategories;
 
   return (
     <SafeAreaViewFlex>

--- a/src/components/screens/Overviews.js
+++ b/src/components/screens/Overviews.js
@@ -66,6 +66,29 @@ const isMapSelected = (query, topFilter) =>
   query === QUERY_TYPES.POINTS_OF_INTEREST &&
   topFilter.find((entry) => entry.selected).id === FILTER_TYPES.MAP;
 
+const hasNestedPointsOfInterestCategories = (categories = []) =>
+  categories.some((category) => {
+    if ((category?.pointsOfInterestTreeCount || 0) > 0) {
+      return true;
+    }
+
+    return hasNestedPointsOfInterestCategories(category?.params?.categories || []);
+  });
+
+const collectNestedPointsOfInterestCategoryIds = (categories = []) => {
+  const ids = [];
+
+  categories.forEach((category) => {
+    if ((category?.pointsOfInterestTreeCount || 0) > 0 && category?.id) {
+      ids.push(String(category.id));
+    }
+
+    ids.push(...collectNestedPointsOfInterestCategoryIds(category?.params?.categories || []));
+  });
+
+  return [...new Set(ids)];
+};
+
 const keyForSelectedValueByQuery = (query) => {
   const QUERIES = {
     [QUERY_TYPES.NEWS_ITEMS]: 'dataProvider'
@@ -348,6 +371,35 @@ export const Overviews = ({ navigation, route }) => {
     !Object.prototype.hasOwnProperty.call(queryVariables, 'dataProvider') &&
     !Object.prototype.hasOwnProperty.call(queryVariables, 'refetch');
 
+  const isShowMapSwitchButton = query === QUERY_TYPES.POINTS_OF_INTEREST;
+  const hasNestedPoiCategories = hasNestedPointsOfInterestCategories(categories);
+  const canShowFloatingMapSwitch =
+    isShowMapSwitchButton && (!!listItems?.length || hasNestedPoiCategories);
+
+  const locationOverviewQueryVariables = useMemo(() => {
+    if (
+      query !== QUERY_TYPES.POINTS_OF_INTEREST ||
+      !hasNestedPoiCategories ||
+      !!listItems?.length ||
+      (queryVariables?.categoryIds?.length || 0) > 0
+    ) {
+      return queryVariables;
+    }
+
+    const categoryIds = collectNestedPointsOfInterestCategoryIds(categories);
+
+    if (!categoryIds.length) {
+      return queryVariables;
+    }
+
+    return {
+      ...queryVariables,
+      category: undefined,
+      categoryId: undefined,
+      categoryIds
+    };
+  }, [categories, hasNestedPoiCategories, listItems?.length, query, queryVariables]);
+
   if ((loading && (!data || initialNewsItemsFetch)) || loadingPosition) {
     return (
       <LoadingContainer>
@@ -370,19 +422,19 @@ export const Overviews = ({ navigation, route }) => {
         />
       )}
 
-      {query === QUERY_TYPES.POINTS_OF_INTEREST &&
+      {isShowMapSwitchButton &&
         switchBetweenListAndMap == SWITCH_BETWEEN_LIST_AND_MAP.TOP_FILTER && (
           <>
             <IndexFilterWrapperAndList filter={filterType} setFilter={setFilterType} />
             <Divider />
           </>
         )}
-      {query === QUERY_TYPES.POINTS_OF_INTEREST && showMap ? (
+      {isShowMapSwitchButton && showMap ? (
         <LocationOverview
           currentPosition={currentPosition}
           navigation={navigation}
           position={position}
-          queryVariables={queryVariables}
+          queryVariables={locationOverviewQueryVariables}
           route={route}
         />
       ) : (
@@ -465,8 +517,7 @@ export const Overviews = ({ navigation, route }) => {
         </>
       )}
       {!loading &&
-        !!listItems?.length &&
-        query === QUERY_TYPES.POINTS_OF_INTEREST &&
+        canShowFloatingMapSwitch &&
         switchBetweenListAndMap == SWITCH_BETWEEN_LIST_AND_MAP.BOTTOM_FLOATING_BUTTON &&
         filterType.find((entry) => entry.title == texts.locationOverview.list)?.selected && (
           <IndexMapSwitch filter={filterType} setFilter={setFilterType} />

--- a/src/components/screens/Overviews.js
+++ b/src/components/screens/Overviews.js
@@ -380,7 +380,6 @@ export const Overviews = ({ navigation, route }) => {
     if (
       query !== QUERY_TYPES.POINTS_OF_INTEREST ||
       !hasNestedPoiCategories ||
-      !!listItems?.length ||
       (queryVariables?.categoryIds?.length || 0) > 0
     ) {
       return queryVariables;
@@ -398,7 +397,7 @@ export const Overviews = ({ navigation, route }) => {
       categoryId: undefined,
       categoryIds
     };
-  }, [categories, hasNestedPoiCategories, listItems?.length, query, queryVariables]);
+  }, [categories, hasNestedPoiCategories, query, queryVariables]);
 
   if ((loading && (!data || initialNewsItemsFetch)) || loadingPosition) {
     return (
@@ -408,11 +407,14 @@ export const Overviews = ({ navigation, route }) => {
     );
   }
 
-  const showMapFilter = (queryVariables?.categoryIds?.length || 0) > 1;
+  const hasMultipleMapCategories =
+    (locationOverviewQueryVariables?.categoryIds?.length || 0) > 1;
+  const hideModalFilter =
+    isShowMapSwitchButton && showMap && hasMultipleMapCategories;
 
   return (
     <SafeAreaViewFlex>
-      {!showMapFilter && (
+      {!hideModalFilter && (
         <Filter
           filterTypes={filterTypes}
           initialQueryVariables={initialQueryVariables}

--- a/src/components/screens/PointOfInterest.tsx
+++ b/src/components/screens/PointOfInterest.tsx
@@ -131,9 +131,20 @@ export const PointOfInterest = ({ data, hideMap, navigation, route }: PointOfInt
     nestedCategory = categories.find((category) => category.name === categoryName);
   }
 
+  const iconName = payload?.iconName || category?.iconName || MAP.DEFAULT_PIN;
+
   const status = availableVehiclesData?.length
     ? availableVehiclesData[0]?.properties?.[vehiclePropertyKey]
     : undefined;
+
+  // Use payload.activeIconName when provided; fall back to the conventional "Active" suffix only
+  // for icons that come from the category or the default pin (where the asset is guaranteed to
+  // exist). When the icon originates from the payload and no activeIconName is supplied, pass
+  // undefined so MapLibre falls back to iconName instead of trying a missing asset.
+  const activeIconName =
+    typeof status === 'string' && status !== 'unbekannt'
+      ? status
+      : payload?.activeIconName ?? (payload?.iconName ? undefined : `${iconName}Active`);
 
   return (
     <WrapperVertical>
@@ -193,14 +204,14 @@ export const PointOfInterest = ({ data, hideMap, navigation, route }: PointOfInt
 
       {!!payload?.freeStatusUrl && (
         <AvailableVehicles
-          iconName={category?.iconName}
+          iconName={iconName}
           isSpecialForParkHaus={availableVehiclesData[0]?.isSpecialForParkHaus}
           loading={availableVehiclesLoading}
           status={status}
         />
       )}
 
-      {hasTravelTimes && <TravelTimes id={id} iconName={category?.iconName} />}
+      {hasTravelTimes && <TravelTimes id={id} iconName={iconName} />}
 
       {!!openingHours?.length && (
         <WrapperVertical>
@@ -253,11 +264,8 @@ export const PointOfInterest = ({ data, hideMap, navigation, route }: PointOfInt
             isMyLocationButtonVisible={false}
             locations={[
               {
-                iconName: category?.iconName || MAP.DEFAULT_PIN,
-                activeIconName:
-                  typeof status === 'string' && status !== 'unbekannt'
-                    ? status
-                    : `${category?.iconName || MAP.DEFAULT_PIN}Active`,
+                iconName: iconName,
+                activeIconName,
                 id,
                 position: { latitude, longitude }
               }


### PR DESCRIPTION
This PR adds a button to switch to map view in the subcategory list, and if the payload includes an `iconName` value, pins sent with that `iconName` are displayed on the map.

|list view|map view|
|--|--|
<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-05-22 at 07 33 25" src="https://github.com/user-attachments/assets/f494d78b-7922-4732-a2e2-f8aaec21a15b" />|<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-05-22 at 07 33 38" src="https://github.com/user-attachments/assets/d63f909a-9140-42f7-9424-9fe6378e62dd" />


SVASD-487