### PR TITLE
feat: enhance WebScreen with user agent handling

### DIFF
--- a/src/screens/WebScreen.tsx
+++ b/src/screens/WebScreen.tsx
@@ -15,6 +15,7 @@ import { SettingsContext } from '../SettingsProvider';
 
 const { MATOMO_TRACKING } = consts;
 
+// eslint-disable-next-line complexity
 export const WebScreen = ({
   route
 }: {
@@ -32,14 +33,19 @@ export const WebScreen = ({
   const { isConnected } = useContext(NetworkContext);
   const { globalSettings = {} } = useContext(SettingsContext);
   const { settings = {} } = globalSettings;
-  const { isIncognitoWebScreens = true } = settings;
+  const { webView = {} } = settings;
+  const { isIncognito: isIncognitoWebView, mobileUserAgent = {} } = webView;
   const trackScreenViewAsync = useTrackScreenViewAsync();
   const webUrl = route.params?.webUrl ?? '';
   const injectedJavaScript = route.params?.injectedJavaScript ?? '';
   const inModalBrowser = route.params?.inModalBrowser ?? false;
   const isExternal = route.params?.isExternal ?? false;
-  // Use route-specific isIncognito if provided, otherwise fall back to global setting
-  const isIncognito = route.params?.isIncognito ?? isIncognitoWebScreens;
+  const resolvedUserAgent = mobileUserAgent?.[device.platform]?.toString()?.trim();
+  const legacyIsIncognitoWebScreens = (settings as { isIncognitoWebScreens?: boolean })
+    ?.isIncognitoWebScreens;
+  // Backward-compatible priority: route param -> new webView key -> legacy key -> default
+  const isIncognito =
+    route.params?.isIncognito ?? isIncognitoWebView ?? legacyIsIncognitoWebScreens ?? true;
 
   // NOTE: we cannot use the `useMatomoTrackScreenView` hook here, as we need the `webUrl`
   //       dependency
@@ -89,6 +95,7 @@ export const WebScreen = ({
         source={{ uri: webUrl }}
         startInLoadingState
         style={styles.container}
+        userAgent={resolvedUserAgent}
       />
     </SafeAreaViewFlex>
   );


### PR DESCRIPTION
With this PR, the mobile user agent value required by some websites can now be updated via `globalSettings`

You can add the mobile user agent to the `settings` object in `globalSettings` separately for each platform, as shown below.

````
  "settings": {
    "webView": {
      "isIncognito": true,
      "mobileUserAgent": {
        "ios": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
        "android": "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
      }
    },
     ...
    }
````

SVASD-585