### PR TITLE
fix: reduce repeated SUE config errors

### DIFF
--- a/__tests__/ConfigurationsProvider.test.tsx
+++ b/__tests__/ConfigurationsProvider.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import { ConfigurationsProvider } from '../src/ConfigurationsProvider';
+import { SettingsContext, initialContext } from '../src/SettingsProvider';
+
+const mockApolloUseQuery = jest.fn();
+const mockReactQueryUseQuery = jest.fn();
+const mockSetConfigurations = jest.fn();
+const mockUseHomeRefresh = jest.fn();
+const mockUseStaticContent = jest.fn();
+
+jest.mock('react-apollo', () => ({
+  useQuery: (...args) => mockApolloUseQuery(...args)
+}));
+
+jest.mock('react-query', () => ({
+  useQuery: (...args) => mockReactQueryUseQuery(...args)
+}));
+
+jest.mock('../src/helpers', () => ({
+  getSueApiConfig: jest.requireActual('../src/helpers/sueHelper').getSueApiConfig,
+  storageHelper: {
+    setConfigurations: (...args) => mockSetConfigurations(...args)
+  }
+}));
+
+jest.mock('../src/hooks', () => ({
+  useHomeRefresh: (...args) => mockUseHomeRefresh(...args),
+  useStaticContent: (...args) => mockUseStaticContent(...args)
+}));
+
+jest.mock('../src/queries', () => ({
+  QUERY_TYPES: {
+    RESOURCE_FILTERS: 'resource-filters',
+    SUE: {
+      CONFIGURATIONS: 'sue-configurations'
+    }
+  },
+  getQuery: jest.fn(() => jest.fn())
+}));
+
+const renderProvider = (sueSettings = {}) => {
+  let testRenderer;
+
+  renderer.act(() => {
+    testRenderer = renderer.create(
+      <SettingsContext.Provider
+        value={{
+          ...initialContext,
+          globalSettings: {
+            ...initialContext.globalSettings,
+            settings: {
+              sue: sueSettings
+            }
+          }
+        }}
+      >
+        <ConfigurationsProvider>
+          <></>
+        </ConfigurationsProvider>
+      </SettingsContext.Provider>
+    );
+  });
+
+  return testRenderer;
+};
+
+describe('ConfigurationsProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockApolloUseQuery.mockReturnValue({
+      data: {
+        resourceFilters: []
+      }
+    });
+
+    mockUseHomeRefresh.mockImplementation(() => undefined);
+  });
+
+  it('refetches SUE configuration on home refresh when base apiConfig is complete and whichApi is invalid', async () => {
+    const refetchSueConfig = jest.fn().mockResolvedValue(undefined);
+    const refetchSueProgress = jest.fn().mockResolvedValue(undefined);
+
+    mockReactQueryUseQuery.mockReturnValue({
+      data: undefined,
+      refetch: refetchSueConfig
+    });
+
+    mockUseStaticContent.mockReturnValue({
+      data: undefined,
+      refetch: refetchSueProgress
+    });
+
+    renderProvider({
+      apiConfig: {
+        whichApi: 'typoed-api',
+        apiKey: 'base-api-key',
+        serverUrl: 'https://example.com'
+      }
+    });
+
+    const onRefresh = mockUseHomeRefresh.mock.calls[0][0];
+
+    await renderer.act(async () => {
+      await onRefresh();
+    });
+
+    expect(refetchSueConfig).toHaveBeenCalledTimes(1);
+    expect(refetchSueProgress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/helpers/sueHelper.test.ts
+++ b/__tests__/helpers/sueHelper.test.ts
@@ -1,0 +1,46 @@
+import { getSueApiConfig } from '../../src/helpers/sueHelper';
+
+describe('getSueApiConfig', () => {
+  it('returns the selected nested api config when whichApi points to an existing key', () => {
+    expect(
+      getSueApiConfig({
+        whichApi: 'secondary',
+        apiKey: 'base-api-key',
+        serverUrl: 'https://base.example.com',
+        secondary: {
+          apiKey: 'secondary-api-key',
+          serverUrl: 'https://secondary.example.com'
+        }
+      })
+    ).toEqual({
+      apiKey: 'secondary-api-key',
+      serverUrl: 'https://secondary.example.com'
+    });
+  });
+
+  it('falls back to the base api config when whichApi points to a missing key', () => {
+    expect(
+      getSueApiConfig({
+        whichApi: 'missing',
+        apiKey: 'base-api-key',
+        serverUrl: 'https://base.example.com'
+      })
+    ).toEqual({
+      whichApi: 'missing',
+      apiKey: 'base-api-key',
+      serverUrl: 'https://base.example.com'
+    });
+  });
+
+  it('returns the base api config when whichApi is not set', () => {
+    expect(
+      getSueApiConfig({
+        apiKey: 'base-api-key',
+        serverUrl: 'https://base.example.com'
+      })
+    ).toEqual({
+      apiKey: 'base-api-key',
+      serverUrl: 'https://base.example.com'
+    });
+  });
+});

--- a/src/ConfigurationsProvider.tsx
+++ b/src/ConfigurationsProvider.tsx
@@ -16,7 +16,7 @@ import {
   defaultResourceFiltersConfig
 } from './config/appDesignSystem';
 import { defaultSueAppConfig } from './config/sue';
-import { storageHelper } from './helpers';
+import { getSueApiConfig, storageHelper } from './helpers';
 import { useHomeRefresh, useStaticContent } from './hooks';
 import { QUERY_TYPES, getQuery } from './queries';
 import { GenericType } from './types';
@@ -56,10 +56,19 @@ const defaultConfiguration = {
 
 export const ConfigurationsContext = createContext(defaultConfiguration);
 
+const hasSueApiConfiguration = (sueConfig: Record<string, any> = {}) => {
+  const { apiConfig = {} } = sueConfig;
+  const selectedApiConfig = getSueApiConfig(apiConfig);
+
+  return !!(selectedApiConfig?.apiKey && selectedApiConfig?.serverUrl);
+};
+
 export const ConfigurationsProvider = ({ children }: { children?: ReactNode }) => {
   const { globalSettings } = useContext(SettingsContext);
   const { settings, appDesignSystem = {} } = globalSettings;
   const { sue = {} } = settings || {};
+  const hasSueSettings = !!Object.keys(sue).length;
+  const hasCompleteSueApiConfiguration = hasSueApiConfiguration(sue);
 
   const [configurations, setConfigurations] = useState(defaultConfiguration);
   const [isLoading, setIsLoading] = useState(true);
@@ -67,14 +76,14 @@ export const ConfigurationsProvider = ({ children }: { children?: ReactNode }) =
   const { data: sueConfigData, refetch: refetchSueConfig } = useQuery(
     [QUERY_TYPES.SUE.CONFIGURATIONS],
     () => getQuery(QUERY_TYPES.SUE.CONFIGURATIONS)(),
-    { enabled: !!Object.keys(sue).length }
+    { enabled: hasSueSettings, retry: false }
   );
 
   const { data: sueProgress, refetch: refetchSueProgress } = useStaticContent({
     refreshTimeKey: 'publicJsonFile-sueReportProgress',
     name: 'sueReportProgress',
     type: 'json',
-    skip: !Object.keys(sue).length
+    skip: !hasSueSettings
   });
 
   const { data: resourceFiltersData } = useQueryWithApollo(getQuery(QUERY_TYPES.RESOURCE_FILTERS), {
@@ -105,13 +114,15 @@ export const ConfigurationsProvider = ({ children }: { children?: ReactNode }) =
     setIsLoading(true);
 
     try {
-      await refetchSueConfig();
+      if (hasCompleteSueApiConfiguration) {
+        await refetchSueConfig();
+      }
       await refetchSueProgress();
     } catch (e) {
       console.warn(e);
     }
     setIsLoading(false);
-  }, []);
+  }, [hasCompleteSueApiConfiguration, refetchSueConfig, refetchSueProgress]);
 
   useHomeRefresh(reloadCallback);
 

--- a/src/helpers/sueHelper.ts
+++ b/src/helpers/sueHelper.ts
@@ -1,11 +1,13 @@
 import { storageHelper } from './storageHelper';
 
+export const getSueApiConfig = (apiConfig: Record<string, any> = {}) =>
+  (apiConfig?.whichApi ? apiConfig?.[apiConfig.whichApi] : undefined) || apiConfig;
+
 export const fetchSueEndpoints = async (serviceRequestId?: number) => {
   const configurations = await storageHelper.configurations();
   const { sueConfig = {} } = configurations;
   const { apiConfig = {} } = sueConfig;
-
-  const { apiKey, serverUrl } = apiConfig[apiConfig?.whichApi] || apiConfig;
+  const { apiKey, serverUrl } = getSueApiConfig(apiConfig);
 
   const sueFetchObj = {
     method: 'GET',


### PR DESCRIPTION
- disabled `react-query` retries for `QUERY_TYPES.SUE.CONFIGURATIONS` so a missing `apiKey` emitted the error only once per query attempt.
- skipped `refetchSueConfig()` during home refresh when `apiConfig` lacked `apiKey` or `serverUrl` so navigation no longer retriggered the same warning.