### PR TITLE
feat: add a feature to manage accessibility settings

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -65,3 +65,7 @@ For detailed documentation see [the auth docs](./AUTH.md).
 ## Augmented Reality
 
 For detailed documentation see [the ar docs](./AR.md).
+
+## Accessibility
+
+For detailed documentation see [the accessibility settings docs](./accessibility-settings.md).

--- a/docs/accessibility-guidelines.md
+++ b/docs/accessibility-guidelines.md
@@ -5,6 +5,30 @@
 This document defines the accessibility baseline for React Native features in this project.
 It covers implementation rules, test expectations, and release checks.
 
+## Runtime Configuration Contract
+
+App-level accessibility behavior is configured from:
+
+- `globalSettings.settings.accessibility.enabledFeatures`
+- `globalSettings.settings.accessibility.defaults`
+
+User preferences are persisted separately in local storage:
+
+- `accessibilityUserSettings`
+
+This separation is required so server-side `globalSettings` refreshes do not overwrite user choices.
+
+## PR Gating Model
+
+Accessibility CI is PR-scoped for merge blocking:
+
+1. Detect changed files/components in PR diff.
+2. Run component-scoped checks for changed files.
+3. Publish JSON/Markdown reports as artifacts and PR comment.
+4. Fail PR only on scoped component findings.
+
+Full-scan tests still run for visibility but do not block PRs by themselves.
+
 ## Implementation Rules
 
 1. Every interactive control must have:
@@ -33,6 +57,15 @@ It covers implementation rules, test expectations, and release checks.
 3. Respect reduced-motion behavior where animations are non-essential.
 4. Validate large text behavior for clipping and overflow in fixed-height controls.
 
+### Reduced Motion Expectations
+
+When app-level `reduceMotionEnabled` is active (or OS reduced motion is active):
+
+1. Stack navigation transitions should be disabled.
+2. Non-essential carousel autoplay should be disabled.
+3. Motion-heavy modal transitions should use `animationType="none"` where practical.
+4. UX flow must remain functionally identical; only animation intensity should change.
+
 ## Test Requirements
 
 1. Add or update component tests when accessibility props are changed.
@@ -50,6 +83,8 @@ Run smoke checks on:
 4. Android font-size scaling
 5. Reduced Motion enabled
 6. High contrast / reduced transparency scenarios
+7. Settings screen and header accessibility modal state sync
+8. Onboarding terms gating (`continue/skip`) behavior
 
 ## PR Review Checklist
 
@@ -60,3 +95,4 @@ Before merge, confirm:
 3. Form changes expose error and disabled semantics.
 4. `npm run test:accessibility` passes.
 5. Any known accessibility tradeoff is documented in the PR description.
+6. If motion behavior changed, reduced-motion mode has been manually verified.

--- a/docs/accessibility-settings.md
+++ b/docs/accessibility-settings.md
@@ -1,0 +1,188 @@
+# Accessibility Settings
+
+## Overview
+
+This document describes the app-level accessibility settings introduced on top of the existing system accessibility support.
+
+The feature has three goals:
+
+1. Allow app operators to enable/disable accessibility capabilities globally via `globalSettings`.
+2. Allow users to manage accessibility preferences from:
+   - the **Settings** screen, and
+   - the **header accessibility modal**.
+3. Persist user preferences locally so selections survive app restarts.
+
+In addition, pull requests are validated with a PR-scoped accessibility workflow that reports missing accessibility requirements per changed component.
+
+## PR Accessibility Workflow (Component-Scoped)
+
+The CI workflow is defined in:
+
+- `.github/workflows/accessibility-checks.yml`
+
+PR behavior:
+
+1. Detect changed files in the PR diff.
+2. Scope accessibility checks to changed files under:
+   - `src/components`
+   - `src/screens`
+   - `src/navigation`
+   - `src/config/navigation`
+3. Run ESLint accessibility rules on scoped files.
+4. Publish a Markdown/JSON report as build artifacts.
+5. Post or update a PR comment with component-level findings.
+6. Fail the PR only when scoped component checks fail.
+
+Full accessibility tests still run for visibility, but PR gate/fail status is determined by scoped component findings.
+
+## Configuration Source
+
+Accessibility configuration is read from:
+
+- `globalSettings.settings.accessibility`
+
+If no configuration is provided, all accessibility features are enabled by default.
+
+## Global Configuration Schema
+
+Use the following JSON shape in `globalSettings`:
+
+```json
+{
+  "settings": {
+    "accessibility": {
+      "enabledFeatures": {
+        "settingsEntry": true,
+        "headerEntry": true,
+        "textScaling": true,
+        "boldText": true,
+        "highContrast": true,
+        "reduceMotion": true,
+        "reduceTransparency": true,
+        "readAloud": true
+      },
+      "defaults": {
+        "textScaleLevel": 2,
+        "highContrastEnabled": false,
+        "reduceMotionEnabled": false,
+        "reduceTransparencyEnabled": false,
+        "readAloudEnabled": false
+      }
+    }
+  }
+}
+```
+
+## Configuration Keys
+
+### `enabledFeatures`
+
+Controls which accessibility capabilities are available in the UI and behavior layer.
+
+- `settingsEntry`
+  - `true`: show Accessibility section in the Settings screen.
+  - `false`: hide Accessibility section from Settings.
+- `headerEntry`
+  - `true`: show accessibility icon in screen headers.
+  - `false`: hide header accessibility icon and modal entry.
+- `textScaling`
+  - Enables/disables text size controls (`A-`, slider, `A+`) in Settings and Header modal.
+  - `boldText` is still read as a backward-compatible alias when `textScaling` is not provided.
+- `boldText`
+  - Backward-compatible alias for `textScaling`.
+- `highContrast`
+  - Enables/disables the in-app higher-contrast preference.
+- `reduceMotion`
+  - Enables/disables in-app reduced-motion preference.
+- `reduceTransparency`
+  - Enables/disables in-app reduced-transparency preference.
+- `readAloud`
+  - Enables/disables read-aloud capability toggle (used as a feature gate for detail TTS behavior).
+
+### `defaults`
+
+Defines default user preference values applied when a user has no stored accessibility preferences yet.
+
+- `textScaleLevel` (0..6, where `2` is default/normal size)
+- `highContrastEnabled`
+- `reduceMotionEnabled`
+- `reduceTransparencyEnabled`
+- `readAloudEnabled`
+
+## Precedence and Persistence
+
+## Runtime precedence
+
+For motion/transparency/text-scaling-related behavior, effective runtime values are resolved from:
+
+1. system accessibility state (OS),
+2. app-level user preference,
+3. feature availability (`enabledFeatures`).
+
+This means OS accessibility still works even if the app-level preference is off.
+
+## Local persistence
+
+User selections are stored in local storage under:
+
+- `accessibilityUserSettings`
+
+Behavior:
+
+- If stored settings exist, they are reused.
+- If no stored settings exist, `defaults` from `globalSettings` are applied.
+- Changes in the Settings screen and header modal update the same stored state.
+
+## User-Facing Behavior
+
+## Settings screen
+
+- Accessibility appears as a dedicated Settings entry when `enabledFeatures.settingsEntry !== false`.
+- The screen exposes toggles only for features enabled by `enabledFeatures`.
+- A reset action restores values to global defaults (`defaults`).
+
+## Header modal
+
+- Header accessibility icon is shown when `enabledFeatures.headerEntry !== false`.
+- Tapping the icon opens a modal with the same toggle set as the Settings screen.
+- Changes made in the modal are applied immediately and persisted.
+
+## Feature Behavior Summary
+
+- **Text Size (A- / Slider / A+)**
+  - Controls app typography scale level and persists user preference.
+  - Applied to app text components and HTML rendering (`Text`, `HtmlView`).
+- **High Contrast**
+  - Replaces low-contrast text colors in app text rendering with stronger contrast where applicable.
+- **Reduce Motion**
+  - Exposes reduced-motion state in accessibility context.
+  - No app-level animation suppression is wired yet.
+- **Reduce Transparency**
+  - Exposes reduced-transparency state for app-level transparency handling.
+  - Already consumed in several UI components (`Input`, `Switch`, `Results`, `VersionNumber`, etc.).
+- **Read Aloud (Feature Gate)**
+  - Provides a persisted toggle and feature gate.
+  - Detail page TTS playback integration is not wired yet.
+
+## Rollout Checklist
+
+1. Add `settings.accessibility` to your `globalSettings` payload.
+2. Enable only the features you want to release.
+3. Set defaults according to your accessibility policy.
+4. Verify:
+   - Settings entry visibility,
+   - header icon visibility,
+   - persistence after app restart,
+   - expected behavior on iOS and Android.
+
+## Troubleshooting
+
+- Accessibility entry does not appear in Settings:
+  - Check `enabledFeatures.settingsEntry` is not `false`.
+- Header icon does not appear:
+  - Check `enabledFeatures.headerEntry` is not `false`.
+- User settings are not persisted:
+  - Verify local storage availability and inspect `accessibilityUserSettings`.
+- Feature toggle visible but no effect:
+  - Confirm the related feature key in `enabledFeatures` is `true`.
+  - Confirm target components consume accessibility context values.

--- a/docs/accessibility-settings.md
+++ b/docs/accessibility-settings.md
@@ -156,7 +156,9 @@ Behavior:
   - Replaces low-contrast text colors in app text rendering with stronger contrast where applicable.
 - **Reduce Motion**
   - Exposes reduced-motion state in accessibility context.
-  - No app-level animation suppression is wired yet.
+  - Stack navigation transitions are disabled in reduced-motion mode.
+  - Image/media carousel autoplay and pause controls are disabled in reduced-motion mode.
+  - Onboarding terms modal switches to `animationType="none"` in reduced-motion mode.
 - **Reduce Transparency**
   - Exposes reduced-transparency state for app-level transparency handling.
   - Already consumed in several UI components (`Input`, `Switch`, `Results`, `VersionNumber`, etc.).

--- a/src/AccessibilityProvider.tsx
+++ b/src/AccessibilityProvider.tsx
@@ -1,8 +1,22 @@
-import React, { createContext, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
-import { accessibilityListeners } from './helpers';
+import {
+  ACCESSIBILITY_FEATURE_BY_PREFERENCE,
+  getTextScaleMultiplier,
+  normalizeTextScaleLevel,
+  accessibilityListeners,
+  resolveAccessibilityConfiguration,
+  storageHelper
+} from './helpers';
+import { SettingsContext } from './SettingsProvider';
+import {
+  AccessibilityContextValue,
+  AccessibilitySystemState,
+  AccessibilityTogglePreferenceKey,
+  AccessibilityUserSettings
+} from './types';
 
-const defaultAccessibility = {
+const defaultSystemAccessibility: AccessibilitySystemState = {
   isBoldTextEnabled: false,
   isGrayscaleEnabled: false,
   isInvertColorsEnabled: false,
@@ -11,14 +25,233 @@ const defaultAccessibility = {
   isScreenReaderEnabled: false
 };
 
-export const AccessibilityContext = createContext(defaultAccessibility);
+const defaultAccessibility: AccessibilityContextValue = {
+  ...defaultSystemAccessibility,
+  defaults: {
+    highContrastEnabled: false,
+    readAloudEnabled: false,
+    reduceMotionEnabled: false,
+    reduceTransparencyEnabled: false,
+    textScaleLevel: 2
+  },
+  features: {
+    boldText: true,
+    headerEntry: true,
+    highContrast: true,
+    readAloud: true,
+    reduceMotion: true,
+    reduceTransparency: true,
+    settingsEntry: true,
+    textScaling: true
+  },
+  isHighContrastEnabled: false,
+  isReadAloudEnabled: false,
+  preferences: {
+    highContrastEnabled: false,
+    readAloudEnabled: false,
+    reduceMotionEnabled: false,
+    reduceTransparencyEnabled: false,
+    textScaleLevel: 2
+  },
+  resetPreferences: () => undefined,
+  setPreference: () => undefined,
+  setPreferences: () => undefined,
+  setTextScaleLevel: () => undefined,
+  system: defaultSystemAccessibility,
+  textScaleMultiplier: 1
+};
+
+export const AccessibilityContext = createContext<AccessibilityContextValue>(defaultAccessibility);
 
 export const AccessibilityProvider = ({ children }: { children?: React.ReactNode }) => {
-  const [accessibility, setAccessibility] = useState(defaultAccessibility);
+  const { globalSettings } = useContext(SettingsContext);
+  const [systemAccessibility, setSystemAccessibility] = useState<AccessibilitySystemState>(
+    defaultSystemAccessibility
+  );
+  const [preferences, setPreferencesState] = useState(defaultAccessibility.preferences);
+  const [hasHydratedSettings, setHasHydratedSettings] = useState(false);
+  const [hasStoredPreferences, setHasStoredPreferences] = useState(false);
+  const [hasUserInteraction, setHasUserInteraction] = useState(false);
+
+  const { defaults, features } = useMemo(
+    () => resolveAccessibilityConfiguration(globalSettings),
+    [globalSettings]
+  );
+
+  const normalizePreferences = useCallback(
+    (
+      values: Partial<AccessibilityUserSettings> & {
+        boldTextEnabled?: boolean;
+        textScaleLevel?: number;
+      },
+      basePreferences: AccessibilityUserSettings
+    ): AccessibilityUserSettings => {
+      const nextPreferences: AccessibilityUserSettings = { ...basePreferences };
+
+      (
+        Object.keys(ACCESSIBILITY_FEATURE_BY_PREFERENCE) as AccessibilityTogglePreferenceKey[]
+      ).forEach((key) => {
+        const featureKey = ACCESSIBILITY_FEATURE_BY_PREFERENCE[key];
+        if (features[featureKey] === false) return;
+
+        const value = values[key];
+        if (typeof value === 'boolean') {
+          nextPreferences[key] = value;
+        }
+      });
+
+      if (features.textScaling) {
+        if (typeof values.textScaleLevel === 'number') {
+          nextPreferences.textScaleLevel = normalizeTextScaleLevel(values.textScaleLevel);
+        } else if (typeof values.boldTextEnabled === 'boolean') {
+          nextPreferences.textScaleLevel = normalizeTextScaleLevel(
+            defaults.textScaleLevel + (values.boldTextEnabled ? 2 : 0)
+          );
+        }
+      }
+
+      return nextPreferences;
+    },
+    [defaults.textScaleLevel, features]
+  );
 
   useEffect(() => {
-    return accessibilityListeners(setAccessibility);
+    return accessibilityListeners(setSystemAccessibility);
   }, []);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const hydratePreferences = async () => {
+      try {
+        const storedSettings = await storageHelper.accessibilityUserSettings();
+
+        if (!mounted) return;
+
+        if (storedSettings && typeof storedSettings === 'object') {
+          setHasStoredPreferences(true);
+          setPreferencesState((prev) =>
+            normalizePreferences(
+              storedSettings as Partial<AccessibilityUserSettings> & {
+                boldTextEnabled?: boolean;
+                textScaleLevel?: number;
+              },
+              prev
+            )
+          );
+        }
+      } catch (error) {
+        console.warn('Could not load accessibility user settings.', error);
+      } finally {
+        if (mounted) {
+          setHasHydratedSettings(true);
+        }
+      }
+    };
+
+    hydratePreferences();
+
+    return () => {
+      mounted = false;
+    };
+  }, [normalizePreferences]);
+
+  useEffect(() => {
+    if (!hasHydratedSettings || hasStoredPreferences || hasUserInteraction) return;
+
+    setPreferencesState((prev) => normalizePreferences(defaults, prev));
+  }, [
+    defaults,
+    hasHydratedSettings,
+    hasStoredPreferences,
+    hasUserInteraction,
+    normalizePreferences
+  ]);
+
+  useEffect(() => {
+    if (!hasHydratedSettings) return;
+    storageHelper.setAccessibilityUserSettings(preferences);
+  }, [hasHydratedSettings, preferences]);
+
+  const setPreference = useCallback(
+    (key: AccessibilityTogglePreferenceKey, value?: boolean) => {
+      const featureKey = ACCESSIBILITY_FEATURE_BY_PREFERENCE[key];
+
+      if (features[featureKey] === false) return;
+
+      setHasUserInteraction(true);
+      setPreferencesState((prev) => ({
+        ...prev,
+        [key]: typeof value === 'boolean' ? value : !prev[key]
+      }));
+    },
+    [features]
+  );
+
+  const setPreferences = useCallback(
+    (values: Partial<typeof defaultAccessibility.preferences>) => {
+      setHasUserInteraction(true);
+      setPreferencesState((prev) => normalizePreferences(values, prev));
+    },
+    [normalizePreferences]
+  );
+
+  const setTextScaleLevel = useCallback(
+    (level: number) => {
+      if (features.textScaling === false) return;
+      setHasUserInteraction(true);
+      setPreferencesState((prev) => ({
+        ...prev,
+        textScaleLevel: normalizeTextScaleLevel(level)
+      }));
+    },
+    [features.textScaling]
+  );
+
+  const resetPreferences = useCallback(() => {
+    setHasUserInteraction(true);
+    setPreferencesState(defaults);
+  }, [defaults]);
+
+  const accessibility = useMemo<AccessibilityContextValue>(() => {
+    const isBoldTextEnabled = systemAccessibility.isBoldTextEnabled;
+    const isReduceMotionEnabled =
+      systemAccessibility.isReduceMotionEnabled ||
+      (features.reduceMotion && preferences.reduceMotionEnabled);
+    const isReduceTransparencyEnabled =
+      systemAccessibility.isReduceTransparencyEnabled ||
+      (features.reduceTransparency && preferences.reduceTransparencyEnabled);
+    const textScaleMultiplier = features.textScaling
+      ? getTextScaleMultiplier(preferences.textScaleLevel)
+      : 1;
+
+    return {
+      ...systemAccessibility,
+      defaults,
+      features,
+      isBoldTextEnabled,
+      isHighContrastEnabled: features.highContrast && preferences.highContrastEnabled,
+      isReadAloudEnabled: features.readAloud && preferences.readAloudEnabled,
+      isReduceMotionEnabled,
+      isReduceTransparencyEnabled,
+      preferences,
+      resetPreferences,
+      setPreference,
+      setPreferences,
+      setTextScaleLevel,
+      system: systemAccessibility,
+      textScaleMultiplier
+    };
+  }, [
+    defaults,
+    features,
+    preferences,
+    resetPreferences,
+    setPreference,
+    setPreferences,
+    setTextScaleLevel,
+    systemAccessibility
+  ]);
 
   return (
     <AccessibilityContext.Provider value={accessibility}>{children}</AccessibilityContext.Provider>

--- a/src/components/AccessibilityHeader.tsx
+++ b/src/components/AccessibilityHeader.tsx
@@ -1,0 +1,42 @@
+import React, { useContext, useState } from 'react';
+import { StyleProp, StyleSheet, TouchableOpacity, ViewStyle } from 'react-native';
+
+import { SettingsContext } from '../SettingsProvider';
+import { colors, consts, Icon, normalize } from '../config';
+import { getAccessibilityHeaderEntryEnabled } from '../helpers';
+
+import { AccessibilitySettingsModal } from './AccessibilitySettingsModal';
+
+type Props = {
+  style: StyleProp<ViewStyle>;
+};
+
+export const AccessibilityHeader = ({ style }: Props) => {
+  const { globalSettings } = useContext(SettingsContext);
+  const [isVisible, setIsVisible] = useState(false);
+
+  if (!getAccessibilityHeaderEntryEnabled(globalSettings)) {
+    return null;
+  }
+
+  return (
+    <>
+      <TouchableOpacity
+        onPress={() => setIsVisible(true)}
+        accessibilityLabel={consts.a11yLabel.accessibilityIcon}
+        accessibilityHint={consts.a11yLabel.accessibilityIconHint}
+        accessibilityRole="button"
+      >
+        <Icon.Settings color={colors.darkText} style={[style, styles.icon]} />
+      </TouchableOpacity>
+
+      <AccessibilitySettingsModal isVisible={isVisible} onClose={() => setIsVisible(false)} />
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  icon: {
+    paddingHorizontal: normalize(3)
+  }
+});

--- a/src/components/AccessibilitySettingsModal.tsx
+++ b/src/components/AccessibilitySettingsModal.tsx
@@ -1,0 +1,87 @@
+import React, { useContext } from 'react';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Overlay } from 'react-native-elements';
+
+import { AccessibilityContext } from '../AccessibilityProvider';
+import { colors, consts, Icon, normalize, texts } from '../config';
+
+import { AccessibilitySettings } from './settings';
+import { HeadlineText, RegularText } from './Text';
+import { Wrapper, WrapperHorizontal } from './Wrapper';
+
+type Props = {
+  isVisible: boolean;
+  onClose: () => void;
+};
+
+export const AccessibilitySettingsModal = ({ isVisible, onClose }: Props) => {
+  const { isReduceMotionEnabled } = useContext(AccessibilityContext);
+
+  return (
+    <Overlay
+      animationType={isReduceMotionEnabled ? 'none' : 'fade'}
+      isVisible={isVisible}
+      onBackdropPress={onClose}
+      overlayStyle={styles.overlay}
+      statusBarTranslucent
+      supportedOrientations={['portrait', 'landscape']}
+    >
+      <View accessibilityViewIsModal importantForAccessibility="yes" style={styles.container}>
+        <TouchableOpacity
+          accessibilityLabel={consts.a11yLabel.closeIcon}
+          accessibilityRole="button"
+          onPress={onClose}
+          style={styles.closeButton}
+        >
+          <Icon.Close color={colors.lighterPrimary} size={normalize(16)} />
+        </TouchableOpacity>
+
+        <Wrapper style={styles.headerWrapper}>
+          <WrapperHorizontal>
+            <HeadlineText center>{texts.accessibilityModal.title}</HeadlineText>
+          </WrapperHorizontal>
+        </Wrapper>
+
+        <Wrapper noPaddingTop>
+          <WrapperHorizontal>
+            <RegularText center small>
+              {texts.accessibilityModal.description}
+            </RegularText>
+          </WrapperHorizontal>
+        </Wrapper>
+
+        <AccessibilitySettings hideIntro withResetButton />
+      </View>
+    </Overlay>
+  );
+};
+
+const styles = StyleSheet.create({
+  closeButton: {
+    alignItems: 'center',
+    backgroundColor: colors.darkText,
+    borderRadius: normalize(16),
+    height: normalize(32),
+    justifyContent: 'center',
+    opacity: 0.64,
+    position: 'absolute',
+    right: normalize(16),
+    top: normalize(16),
+    width: normalize(32),
+    zIndex: 1
+  },
+  container: {
+    borderRadius: normalize(8),
+    maxHeight: '92%',
+    width: '100%'
+  },
+  headerWrapper: {
+    paddingBottom: normalize(8)
+  },
+  overlay: {
+    borderRadius: normalize(8),
+    maxHeight: '92%',
+    padding: 0,
+    width: '95%'
+  }
+});

--- a/src/components/HeaderRight.tsx
+++ b/src/components/HeaderRight.tsx
@@ -6,6 +6,7 @@ import { ShareContent, StyleSheet } from 'react-native';
 
 import { normalize } from '../config';
 
+import { AccessibilityHeader } from './AccessibilityHeader';
 import { BookmarkHeader } from './bookmarks';
 import { CalendarHeader } from './CalendarHeader';
 import { ChatHeader } from './ChatHeader';
@@ -19,10 +20,12 @@ import { ShareHeader } from './ShareHeader';
 import { WrapperRow } from './Wrapper';
 
 type Props = {
-  navigation: StackNavigationProp<any> & DrawerNavigationProp<any>;
+  navigation: StackNavigationProp<Record<string, object | undefined>> &
+    DrawerNavigationProp<Record<string, object | undefined>>;
   onPress?: () => void;
-  route: RouteProp<any, string>;
+  route: RouteProp<Record<string, object | undefined>, string>;
   shareContent?: ShareContent;
+  withAccessibility?: boolean;
   withBookmark?: boolean;
   withCalendar?: boolean;
   withChat?: boolean;
@@ -41,6 +44,7 @@ export const HeaderRight = ({
   onPress,
   route,
   shareContent = route.params?.shareContent,
+  withAccessibility = true,
   withBookmark = false,
   withCalendar = false,
   withChat = false,
@@ -53,6 +57,7 @@ export const HeaderRight = ({
   withShare = false
 }: Props) => (
   <WrapperRow style={styles.headerRight}>
+    {withAccessibility && <AccessibilityHeader style={styles.icon} />}
     {withBookmark && <BookmarkHeader route={route} style={styles.icon} />}
     {withCalendar && <CalendarHeader navigation={navigation} style={styles.icon} />}
     {withChat && <ChatHeader navigation={navigation} style={styles.icon} />}

--- a/src/components/HtmlView.js
+++ b/src/components/HtmlView.js
@@ -17,7 +17,7 @@ import { RegularText } from './Text';
 
 const { HTML_REGEX } = consts;
 
-const cssRules =
+const getCssRules = (textScaleMultiplier = 1) =>
   cssRulesFromSpecs({
     ...defaultTableStylesSpecs,
     linkColor: colors.primary,
@@ -32,7 +32,7 @@ const cssRules =
   }) +
   `
 :root {
-  font-size: ${normalize(13)}px;
+  font-size: ${normalize(13) * textScaleMultiplier}px;
 }
 th {
   border-bottom: 1px solid ${'#3f5c7a'};
@@ -116,7 +116,7 @@ export const HtmlView = memo(
     tagsStyles = {},
     width
   }) => {
-    const { isBoldTextEnabled } = useContext(AccessibilityContext);
+    const { isBoldTextEnabled, textScaleMultiplier = 1 } = useContext(AccessibilityContext);
 
     let calculatedWidth =
       width !== undefined
@@ -153,14 +153,14 @@ export const HtmlView = memo(
               style: { opacity: 0.99 }
             }
           },
-          table: { cssRules }
+          table: { cssRules: getCssRules(textScaleMultiplier) }
         }}
         tagsStyles={{
           ...styles.html,
           ...(isBoldTextEnabled ? styles.htmlBoldTextEnabled : {}),
           ...tagsStyles
         }}
-        emSize={normalize(16)}
+        emSize={normalize(16) * textScaleMultiplier}
         baseStyle={styles.baseFontStyle}
         ignoredStyles={['width', 'height']}
         contentWidth={maxWidth}

--- a/src/components/ImagesCarousel.js
+++ b/src/components/ImagesCarousel.js
@@ -8,6 +8,7 @@ import Carousel from 'react-native-snap-carousel';
 import { colors, Icon, normalize, texts } from '../config';
 import { graphqlFetchPolicy, imageWidth, isActive, shareMessage } from '../helpers';
 import { useRefreshTime } from '../hooks';
+import { AccessibilityContext } from '../AccessibilityProvider';
 import { NetworkContext } from '../NetworkProvider';
 import { OrientationContext } from '../OrientationProvider';
 import { getQuery } from '../queries';
@@ -27,6 +28,7 @@ export const ImagesCarousel = ({
 }) => {
   const { dimensions } = useContext(OrientationContext);
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
+  const { isReduceMotionEnabled } = useContext(AccessibilityContext);
   const { globalSettings } = useContext(SettingsContext);
   const { settings = {} } = globalSettings;
   const { sliderPauseButton = {}, sliderSettings = {} } = settings;
@@ -38,22 +40,30 @@ export const ImagesCarousel = ({
   } = sliderPauseButton;
   const refreshTime = useRefreshTime(refreshTimeKey);
   const [isPaused, setIsPaused] = useState(false);
-  const [carouselImageIndex, setCarouselImageIndex] = useState(0);
+  const [, setCarouselImageIndex] = useState(0);
 
   const carouselRef = useRef();
   const isFocused = useIsFocused();
 
-  if (isFocused) {
+  useEffect(() => {
+    if (!isFocused || isReduceMotionEnabled) {
+      carouselRef.current?.stopAutoplay();
+      return;
+    }
+
     carouselRef.current?.startAutoplay();
-  } else {
-    carouselRef.current?.stopAutoplay();
-  }
+  }, [isFocused, isReduceMotionEnabled]);
 
   useEffect(() => {
-    isPaused ? carouselRef.current?.stopAutoplay() : carouselRef.current?.startAutoplay();
-  }, [isPaused]);
+    if (isReduceMotionEnabled) {
+      carouselRef.current?.stopAutoplay();
+      return;
+    }
 
-  const shouldShowPauseButton = showSliderPauseButton && !isDisturber;
+    isPaused ? carouselRef.current?.stopAutoplay() : carouselRef.current?.startAutoplay();
+  }, [isPaused, isReduceMotionEnabled]);
+
+  const shouldShowPauseButton = showSliderPauseButton && !isDisturber && !isReduceMotionEnabled;
 
   const fetchPolicy = graphqlFetchPolicy({
     isConnected,
@@ -130,7 +140,7 @@ export const ImagesCarousel = ({
         />
       );
     },
-    [navigation, fetchPolicy, aspectRatio]
+    [navigation, fetchPolicy, aspectRatio, isImageFullWidth]
   );
 
   if (!data || data.length === 0) return null;
@@ -150,7 +160,7 @@ export const ImagesCarousel = ({
   return (
     <View>
       <Carousel
-        autoplay
+        autoplay={!isReduceMotionEnabled}
         autoplayDelay={0}
         autoplayInterval={autoplayInterval || sliderSettings.autoplayInterval || 4000}
         containerCustomStyle={styles.center}

--- a/src/components/MediaCarousel.tsx
+++ b/src/components/MediaCarousel.tsx
@@ -6,6 +6,7 @@ import Carousel from 'react-native-snap-carousel';
 
 import { colors, Icon, normalize, texts } from '../config';
 import { imageWidth } from '../helpers';
+import { AccessibilityContext } from '../AccessibilityProvider';
 import { OrientationContext } from '../OrientationProvider';
 import { SettingsContext } from '../SettingsProvider';
 
@@ -46,6 +47,7 @@ const MediaCarouselItem = ({ item }: { item: MediaContent }) => {
 
 export const MediaCarousel = ({ autoplayInterval, mediaContents }: MediaCarouselProps) => {
   const { dimensions } = useContext(OrientationContext);
+  const { isReduceMotionEnabled } = useContext(AccessibilityContext);
   const { globalSettings } = useContext(SettingsContext);
   const { settings = {} } = globalSettings;
   const { sliderPauseButton = {}, sliderSettings = {} } = settings as {
@@ -72,16 +74,21 @@ export const MediaCarousel = ({ autoplayInterval, mediaContents }: MediaCarousel
   const isFocused = useIsFocused();
 
   useEffect(() => {
-    if (isFocused) {
+    if (isFocused && !isReduceMotionEnabled) {
       carouselRef.current?.startAutoplay();
     } else {
       carouselRef.current?.stopAutoplay();
     }
-  }, [isFocused]);
+  }, [isFocused, isReduceMotionEnabled]);
 
   useEffect(() => {
+    if (isReduceMotionEnabled) {
+      carouselRef.current?.stopAutoplay();
+      return;
+    }
+
     isPaused ? carouselRef.current?.stopAutoplay() : carouselRef.current?.startAutoplay();
-  }, [isPaused]);
+  }, [isPaused, isReduceMotionEnabled]);
 
   const filteredContents = _filter(
     mediaContents,
@@ -115,7 +122,7 @@ export const MediaCarousel = ({ autoplayInterval, mediaContents }: MediaCarousel
   return (
     <View>
       <Carousel
-        autoplay
+        autoplay={!isReduceMotionEnabled}
         autoplayDelay={0}
         autoplayInterval={autoplayInterval || (sliderSettings.autoplayInterval as number) || 4000}
         containerCustomStyle={styles.center}
@@ -134,6 +141,7 @@ export const MediaCarousel = ({ autoplayInterval, mediaContents }: MediaCarousel
       />
 
       {showSliderPauseButton &&
+        !isReduceMotionEnabled &&
         pauseButton(
           horizontalPosition,
           isCopyrighted,

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Overlay } from 'react-native-elements';
 
+import { AccessibilityContext } from '../AccessibilityProvider';
 import { consts, normalize, texts } from '../config';
 
 import { BoldText } from './Text';
@@ -30,9 +31,11 @@ export const Modal = ({
   onModalVisible,
   overlayStyle
 }: TModal) => {
+  const { isReduceMotionEnabled } = useContext(AccessibilityContext);
+
   return (
     <Overlay
-      animationType="fade"
+      animationType={isReduceMotionEnabled ? 'none' : 'fade'}
       isVisible={isVisible}
       onBackdropPress={isBackdropPress ? onModalVisible : undefined}
       overlayStyle={[!isListView && styles.overlay, styles.overlayWidth, { height }, overlayStyle]}

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
-import { Text as RNText } from 'react-native';
+import { StyleSheet, Text as RNText } from 'react-native';
 import styled, { css } from 'styled-components/native';
 
 import { AccessibilityContext } from '../AccessibilityProvider';
@@ -33,15 +33,55 @@ function parseText(text) {
   return result;
 }
 
-export const Text = ({ children, style, italic, ...props }) => {
-  const { isBoldTextEnabled } = useContext(AccessibilityContext);
+const scaleTypography = (style, scale = 1) => {
+  if (!style || scale === 1) return style;
+
+  const scaledStyle = { ...style };
+  if (typeof style.fontSize === 'number') {
+    scaledStyle.fontSize = style.fontSize * scale;
+  }
+  if (typeof style.lineHeight === 'number') {
+    scaledStyle.lineHeight = style.lineHeight * scale;
+  }
+
+  return scaledStyle;
+};
+
+const updateColorForHighContrast = (style, isHighContrastEnabled) => {
+  if (!style || !isHighContrastEnabled) return style;
+  if (!style.color) return style;
+
+  if (
+    style.color === colors.placeholder ||
+    style.color === colors.gray60 ||
+    style.color === colors.gray40
+  ) {
+    return {
+      ...style,
+      color: colors.darkText,
+      textDecorationColor: colors.darkText
+    };
+  }
+
+  return style;
+};
+
+export const Text = ({ children, style, italic, ignoreTextScale = false, ...props }) => {
+  const {
+    isBoldTextEnabled,
+    isHighContrastEnabled,
+    textScaleMultiplier = 1
+  } = useContext(AccessibilityContext);
+  const flattenedStyle = StyleSheet.flatten(style || {});
+  const baseStyle = scaleTypography(flattenedStyle, ignoreTextScale ? 1 : textScaleMultiplier);
+  const adjustedStyle = updateColorForHighContrast(baseStyle, isHighContrastEnabled);
 
   /* eslint-disable react-native/no-inline-styles */
   return (
     <RNText
       {...props}
       style={[
-        ...style,
+        adjustedStyle,
         isBoldTextEnabled && { fontFamily: 'bold' },
         italic && { fontFamily: 'bold-italic' }
       ]}
@@ -54,6 +94,7 @@ export const Text = ({ children, style, italic, ...props }) => {
 
 Text.propTypes = {
   children: PropTypes.node,
+  ignoreTextScale: PropTypes.bool,
   style: PropTypes.array,
   italic: PropTypes.bool
 };

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -23,6 +23,8 @@ export * from './whistleblow';
 export * from './widgets';
 
 export * from './BackToTop';
+export * from './AccessibilityHeader';
+export * from './AccessibilitySettingsModal';
 export * from './Button';
 export * from './Calendar';
 export * from './calendarArrows';

--- a/src/components/settings/AccessibilitySettings.tsx
+++ b/src/components/settings/AccessibilitySettings.tsx
@@ -1,0 +1,237 @@
+import React, { useMemo } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { ListItem, Slider } from 'react-native-elements';
+
+import { colors, consts, normalize, texts } from '../../config';
+import { ACCESSIBILITY_TEXT_SCALE_MULTIPLIERS, normalizeTextScaleLevel } from '../../helpers';
+import { useAccessibilityPreferences } from '../../hooks';
+import { Button } from '../Button';
+import { SettingsToggle } from '../SettingsToggle';
+import { BoldText, RegularText } from '../Text';
+import { Touchable } from '../Touchable';
+import { WrapperHorizontal, WrapperVertical } from '../Wrapper';
+
+type Props = {
+  hideIntro?: boolean;
+  withResetButton?: boolean;
+};
+
+type Definition = {
+  description?: string;
+  featureKey: keyof ReturnType<typeof useAccessibilityPreferences>['features'];
+  key: Exclude<
+    keyof ReturnType<typeof useAccessibilityPreferences>['preferences'],
+    'textScaleLevel'
+  >;
+  title: string;
+};
+
+const SETTINGS_DEFINITIONS: Definition[] = [
+  {
+    key: 'highContrastEnabled',
+    featureKey: 'highContrast',
+    title: texts.settingsContents.accessibility.highContrast.title,
+    description: texts.settingsContents.accessibility.highContrast.description
+  },
+  {
+    key: 'reduceMotionEnabled',
+    featureKey: 'reduceMotion',
+    title: texts.settingsContents.accessibility.reduceMotion.title,
+    description: texts.settingsContents.accessibility.reduceMotion.description
+  },
+  {
+    key: 'reduceTransparencyEnabled',
+    featureKey: 'reduceTransparency',
+    title: texts.settingsContents.accessibility.reduceTransparency.title,
+    description: texts.settingsContents.accessibility.reduceTransparency.description
+  },
+  {
+    key: 'readAloudEnabled',
+    featureKey: 'readAloud',
+    title: texts.settingsContents.accessibility.readAloud.title,
+    description: texts.settingsContents.accessibility.readAloud.description
+  }
+];
+
+export const AccessibilitySettings = ({ hideIntro = false, withResetButton = true }: Props) => {
+  const { features, preferences, resetPreferences, setPreference, setTextScaleLevel } =
+    useAccessibilityPreferences();
+
+  const availableSettings = SETTINGS_DEFINITIONS.filter((setting) => features[setting.featureKey]);
+  const textScaleLevel = normalizeTextScaleLevel(preferences.textScaleLevel);
+  const textScaleLevelLabels = useMemo(
+    () => [
+      texts.settingsContents.accessibility.textSize.levelSmallest,
+      texts.settingsContents.accessibility.textSize.levelSmall,
+      texts.settingsContents.accessibility.textSize.levelDefault,
+      texts.settingsContents.accessibility.textSize.levelLarge,
+      texts.settingsContents.accessibility.textSize.levelLarger,
+      texts.settingsContents.accessibility.textSize.levelLargest,
+      texts.settingsContents.accessibility.textSize.levelMaximum
+    ],
+    []
+  );
+  const canDecreaseTextScale = textScaleLevel > 0;
+  const canIncreaseTextScale = textScaleLevel < ACCESSIBILITY_TEXT_SCALE_MULTIPLIERS.length - 1;
+  const showTextScaleControl = features.textScaling;
+  const hasControls = showTextScaleControl || availableSettings.length > 0;
+
+  return (
+    <ScrollView>
+      {!hideIntro && (
+        <WrapperHorizontal>
+          <WrapperVertical>
+            <RegularText>{texts.settingsContents.accessibility.intro}</RegularText>
+          </WrapperVertical>
+        </WrapperHorizontal>
+      )}
+
+      {showTextScaleControl && (
+        <WrapperHorizontal>
+          <ListItem
+            accessibilityLabel={`${texts.settingsContents.accessibility.textSize.title} ${consts.a11yLabel.button}`}
+            bottomDivider={!availableSettings.length}
+            containerStyle={styles.listItem}
+            topDivider
+          >
+            <ListItem.Content>
+              <BoldText small>{texts.settingsContents.accessibility.textSize.title}</BoldText>
+              <RegularText small>
+                {texts.settingsContents.accessibility.textSize.description}
+              </RegularText>
+
+              <WrapperVertical noPaddingBottom>
+                <View style={styles.textScaleRow}>
+                  <Touchable
+                    accessibilityLabel={texts.accessibilityLabels.actions.decreaseTextSize}
+                    accessibilityState={{ disabled: !canDecreaseTextScale }}
+                    disabled={!canDecreaseTextScale}
+                    onPress={() => setTextScaleLevel(textScaleLevel - 1)}
+                    style={[
+                      styles.textScaleButton,
+                      !canDecreaseTextScale && styles.textScaleButtonDisabled
+                    ]}
+                  >
+                    <RegularText ignoreTextScale>
+                      {texts.settingsContents.accessibility.textSize.decreaseLabel}
+                    </RegularText>
+                  </Touchable>
+
+                  <View style={styles.sliderContainer}>
+                    <Slider
+                      accessibilityLabel={texts.settingsContents.accessibility.textSize.sliderLabel}
+                      maximumTrackTintColor={colors.gray40}
+                      maximumValue={ACCESSIBILITY_TEXT_SCALE_MULTIPLIERS.length - 1}
+                      minimumTrackTintColor={colors.primary}
+                      minimumValue={0}
+                      onSlidingComplete={(value) => setTextScaleLevel(value)}
+                      step={1}
+                      style={styles.slider}
+                      thumbStyle={styles.sliderThumb}
+                      thumbTouchSize={{ height: normalize(44), width: normalize(44) }}
+                      value={textScaleLevel}
+                    />
+                  </View>
+
+                  <Touchable
+                    accessibilityLabel={texts.accessibilityLabels.actions.increaseTextSize}
+                    accessibilityState={{ disabled: !canIncreaseTextScale }}
+                    disabled={!canIncreaseTextScale}
+                    onPress={() => setTextScaleLevel(textScaleLevel + 1)}
+                    style={[
+                      styles.textScaleButton,
+                      !canIncreaseTextScale && styles.textScaleButtonDisabled
+                    ]}
+                  >
+                    <RegularText big ignoreTextScale>
+                      {texts.settingsContents.accessibility.textSize.increaseLabel}
+                    </RegularText>
+                  </Touchable>
+                </View>
+
+                <RegularText small>
+                  {texts.settingsContents.accessibility.textSize.currentValue.replace(
+                    '{{value}}',
+                    textScaleLevelLabels[textScaleLevel]
+                  )}
+                </RegularText>
+              </WrapperVertical>
+            </ListItem.Content>
+          </ListItem>
+        </WrapperHorizontal>
+      )}
+
+      {availableSettings.map((setting, index) => (
+        <WrapperHorizontal key={setting.key}>
+          <SettingsToggle
+            needsConnection={false}
+            item={{
+              bottomDivider: index === availableSettings.length - 1,
+              description: setting.description,
+              onActivate: () => setPreference(setting.key, true),
+              onDeactivate: () => setPreference(setting.key, false),
+              title: setting.title,
+              topDivider: !showTextScaleControl && index === 0,
+              value: preferences[setting.key]
+            }}
+          />
+        </WrapperHorizontal>
+      ))}
+
+      {withResetButton && hasControls && (
+        <WrapperHorizontal>
+          <WrapperVertical>
+            <Button
+              invert
+              title={texts.settingsContents.accessibility.reset}
+              onPress={resetPreferences}
+            />
+          </WrapperVertical>
+        </WrapperHorizontal>
+      )}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  listItem: {
+    backgroundColor: colors.transparent,
+    paddingHorizontal: 0,
+    paddingVertical: normalize(10)
+  },
+  slider: {
+    marginHorizontal: 0,
+    width: '100%'
+  },
+  sliderContainer: {
+    flex: 1,
+    minWidth: 0,
+    justifyContent: 'center',
+    marginHorizontal: normalize(12)
+  },
+  sliderThumb: {
+    backgroundColor: colors.primary,
+    height: normalize(20),
+    width: normalize(20)
+  },
+  textScaleButton: {
+    alignItems: 'center',
+    borderColor: colors.gray40,
+    borderRadius: normalize(18),
+    borderWidth: normalize(1),
+    justifyContent: 'center',
+    minHeight: normalize(36),
+    minWidth: normalize(72),
+    paddingHorizontal: normalize(8)
+  },
+  textScaleButtonDisabled: {
+    opacity: 0.5
+  },
+  textScaleRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    marginBottom: normalize(8),
+    marginTop: normalize(8),
+    width: '100%'
+  }
+});

--- a/src/components/settings/index.js
+++ b/src/components/settings/index.js
@@ -1,3 +1,4 @@
+export * from './AccessibilitySettings';
 export * from './ListSettings';
 export * from './LocationSettings';
 export * from './MowasRegionSettings';

--- a/src/config/consts.js
+++ b/src/config/consts.js
@@ -7,6 +7,8 @@ export const consts = {
   a11yLabel: {
     address: '(Adresse)',
     appVersion: '(App-Version)',
+    accessibilityIcon: 'Barrierefreiheit (Taste)',
+    accessibilityIconHint: 'Öffnet die Barrierefreiheits-Einstellungen',
     backIcon: 'Zurück (Taste)',
     backIconHint: 'Navigieren zurück zur vorherigen Seite',
     birthDate: 'Geburtsdatum',

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -12,6 +12,7 @@ export const texts = {
       createNewComment: 'Neuen Kommentar verfassen',
       createNewPost: 'Neuen Beitrag verfassen',
       decreaseQuantity: 'Anzahl verringern',
+      decreaseTextSize: 'Textgröße verkleinern',
       deleteAll: 'Alle löschen',
       deleteComment: 'Kommentar löschen',
       deleteDocument: 'Dokument löschen',
@@ -23,12 +24,14 @@ export const texts = {
       enterActivationCode: 'Aktivierungscode eingeben',
       finishEditing: 'Bearbeitung beenden',
       increaseQuantity: 'Anzahl erhöhen',
+      increaseTextSize: 'Textgröße vergrößern',
       like: 'Gefällt mir',
       listView: 'Listenansicht',
       loadMore: 'Mehr laden',
       loadPreviousComments: 'Frühere Kommentare laden',
       nextDay: 'Nächster Tag',
       openAddress: 'Adresse öffnen',
+      openAccessibilitySettings: 'Barrierefreiheit öffnen',
       openDocument: 'Dokument öffnen',
       openLink: 'Link öffnen',
       openPdf: 'PDF öffnen',
@@ -88,6 +91,11 @@ export const texts = {
       active: 'geöffnet',
       inactive: 'geschlossen'
     }
+  },
+  accessibilityModal: {
+    description:
+      'Passe die Barrierefreiheits-Optionen direkt im aktuellen Bildschirm an. Die Änderungen werden sofort gespeichert.',
+    title: 'Barrierefreiheit'
   },
   appIntro: {
     continue: 'Weiter',
@@ -1223,6 +1231,43 @@ export const texts = {
     edit: 'Kacheln bearbeiten'
   },
   settingsContents: {
+    accessibility: {
+      intro:
+        'Diese Einstellungen erweitern die systemweiten Bedienungshilfen um app-interne Optionen.',
+      reset: 'Auf Standardwerte zurücksetzen',
+      setting: 'Barrierefreiheit',
+      textSize: {
+        title: 'Textgröße',
+        description: 'Passe die Schriftgröße in der App stufenweise an.',
+        sliderLabel: 'Textgrößenregler',
+        decreaseLabel: 'A-',
+        increaseLabel: 'A+',
+        currentValue: 'Aktuelle Größe: {{value}}',
+        levelSmallest: 'Sehr klein',
+        levelSmall: 'Klein',
+        levelDefault: 'Standard',
+        levelLarge: 'Groß',
+        levelLarger: 'Sehr groß',
+        levelLargest: 'Extra groß',
+        levelMaximum: 'Maximum'
+      },
+      highContrast: {
+        title: 'Höherer Kontrast',
+        description: 'Reduziert kontrastarme Textfarben für bessere Lesbarkeit.'
+      },
+      readAloud: {
+        title: 'Lesemodus in Details',
+        description: 'Ermöglicht das Vorlesen von Detailinhalten per Sprachausgabe.'
+      },
+      reduceMotion: {
+        title: 'Bewegung reduzieren',
+        description: 'Verringert Bewegungs- und Übergangseffekte in der App.'
+      },
+      reduceTransparency: {
+        title: 'Transparenz reduzieren',
+        description: 'Verwendet stärker deckende Oberflächen und Hervorhebungen.'
+      }
+    },
     analytics: {
       no: 'Nein',
       onActivate:
@@ -1282,6 +1327,7 @@ export const texts = {
     intro: ''
   },
   settingsTitles: {
+    accessibility: 'Barrierefreiheit',
     analytics: 'Matomo Analytics',
     arListLayouts: {
       alertTitle: 'Hinweis',

--- a/src/helpers/accessibilityListeners.ts
+++ b/src/helpers/accessibilityListeners.ts
@@ -1,9 +1,12 @@
+import type { Dispatch, SetStateAction } from 'react';
 import { AccessibilityInfo } from 'react-native';
 
-import { Accessibility } from '../types';
+import { AccessibilitySystemState } from '../types';
 
 // for detailed information: https://reactnative.dev/docs/accessibilityinfo#addeventlistener
-export const accessibilityListeners = (setAccessibility: (prev: any) => void) => {
+export const accessibilityListeners = (
+  setAccessibility: Dispatch<SetStateAction<AccessibilitySystemState>>
+) => {
   /*
    * Fires when the state of the bold text toggle changes.
    * Is true when bold text is enabled and false otherwise.
@@ -11,7 +14,7 @@ export const accessibilityListeners = (setAccessibility: (prev: any) => void) =>
   const boldTextChangedSubscription = AccessibilityInfo.addEventListener(
     'boldTextChanged',
     (isBoldTextEnabled) => {
-      setAccessibility((prev: Accessibility) => ({
+      setAccessibility((prev: AccessibilitySystemState) => ({
         ...prev,
         isBoldTextEnabled
       }));
@@ -25,7 +28,7 @@ export const accessibilityListeners = (setAccessibility: (prev: any) => void) =>
   const grayscaleChangedSubscription = AccessibilityInfo.addEventListener(
     'grayscaleChanged',
     (isGrayscaleEnabled) => {
-      setAccessibility((prev: Accessibility) => ({
+      setAccessibility((prev: AccessibilitySystemState) => ({
         ...prev,
         isGrayscaleEnabled
       }));
@@ -39,7 +42,7 @@ export const accessibilityListeners = (setAccessibility: (prev: any) => void) =>
   const invertColorsChangedSubscription = AccessibilityInfo.addEventListener(
     'invertColorsChanged',
     (isInvertColorsEnabled) => {
-      setAccessibility((prev: Accessibility) => ({
+      setAccessibility((prev: AccessibilitySystemState) => ({
         ...prev,
         isInvertColorsEnabled
       }));
@@ -54,7 +57,7 @@ export const accessibilityListeners = (setAccessibility: (prev: any) => void) =>
   const reduceMotionChangedSubscription = AccessibilityInfo.addEventListener(
     'reduceMotionChanged',
     (isReduceMotionEnabled) => {
-      setAccessibility((prev: Accessibility) => ({
+      setAccessibility((prev: AccessibilitySystemState) => ({
         ...prev,
         isReduceMotionEnabled
       }));
@@ -68,7 +71,7 @@ export const accessibilityListeners = (setAccessibility: (prev: any) => void) =>
   const reduceTransparencyChangedSubscription = AccessibilityInfo.addEventListener(
     'reduceTransparencyChanged',
     (isReduceTransparencyEnabled) => {
-      setAccessibility((prev: Accessibility) => ({
+      setAccessibility((prev: AccessibilitySystemState) => ({
         ...prev,
         isReduceTransparencyEnabled
       }));
@@ -82,7 +85,7 @@ export const accessibilityListeners = (setAccessibility: (prev: any) => void) =>
   const screenReaderChangedSubscription = AccessibilityInfo.addEventListener(
     'screenReaderChanged',
     (isScreenReaderEnabled) => {
-      setAccessibility((prev: Accessibility) => ({
+      setAccessibility((prev: AccessibilitySystemState) => ({
         ...prev,
         isScreenReaderEnabled
       }));
@@ -90,22 +93,25 @@ export const accessibilityListeners = (setAccessibility: (prev: any) => void) =>
   );
 
   AccessibilityInfo.isBoldTextEnabled().then((isBoldTextEnabled) => {
-    setAccessibility((prev: Accessibility) => ({ ...prev, isBoldTextEnabled }));
+    setAccessibility((prev: AccessibilitySystemState) => ({ ...prev, isBoldTextEnabled }));
   });
   AccessibilityInfo.isGrayscaleEnabled().then((isGrayscaleEnabled) => {
-    setAccessibility((prev: Accessibility) => ({ ...prev, isGrayscaleEnabled }));
+    setAccessibility((prev: AccessibilitySystemState) => ({ ...prev, isGrayscaleEnabled }));
   });
   AccessibilityInfo.isInvertColorsEnabled().then((isInvertColorsEnabled) => {
-    setAccessibility((prev: Accessibility) => ({ ...prev, isInvertColorsEnabled }));
+    setAccessibility((prev: AccessibilitySystemState) => ({ ...prev, isInvertColorsEnabled }));
   });
   AccessibilityInfo.isReduceMotionEnabled().then((isReduceMotionEnabled) => {
-    setAccessibility((prev: Accessibility) => ({ ...prev, isReduceMotionEnabled }));
+    setAccessibility((prev: AccessibilitySystemState) => ({ ...prev, isReduceMotionEnabled }));
   });
   AccessibilityInfo.isReduceTransparencyEnabled().then((isReduceTransparencyEnabled) => {
-    setAccessibility((prev: Accessibility) => ({ ...prev, isReduceTransparencyEnabled }));
+    setAccessibility((prev: AccessibilitySystemState) => ({
+      ...prev,
+      isReduceTransparencyEnabled
+    }));
   });
   AccessibilityInfo.isScreenReaderEnabled().then((isScreenReaderEnabled) => {
-    setAccessibility((prev: Accessibility) => ({ ...prev, isScreenReaderEnabled }));
+    setAccessibility((prev: AccessibilitySystemState) => ({ ...prev, isScreenReaderEnabled }));
   });
 
   return () => {

--- a/src/helpers/accessibilitySettingsHelper.ts
+++ b/src/helpers/accessibilitySettingsHelper.ts
@@ -1,0 +1,155 @@
+import {
+  AccessibilityFeatureAvailability,
+  AccessibilityFeatureKey,
+  AccessibilityTogglePreferenceKey,
+  AccessibilityUserSettings
+} from '../types';
+
+export const ACCESSIBILITY_FEATURE_BY_PREFERENCE: Record<
+  AccessibilityTogglePreferenceKey,
+  AccessibilityFeatureKey
+> = {
+  highContrastEnabled: 'highContrast',
+  readAloudEnabled: 'readAloud',
+  reduceMotionEnabled: 'reduceMotion',
+  reduceTransparencyEnabled: 'reduceTransparency'
+};
+
+export const ACCESSIBILITY_TEXT_SCALE_MULTIPLIERS = [0.9, 0.95, 1, 1.1, 1.2, 1.3, 1.4] as const;
+export const DEFAULT_ACCESSIBILITY_TEXT_SCALE_LEVEL = 2;
+
+export const DEFAULT_ACCESSIBILITY_FEATURES: AccessibilityFeatureAvailability = {
+  boldText: true,
+  headerEntry: true,
+  highContrast: true,
+  readAloud: true,
+  reduceMotion: true,
+  reduceTransparency: true,
+  settingsEntry: true,
+  textScaling: true
+};
+
+export const DEFAULT_ACCESSIBILITY_USER_SETTINGS: AccessibilityUserSettings = {
+  highContrastEnabled: false,
+  readAloudEnabled: false,
+  reduceMotionEnabled: false,
+  reduceTransparencyEnabled: false,
+  textScaleLevel: DEFAULT_ACCESSIBILITY_TEXT_SCALE_LEVEL
+};
+
+type AccessibilityGlobalSettings = {
+  settings?: {
+    accessibility?: {
+      defaults?: Partial<AccessibilityUserSettings> & {
+        boldTextEnabled?: boolean;
+      };
+      enabledFeatures?: Partial<AccessibilityFeatureAvailability>;
+    };
+  };
+};
+
+const normalizeBooleanRecord = <T extends string>(
+  values: Record<string, unknown> | undefined,
+  defaults: Record<T, boolean>
+) => {
+  return Object.keys(defaults).reduce((acc, key) => {
+    const typedKey = key as T;
+    const value = values?.[typedKey];
+
+    acc[typedKey] = typeof value === 'boolean' ? value : defaults[typedKey];
+    return acc;
+  }, {} as Record<T, boolean>);
+};
+
+export const normalizeTextScaleLevel = (value: unknown) => {
+  const maxLevel = ACCESSIBILITY_TEXT_SCALE_MULTIPLIERS.length - 1;
+  const minLevel = 0;
+
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return DEFAULT_ACCESSIBILITY_TEXT_SCALE_LEVEL;
+  }
+
+  return Math.min(maxLevel, Math.max(minLevel, Math.round(value)));
+};
+
+const getLegacyTextScaleLevel = (legacyBoldTextEnabled: unknown) => {
+  if (typeof legacyBoldTextEnabled !== 'boolean') return DEFAULT_ACCESSIBILITY_TEXT_SCALE_LEVEL;
+
+  return legacyBoldTextEnabled
+    ? DEFAULT_ACCESSIBILITY_TEXT_SCALE_LEVEL + 2
+    : DEFAULT_ACCESSIBILITY_TEXT_SCALE_LEVEL;
+};
+
+export const getTextScaleMultiplier = (textScaleLevel: number) =>
+  ACCESSIBILITY_TEXT_SCALE_MULTIPLIERS[normalizeTextScaleLevel(textScaleLevel)];
+
+/* eslint-disable complexity */
+export const resolveAccessibilityConfiguration = (
+  globalSettings?: AccessibilityGlobalSettings | null
+) => {
+  const accessibilitySettings = globalSettings?.settings?.accessibility || {};
+  const featureSettings = accessibilitySettings?.enabledFeatures || {};
+  const defaultSettings = accessibilitySettings?.defaults || {};
+
+  const enabledFeatures = normalizeBooleanRecord<AccessibilityFeatureKey>(
+    featureSettings,
+    DEFAULT_ACCESSIBILITY_FEATURES
+  );
+
+  if (
+    typeof featureSettings.textScaling !== 'boolean' &&
+    typeof featureSettings.boldText === 'boolean'
+  ) {
+    enabledFeatures.textScaling = featureSettings.boldText;
+  }
+
+  if (
+    typeof featureSettings.boldText !== 'boolean' &&
+    typeof featureSettings.textScaling === 'boolean'
+  ) {
+    enabledFeatures.boldText = featureSettings.textScaling;
+  }
+
+  const defaults: AccessibilityUserSettings = {
+    ...DEFAULT_ACCESSIBILITY_USER_SETTINGS,
+    highContrastEnabled:
+      typeof defaultSettings.highContrastEnabled === 'boolean'
+        ? defaultSettings.highContrastEnabled
+        : DEFAULT_ACCESSIBILITY_USER_SETTINGS.highContrastEnabled,
+    readAloudEnabled:
+      typeof defaultSettings.readAloudEnabled === 'boolean'
+        ? defaultSettings.readAloudEnabled
+        : DEFAULT_ACCESSIBILITY_USER_SETTINGS.readAloudEnabled,
+    reduceMotionEnabled:
+      typeof defaultSettings.reduceMotionEnabled === 'boolean'
+        ? defaultSettings.reduceMotionEnabled
+        : DEFAULT_ACCESSIBILITY_USER_SETTINGS.reduceMotionEnabled,
+    reduceTransparencyEnabled:
+      typeof defaultSettings.reduceTransparencyEnabled === 'boolean'
+        ? defaultSettings.reduceTransparencyEnabled
+        : DEFAULT_ACCESSIBILITY_USER_SETTINGS.reduceTransparencyEnabled,
+    textScaleLevel:
+      typeof defaultSettings.textScaleLevel === 'number'
+        ? normalizeTextScaleLevel(defaultSettings.textScaleLevel)
+        : getLegacyTextScaleLevel(defaultSettings.boldTextEnabled)
+  };
+
+  return {
+    defaults,
+    features: enabledFeatures
+  };
+};
+/* eslint-enable complexity */
+
+export const isAccessibilityFeatureEnabled = (
+  globalSettings: AccessibilityGlobalSettings | null | undefined,
+  feature: AccessibilityFeatureKey
+) => resolveAccessibilityConfiguration(globalSettings).features[feature] !== false;
+
+export const getAccessibilitySettingsEntryEnabled = (
+  globalSettings: AccessibilityGlobalSettings | null | undefined
+) => isAccessibilityFeatureEnabled(globalSettings, 'settingsEntry');
+
+export const getAccessibilityHeaderEntryEnabled = (
+  globalSettings: AccessibilityGlobalSettings | null | undefined
+) => isAccessibilityFeatureEnabled(globalSettings, 'headerEntry');

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -5,6 +5,7 @@ export * from './whistleblow';
 export * from './wallet';
 
 export * from './accessibilityListeners';
+export * from './accessibilitySettingsHelper';
 export * from './addressHelper';
 export * from './bookmarkHelper';
 export * from './calendarHelper';

--- a/src/helpers/storageHelper.js
+++ b/src/helpers/storageHelper.js
@@ -8,6 +8,8 @@ export const removeFromStore = async (key) => await AsyncStorage.removeItem(key)
 export const resetStore = async () => await AsyncStorage.clear();
 
 export const storageHelper = {
+  accessibilityUserSettings: () => readFromStore('accessibilityUserSettings'),
+  setAccessibilityUserSettings: (settings) => addToStore('accessibilityUserSettings', settings),
   globalSettings: () => readFromStore('globalSettings'),
   setGlobalSettings: (globalSettings) => addToStore('globalSettings', globalSettings),
   locationSettings: () => readFromStore('locationSettings'),

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -5,6 +5,7 @@ export * from './volunteer';
 
 export * from './apollo';
 export * from './appInfo';
+export * from './useAccessibilityPreferences';
 export * from './Bookmarks';
 export * from './Chatbot';
 export * from './constructionSites';

--- a/src/hooks/useAccessibilityPreferences.ts
+++ b/src/hooks/useAccessibilityPreferences.ts
@@ -1,0 +1,82 @@
+import { useCallback, useContext, useMemo } from 'react';
+
+import { AccessibilityContext } from '../AccessibilityProvider';
+import { ACCESSIBILITY_FEATURE_BY_PREFERENCE } from '../helpers';
+import { AccessibilityTogglePreferenceKey, AccessibilityUserSettings } from '../types';
+
+export const useAccessibilityPreferences = () => {
+  const {
+    defaults,
+    features,
+    preferences,
+    resetPreferences,
+    setPreference,
+    setPreferences,
+    setTextScaleLevel,
+    textScaleMultiplier
+  } = useContext(AccessibilityContext);
+
+  const isPreferenceAvailable = useCallback(
+    (key: AccessibilityTogglePreferenceKey) => {
+      return features[ACCESSIBILITY_FEATURE_BY_PREFERENCE[key]] !== false;
+    },
+    [features]
+  );
+
+  const isTextScalingAvailable = features.textScaling !== false;
+
+  const availablePreferenceKeys = useMemo(
+    () =>
+      (
+        Object.keys(ACCESSIBILITY_FEATURE_BY_PREFERENCE) as AccessibilityTogglePreferenceKey[]
+      ).filter((key) => isPreferenceAvailable(key)),
+    [isPreferenceAvailable]
+  );
+
+  const togglePreference = useCallback(
+    (key: AccessibilityTogglePreferenceKey, value?: boolean) => {
+      if (!isPreferenceAvailable(key)) return;
+      setPreference(key, value);
+    },
+    [isPreferenceAvailable, setPreference]
+  );
+
+  const updatePreferences = useCallback(
+    (values: Partial<AccessibilityUserSettings>) => {
+      const filteredValues = Object.entries(values).reduce((acc, [key, value]) => {
+        if (key === 'textScaleLevel') {
+          if (isTextScalingAvailable && typeof value === 'number') {
+            acc.textScaleLevel = value;
+          }
+          return acc;
+        }
+
+        const typedKey = key as AccessibilityTogglePreferenceKey;
+        if (isPreferenceAvailable(typedKey) && typeof value === 'boolean') {
+          acc[typedKey] = value;
+        }
+        return acc;
+      }, {} as Partial<AccessibilityUserSettings>);
+
+      setPreferences(filteredValues);
+    },
+    [isPreferenceAvailable, isTextScalingAvailable, setPreferences]
+  );
+
+  return {
+    availablePreferenceKeys,
+    defaults,
+    features,
+    isPreferenceAvailable,
+    isTextScalingAvailable,
+    preferences,
+    resetPreferences,
+    setPreference: togglePreference,
+    setPreferences: updatePreferences,
+    setTextScaleLevel: (level: number) => {
+      if (!isTextScalingAvailable) return;
+      setTextScaleLevel(level);
+    },
+    textScaleMultiplier
+  };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -219,18 +219,20 @@ const MainAppWithApolloProvider = () => {
           initialConversationSettings
         }}
       >
-        <ConfigurationsProvider>
-          <OnboardingManager>
-            <ProfileProvider>
-              <UnreadMessagesProvider>
-                <RootView>
-                  <OtaUpdateManager />
-                  <Navigator navigationType={initialGlobalSettings.navigation} />
-                </RootView>
-              </UnreadMessagesProvider>
-            </ProfileProvider>
-          </OnboardingManager>
-        </ConfigurationsProvider>
+        <AccessibilityProvider>
+          <ConfigurationsProvider>
+            <OnboardingManager>
+              <ProfileProvider>
+                <UnreadMessagesProvider>
+                  <RootView>
+                    <OtaUpdateManager />
+                    <Navigator navigationType={initialGlobalSettings.navigation} />
+                  </RootView>
+                </UnreadMessagesProvider>
+              </ProfileProvider>
+            </OnboardingManager>
+          </ConfigurationsProvider>
+        </AccessibilityProvider>
       </SettingsProvider>
     </ApolloProvider>
   );
@@ -243,9 +245,7 @@ export const MainApp = () => (
         <PermanentFilterProvider>
           <ReactQueryProvider>
             <SafeAreaProvider>
-              <AccessibilityProvider>
-                <MainAppWithApolloProvider />
-              </AccessibilityProvider>
+              <MainAppWithApolloProvider />
             </SafeAreaProvider>
           </ReactQueryProvider>
         </PermanentFilterProvider>

--- a/src/navigation/AppStackNavigator.tsx
+++ b/src/navigation/AppStackNavigator.tsx
@@ -1,24 +1,56 @@
-import { createStackNavigator } from '@react-navigation/stack';
-import React from 'react';
+import { CardStyleInterpolators, createStackNavigator } from '@react-navigation/stack';
+import React, { useContext } from 'react';
 
+import { AccessibilityContext } from '../AccessibilityProvider';
 import { StackConfig } from '../types';
 
 const Stack = createStackNavigator<Record<string, { title: string } | undefined>>();
 
-export const getStackNavigator = (stackConfig: StackConfig) => () =>
-  (
+export const getStackNavigator = (stackConfig: StackConfig) => () => {
+  const { isReduceMotionEnabled } = useContext(AccessibilityContext);
+
+  return (
     <Stack.Navigator
       initialRouteName={stackConfig.initialRouteName}
-      screenOptions={stackConfig.screenOptions}
+      screenOptions={(props) => {
+        const resolvedOptions =
+          typeof stackConfig.screenOptions === 'function'
+            ? stackConfig.screenOptions(props)
+            : stackConfig.screenOptions || {};
+
+        return {
+          ...resolvedOptions,
+          animationEnabled: isReduceMotionEnabled ? false : resolvedOptions.animationEnabled,
+          cardStyleInterpolator: isReduceMotionEnabled
+            ? CardStyleInterpolators.forNoAnimation
+            : resolvedOptions.cardStyleInterpolator,
+          gestureEnabled: isReduceMotionEnabled ? false : resolvedOptions.gestureEnabled
+        };
+      }}
     >
       {stackConfig.screenConfigs.map((screenConfig) => (
         <Stack.Screen
           key={screenConfig.routeName}
           name={screenConfig.routeName}
           component={screenConfig.screenComponent}
-          options={screenConfig.screenOptions}
+          options={(props) => {
+            const resolvedOptions =
+              typeof screenConfig.screenOptions === 'function'
+                ? screenConfig.screenOptions(props)
+                : screenConfig.screenOptions || {};
+
+            return {
+              ...resolvedOptions,
+              animationEnabled: isReduceMotionEnabled ? false : resolvedOptions.animationEnabled,
+              cardStyleInterpolator: isReduceMotionEnabled
+                ? CardStyleInterpolators.forNoAnimation
+                : resolvedOptions.cardStyleInterpolator,
+              gestureEnabled: isReduceMotionEnabled ? false : resolvedOptions.gestureEnabled
+            };
+          }}
           initialParams={screenConfig.initialParams}
         />
       ))}
     </Stack.Navigator>
   );
+};

--- a/src/navigation/screenOptions.tsx
+++ b/src/navigation/screenOptions.tsx
@@ -1,4 +1,5 @@
 import { RouteProp } from '@react-navigation/core';
+import { NavigationProp } from '@react-navigation/native';
 import { CardStyleInterpolators, StackNavigationOptions } from '@react-navigation/stack';
 import React from 'react';
 import { StyleSheet } from 'react-native';
@@ -6,15 +7,18 @@ import { StyleSheet } from 'react-native';
 import { DiagonalGradient, FavoritesHeader, HeaderLeft, HeaderRight } from '../components';
 import { colors, normalize } from '../config';
 
+type NavigationParams = Record<string, object | undefined>;
+
 type OptionProps = {
-  route: RouteProp<Record<string, any | undefined>, string>;
-  navigation: any;
+  route: RouteProp<NavigationParams, string>;
+  navigation: NavigationProp<NavigationParams>;
 };
 
 type OptionConfig = {
   cardStyleInterpolator?: StackNavigationOptions['cardStyleInterpolator'];
   noHeaderLeft?: boolean;
   withBookmark?: boolean;
+  withAccessibility?: boolean;
   withDelete?: boolean;
   withDrawer?: boolean;
   withFavorites?: boolean;
@@ -28,6 +32,7 @@ export const getScreenOptions =
     cardStyleInterpolator,
     noHeaderLeft = false,
     withBookmark,
+    withAccessibility = true,
     withDelete,
     withDrawer,
     withFavorites,
@@ -48,6 +53,7 @@ export const getScreenOptions =
             navigation,
             route,
             shareContent: route.params?.shareContent,
+            withAccessibility,
             withBookmark,
             withDelete,
             withDrawer,

--- a/src/screens/AppIntroScreen.tsx
+++ b/src/screens/AppIntroScreen.tsx
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import {
   Alert,
   ListRenderItem,
@@ -17,12 +17,16 @@ import { getStatusBarHeight } from 'react-native-status-bar-height';
 
 import { BoldText, Checkbox, Image, RegularText, SafeAreaViewFlex, Wrapper } from '../components';
 import { colors, consts, device, Icon, normalize, texts } from '../config';
-import { addToStore, Initializer } from '../helpers';
+import { addToStore, Initializer, readFromStore } from '../helpers';
 import { useStaticContent } from '../hooks';
 import { parseIntroSlides } from '../jsonValidation';
-import { HAS_TERMS_AND_CONDITIONS_STORE_KEY } from '../OnboardingManager';
+import {
+  HAS_TERMS_AND_CONDITIONS_STORE_KEY,
+  TERMS_AND_CONDITIONS_STORE_KEY
+} from '../OnboardingManager';
 import { QUERY_TYPES } from '../queries';
 import { AppIntroSlide } from '../types';
+import { AccessibilityContext } from '../AccessibilityProvider';
 
 import { HtmlScreen } from './HtmlScreen';
 
@@ -34,21 +38,6 @@ type SliderButtonProps = {
   style: StyleProp<ViewStyle>;
   isDisabled?: boolean;
   isLightest?: boolean;
-};
-
-type ButtonProps = {
-  hasAcceptedTerms: boolean;
-  setOnboardingComplete?: () => void;
-  sliderRef: React.RefObject<any>;
-  slides: AppIntroSlide[];
-  styles: {
-    skipButton: StyleProp<ViewStyle>;
-    sliderButtonContainer: StyleProp<ViewStyle>;
-    sliderButtonDisabled: StyleProp<ViewStyle>;
-  };
-  termsAndConditionsAlert: () => void;
-  termsSlideIndex?: number;
-  texts: { appIntro: { continue: string; skip: string } };
 };
 
 const SliderButton = ({
@@ -65,7 +54,8 @@ const SliderButton = ({
       accessibilityLabel={`${label} ${consts.a11yLabel.button}`}
       accessibilityRole="button"
       accessibilityState={{ disabled: isDisabled }}
-      onPress={onPress}
+      disabled={isDisabled}
+      onPress={isDisabled ? undefined : onPress}
       style={buttonStyle}
     >
       <BoldText lightest={isLightest}>{label.toUpperCase()}</BoldText>
@@ -73,116 +63,55 @@ const SliderButton = ({
   );
 };
 
-const NextButton = ({
-  hasAcceptedTerms,
-  sliderRef,
-  slides,
-  styles,
-  termsAndConditionsAlert,
-  texts
-}: ButtonProps) => {
-  const currentSlideIndex = sliderRef.current?.state?.activeIndex ?? 0;
-  const currentSlide = slides[currentSlideIndex];
-  const isTermsSlide =
-    slides[currentSlideIndex]?.onLeaveSlideName === Initializer.TermsAndConditions;
+const goToIntroSlide = (
+  sliderRef: React.RefObject<any>,
+  pageNum: number,
+  triggerOnSlideChange = true,
+  reduceMotion = false
+) => {
+  const slider = sliderRef.current;
+  if (!slider) return;
 
-  const handlePress = () => {
-    if (isTermsSlide && !hasAcceptedTerms) {
-      termsAndConditionsAlert();
-      return;
-    }
+  if (!reduceMotion) {
+    slider.goToSlide(pageNum, triggerOnSlideChange);
+    return;
+  }
 
-    if (currentSlide.onLeaveSlide) {
-      currentSlide.onLeaveSlide(true);
-    }
+  const prevNum = slider.state?.activeIndex ?? 0;
+  slider.setState({ activeIndex: pageNum });
 
-    sliderRef.current?.goToSlide(currentSlideIndex + 1, true);
-  };
+  const width = slider.state?.width ?? 0;
+  const rtlSafeIndex = slider._rtlSafeIndex ? slider._rtlSafeIndex(pageNum) : pageNum;
 
-  return (
-    <SliderButton
-      label={texts.appIntro.continue}
-      onPress={handlePress}
-      style={styles.sliderButtonContainer}
-      isDisabled={isTermsSlide && !hasAcceptedTerms}
-      isLightest={!(isTermsSlide && !hasAcceptedTerms)}
-    />
-  );
+  slider.getListRef?.()?.scrollToOffset?.({
+    animated: false,
+    offset: rtlSafeIndex * width
+  });
+
+  if (triggerOnSlideChange && slider.props?.onSlideChange) {
+    slider.props.onSlideChange(pageNum, prevNum);
+  }
 };
-
-const SkipButton = ({
-  hasAcceptedTerms,
-  setOnboardingComplete,
-  sliderRef,
-  styles,
-  termsAndConditionsAlert,
-  termsSlideIndex,
-  texts
-}: ButtonProps) => {
-  const handlePress = () => {
-    if (termsSlideIndex !== -1 && !hasAcceptedTerms && sliderRef.current) {
-      sliderRef.current?.goToSlide(termsSlideIndex, true);
-      termsAndConditionsAlert();
-      return;
-    }
-
-    setOnboardingComplete();
-  };
-
-  return (
-    <SliderButton
-      label={texts.appIntro.skip}
-      onPress={handlePress}
-      style={[styles.sliderButtonContainer, styles.skipButton]}
-    />
-  );
-};
-
-const DoneButton = ({
-  hasAcceptedTerms,
-  setOnboardingComplete,
-  sliderRef,
-  slides,
-  styles,
-  termsAndConditionsAlert,
-  texts
-}: ButtonProps) => {
-  const handlePress = () => {
-    const currentSlideIndex = sliderRef.current?.state?.activeIndex ?? 0;
-    const isTermsSlide =
-      slides[currentSlideIndex]?.onLeaveSlideName === Initializer.TermsAndConditions;
-
-    if (isTermsSlide && !hasAcceptedTerms) {
-      termsAndConditionsAlert();
-      return;
-    }
-
-    setOnboardingComplete();
-  };
-
-  return (
-    <SliderButton
-      label={texts.appIntro.continue}
-      onPress={handlePress}
-      style={styles.sliderButtonContainer}
-      isLightest
-    />
-  );
-};
-
-export default NextButton;
 
 const TermsAndConditionsSection = ({
   backgroundColor,
   contentName,
-  setShowButtonTermsAndConditions
+  hasAcceptedTerms,
+  onTermsAcceptanceChange,
+  reduceMotion
 }: {
   backgroundColor?: string;
   contentName?: string;
-  setShowButtonTermsAndConditions: (value: boolean) => void;
+  hasAcceptedTerms: boolean;
+  onTermsAcceptanceChange: (value: boolean) => void;
+  reduceMotion: boolean;
 }) => {
-  const [hasAcceptedDataPrivacy, setHasAcceptedDataPrivacy] = useState(false);
+  const [hasAcceptedDataPrivacy, setHasAcceptedDataPrivacy] = useState(hasAcceptedTerms);
   const [isModalVisibleDataPrivacy, setModalVisibleDataPrivacy] = useState(false);
+
+  useEffect(() => {
+    setHasAcceptedDataPrivacy(hasAcceptedTerms);
+  }, [hasAcceptedTerms]);
 
   return (
     <View style={{ position: 'absolute', bottom: normalize(180), width: '100%' }}>
@@ -196,8 +125,9 @@ const TermsAndConditionsSection = ({
           navigate={() => setModalVisibleDataPrivacy(true)}
           linkDescription={texts.profile.privacyCheckLink}
           onPress={() => {
-            setHasAcceptedDataPrivacy(!hasAcceptedDataPrivacy);
-            setShowButtonTermsAndConditions(!hasAcceptedDataPrivacy);
+            const nextValue = !hasAcceptedDataPrivacy;
+            setHasAcceptedDataPrivacy(nextValue);
+            onTermsAcceptanceChange(nextValue);
           }}
           title={texts.profile.privacyChecked}
           uncheckedIcon={<Icon.Square color={colors.placeholder} />}
@@ -205,7 +135,7 @@ const TermsAndConditionsSection = ({
       </Wrapper>
 
       <Modal
-        animationType="slide"
+        animationType={reduceMotion ? 'none' : 'slide'}
         onRequestClose={() => setModalVisibleDataPrivacy(false)}
         presentationStyle="pageSheet"
         visible={isModalVisibleDataPrivacy}
@@ -252,12 +182,14 @@ type Props = {
 
 const renderSlide: ListRenderItem<AppIntroSlide> = ({
   backgroundColor,
+  hasAcceptedTerms,
   item,
-  setShowButtonTermsAndConditions
+  onTermsAcceptanceChange
 }: {
   backgroundColor?: string;
+  hasAcceptedTerms: boolean;
   item: AppIntroSlide;
-  setShowButtonTermsAndConditions: (value: boolean) => void;
+  onTermsAcceptanceChange: (value: boolean) => void;
 }) => {
   const ImageComponent = () => (
     <Image
@@ -305,7 +237,8 @@ const renderSlide: ListRenderItem<AppIntroSlide> = ({
         <TermsAndConditionsSection
           backgroundColor={backgroundColor}
           contentName={item.contentName}
-          setShowButtonTermsAndConditions={setShowButtonTermsAndConditions}
+          hasAcceptedTerms={hasAcceptedTerms}
+          onTermsAcceptanceChange={onTermsAcceptanceChange}
         />
       )}
     </ScrollView>
@@ -317,8 +250,10 @@ export const AppIntroScreen = ({
   onlyTermsAndConditions,
   backgroundColor = colors.surface
 }: Props) => {
+  const { isReduceMotionEnabled } = useContext(AccessibilityContext);
   const [showDoneButtonTermsAndConditions, setShowDoneButtonTermsAndConditions] = useState(true);
   const [hasAcceptedTerms, setHasAcceptedTerms] = useState(false);
+  const [activeSlideIndex, setActiveSlideIndex] = useState(0);
   const sliderRef = useRef<AppIntroSlider>(null);
 
   const { data, error, loading } = useStaticContent({
@@ -342,12 +277,26 @@ export const AppIntroScreen = ({
   const renderItem = ({ item }) =>
     renderSlide({
       backgroundColor,
+      hasAcceptedTerms,
       item,
-      setShowButtonTermsAndConditions: (value) => {
+      onTermsAcceptanceChange: (value) => {
         setShowDoneButtonTermsAndConditions(value);
         setHasAcceptedTerms(value);
-      }
+      },
+      reduceMotion: isReduceMotionEnabled
     });
+
+  useEffect(() => {
+    const hydrateTermsStatus = async () => {
+      const termsAndConditionsAccepted = await readFromStore(TERMS_AND_CONDITIONS_STORE_KEY);
+      const accepted = termsAndConditionsAccepted === 'accepted';
+
+      setHasAcceptedTerms(accepted);
+      setShowDoneButtonTermsAndConditions(accepted);
+    };
+
+    hydrateTermsStatus();
+  }, []);
 
   useEffect(() => {
     if (error || (!loading && !slides?.length)) {
@@ -367,6 +316,45 @@ export const AppIntroScreen = ({
     return null;
   }
 
+  const isTermsSlide =
+    slides?.[activeSlideIndex]?.onLeaveSlideName === Initializer.TermsAndConditions;
+  const isPrimaryActionDisabled = isTermsSlide && !hasAcceptedTerms;
+  const isLastSlide = activeSlideIndex === slides.length - 1;
+
+  const handleNext = () => {
+    if (isPrimaryActionDisabled) {
+      termsAndConditionsAlert();
+      return;
+    }
+
+    const currentSlide = slides[activeSlideIndex];
+
+    if (currentSlide?.onLeaveSlide) {
+      currentSlide.onLeaveSlide(true);
+    }
+
+    goToIntroSlide(sliderRef, activeSlideIndex + 1, true, isReduceMotionEnabled);
+  };
+
+  const handleSkip = () => {
+    if (termsSlideIndex !== -1 && !hasAcceptedTerms && sliderRef.current) {
+      goToIntroSlide(sliderRef, termsSlideIndex, true, isReduceMotionEnabled);
+      termsAndConditionsAlert();
+      return;
+    }
+
+    setOnboardingComplete();
+  };
+
+  const handleDone = () => {
+    if (isPrimaryActionDisabled) {
+      termsAndConditionsAlert();
+      return;
+    }
+
+    setOnboardingComplete();
+  };
+
   return (
     <SafeAreaViewFlex style={[styles.background, { backgroundColor }]} edges={['top', 'bottom']}>
       <StatusBar style="dark" translucent backgroundColor="transparent" />
@@ -377,43 +365,44 @@ export const AppIntroScreen = ({
         dotClickEnabled={false}
         dotStyle={onlyTermsAndConditions ? styles.hiddenDot : styles.inactiveDot}
         keyExtractor={keyExtractor}
+        onSlideChange={(index) => setActiveSlideIndex(index)}
         renderDoneButton={() => (
-          <DoneButton
-            hasAcceptedTerms={hasAcceptedTerms}
-            setOnboardingComplete={setOnboardingComplete}
-            sliderRef={sliderRef}
-            slides={slides}
-            styles={styles}
-            termsAndConditionsAlert={termsAndConditionsAlert}
-            texts={texts}
+          <SliderButton
+            label={texts.appIntro.continue}
+            onPress={handleDone}
+            style={[
+              styles.sliderButtonContainer,
+              isPrimaryActionDisabled && styles.sliderButtonDisabled
+            ]}
+            isDisabled={false}
+            isLightest={!isPrimaryActionDisabled}
           />
         )}
         renderItem={renderItem}
         ref={sliderRef}
         renderNextButton={() => (
-          <NextButton
-            hasAcceptedTerms={hasAcceptedTerms}
-            sliderRef={sliderRef}
-            slides={slides}
-            styles={styles}
-            termsAndConditionsAlert={termsAndConditionsAlert}
-            texts={texts}
+          <SliderButton
+            label={texts.appIntro.continue}
+            onPress={handleNext}
+            style={[
+              styles.sliderButtonContainer,
+              isPrimaryActionDisabled && styles.sliderButtonDisabled
+            ]}
+            isDisabled={false}
+            isLightest={!isPrimaryActionDisabled}
           />
         )}
         renderSkipButton={() => (
-          <SkipButton
-            hasAcceptedTerms={hasAcceptedTerms}
-            setOnboardingComplete={setOnboardingComplete}
-            sliderRef={sliderRef}
-            styles={styles}
-            termsAndConditionsAlert={termsAndConditionsAlert}
-            termsSlideIndex={termsSlideIndex}
-            texts={texts}
+          <SliderButton
+            label={texts.appIntro.skip}
+            onPress={handleSkip}
+            style={[styles.sliderButtonContainer, styles.skipButton]}
           />
         )}
         scrollEnabled={false}
-        showDoneButton={showDoneButtonTermsAndConditions}
-        showSkipButton
+        showDoneButton={showDoneButtonTermsAndConditions && isLastSlide}
+        showNextButton={!isLastSlide}
+        showSkipButton={!isLastSlide}
         style={device.platform === 'android' && { paddingTop: getStatusBarHeight() }}
       />
     </SafeAreaViewFlex>

--- a/src/screens/ChatbotScreen.tsx
+++ b/src/screens/ChatbotScreen.tsx
@@ -1,8 +1,16 @@
 import { useNavigation } from '@react-navigation/native';
-import React, { useContext, useEffect, useLayoutEffect, useMemo } from 'react';
+import React, { useContext, useEffect, useLayoutEffect } from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
 
-import { Button, Chat, EmptyMessage, LoadingSpinner, Wrapper } from '../components';
+import {
+  AccessibilityHeader,
+  Button,
+  Chat,
+  EmptyMessage,
+  LoadingSpinner,
+  Wrapper,
+  WrapperRow
+} from '../components';
 import { colors, Icon, normalize, texts } from '../config';
 import { useChatbot, useStaticContent } from '../hooks';
 import { NetworkContext } from '../NetworkProvider';
@@ -14,7 +22,7 @@ export const ChatbotScreen = () => {
   const { isConnected: isNetworkConnected } = useContext(NetworkContext);
   const { globalSettings } = useContext(SettingsContext);
   const { settings } = globalSettings;
-  const { chatbotType } = (settings as any) || {};
+  const chatbotType = (settings as { chatbotType?: string } | undefined)?.chatbotType;
 
   const { data: chatbotConfiguration, loading: configLoading } = useStaticContent<ChatbotConfig>({
     name: `${chatbotType}-chatbotSettings`,
@@ -48,21 +56,22 @@ export const ChatbotScreen = () => {
     };
   }, [disconnect]);
 
-  const userId = useMemo(() => {
-    return '1';
-  }, [chatbotConfiguration]);
+  const userId = '1';
 
   useLayoutEffect(() => {
     navigation.setOptions({
       headerRight: () => (
-        <TouchableOpacity
-          onPress={retry}
-          style={styles.headerButton}
-          accessibilityLabel={texts.chatbot.headerButtonAccessibilityLabel}
-          accessibilityHint={texts.chatbot.headerButtonAccessibilityHint}
-        >
-          <Icon.NamedIcon name="refresh" size={normalize(24)} color={colors.darkText} />
-        </TouchableOpacity>
+        <WrapperRow style={styles.headerRight}>
+          <AccessibilityHeader style={styles.icon} />
+          <TouchableOpacity
+            onPress={retry}
+            style={styles.headerButton}
+            accessibilityLabel={texts.chatbot.headerButtonAccessibilityLabel}
+            accessibilityHint={texts.chatbot.headerButtonAccessibilityHint}
+          >
+            <Icon.NamedIcon name="refresh" size={normalize(24)} color={colors.darkText} />
+          </TouchableOpacity>
+        </WrapperRow>
       )
     });
   }, [navigation, retry]);
@@ -120,7 +129,14 @@ export const ChatbotScreen = () => {
 };
 
 const styles = StyleSheet.create({
+  headerRight: {
+    alignItems: 'center',
+    paddingRight: normalize(8)
+  },
   headerButton: {
-    paddingHorizontal: normalize(14)
+    paddingHorizontal: normalize(10)
+  },
+  icon: {
+    paddingHorizontal: normalize(6)
   }
 });

--- a/src/screens/PdfScreen.tsx
+++ b/src/screens/PdfScreen.tsx
@@ -1,9 +1,9 @@
-import { NavigationProp } from '@react-navigation/native';
+import { NavigationProp, ParamListBase } from '@react-navigation/native';
 import React, { useContext, useEffect, useState } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import Pdf from 'react-native-pdf';
 
-import { RegularText, SafeAreaViewFlex, WrapperRow } from '../components';
+import { AccessibilityHeader, RegularText, SafeAreaViewFlex, WrapperRow } from '../components';
 import { colors, consts, Icon, normalize } from '../config';
 import { onDownloadAndSharePdf } from '../helpers';
 import { useTrackScreenViewAsync } from '../hooks';
@@ -12,7 +12,7 @@ import { NetworkContext } from '../NetworkProvider';
 const { MATOMO_TRACKING } = consts;
 
 type PdfScreenProps = {
-  navigation: NavigationProp<any>;
+  navigation: NavigationProp<ParamListBase>;
   route: { params: { pdfUrl: string; title: string; injectedJavaScript: string } };
 };
 
@@ -27,13 +27,14 @@ export const PdfScreen = ({ navigation, route }: PdfScreenProps) => {
   //       dependency
   useEffect(() => {
     isConnected && pdfUrl && trackScreenViewAsync(`${MATOMO_TRACKING.SCREEN_VIEW.PDF} / ${pdfUrl}`);
-  }, [pdfUrl]);
+  }, [isConnected, pdfUrl, trackScreenViewAsync]);
 
   useEffect(() => {
     if (title) {
       navigation.setOptions({
         headerRight: () => (
           <WrapperRow style={styles.headerRight}>
+            <AccessibilityHeader style={styles.icon} />
             <TouchableOpacity
               accessibilityLabel={`PDF herunterladen ${consts.a11yLabel.button}`}
               accessibilityRole="button"
@@ -45,7 +46,7 @@ export const PdfScreen = ({ navigation, route }: PdfScreenProps) => {
         )
       });
     }
-  }, [title]);
+  }, [navigation, pdfUrl, title]);
 
   if (!pdfUrl) return null;
 

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -621,7 +621,14 @@ export const SueReportScreen = ({
       });
     } else {
       navigation.setOptions({
-        headerRight: () => null
+        headerRight: () => (
+          <HeaderRight
+            {...{
+              navigation,
+              route
+            }}
+          />
+        )
       });
     }
   }, [storedValues, service, selectedPosition]);

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -13,6 +13,7 @@ import {
   Wrapper
 } from '../components';
 import {
+  AccessibilitySettings,
   ListSettings,
   LocationSettings,
   MowasRegionSettings,
@@ -22,6 +23,7 @@ import {
 import { colors, consts, normalize, texts } from '../config';
 import {
   addToStore,
+  getAccessibilitySettingsEntryEnabled,
   createMatomoUserId,
   matomoSettings,
   readFromStore,
@@ -47,6 +49,7 @@ const { MATOMO_TRACKING } = consts;
 const keyExtractor = (item, index) => `index${index}-item${item.title || item}`;
 
 export const SETTINGS_SCREENS = {
+  ACCESSIBILITY: 'accessibilitySettings',
   AR: 'augmentedRealitySettings',
   LIST: 'listSettings',
   LOCATION: 'locationSettings',
@@ -143,6 +146,23 @@ const renderItem = ({ item, navigation, listsWithoutArrows, settingsScreenListIt
         navigation={navigation}
       />
     );
+  } else if (item === SETTINGS_SCREENS.ACCESSIBILITY) {
+    component = (
+      <TextListItem
+        item={{
+          bottomDivider: false,
+          isHeadlineTitle: false,
+          params: {
+            setting: item,
+            title: title || texts.settingsContents.accessibility.setting
+          },
+          routeName: ScreenName.Settings,
+          title: title || texts.settingsContents.accessibility.setting
+        }}
+        listsWithoutArrows={listsWithoutArrows}
+        navigation={navigation}
+      />
+    );
   } else {
     component = <SettingsToggle needsConnection={false} item={item} />;
   }
@@ -191,6 +211,7 @@ export const onDeactivatePushNotifications = (revert) => {
     });
 };
 
+/* eslint-disable complexity */
 export const SettingsScreen = ({ navigation, route }) => {
   const { globalSettings } = useContext(SettingsContext);
   const { mowas, settings = {} } = globalSettings;
@@ -204,6 +225,8 @@ export const SettingsScreen = ({ navigation, route }) => {
 
   useMatomoTrackScreenView(MATOMO_TRACKING.SCREEN_VIEW.SETTINGS);
 
+  // settings screen structure is intentionally built once per entry state
+  /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     /* eslint-disable complexity */
     const updateData = async () => {
@@ -365,6 +388,12 @@ export const SettingsScreen = ({ navigation, route }) => {
         });
       }
 
+      if (getAccessibilitySettingsEntryEnabled(globalSettings)) {
+        settingsList.push({
+          data: [SETTINGS_SCREENS.ACCESSIBILITY]
+        });
+      }
+
       settingsList.push({
         data: [SETTINGS_SCREENS.PERMANENT_FILTER]
       });
@@ -400,6 +429,7 @@ export const SettingsScreen = ({ navigation, route }) => {
 
     setting == '' && updateData();
   }, [setting]);
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   if (setting == '' && !data.length) {
     return (
@@ -431,6 +461,9 @@ export const SettingsScreen = ({ navigation, route }) => {
     case SETTINGS_SCREENS.PERSONALIZED_PUSH:
       Component = <PersonalizedPushSettings />;
       break;
+    case SETTINGS_SCREENS.ACCESSIBILITY:
+      Component = <AccessibilitySettings />;
+      break;
     default:
       Component = (
         <SectionList
@@ -455,6 +488,7 @@ export const SettingsScreen = ({ navigation, route }) => {
 
   return <SafeAreaViewFlex>{Component}</SafeAreaViewFlex>;
 };
+/* eslint-enable complexity */
 
 const styles = StyleSheet.create({
   container: {

--- a/src/screens/WasteCollectionScreen.js
+++ b/src/screens/WasteCollectionScreen.js
@@ -16,6 +16,7 @@ import { Calendar as RNCalendar } from 'react-native-calendars';
 import { Overlay } from 'react-native-elements';
 
 import {
+  AccessibilityHeader,
   BoldText,
   Button,
   CalendarListToggle,
@@ -86,6 +87,8 @@ export const WasteCollectionScreen = ({ navigation }) => {
     texts: wasteAddressesTexts = {},
     twoStep: hasWasteAddressesTwoStep = false
   } = wasteAddresses;
+  const [selectedStreetId, setSelectedStreetId] = useState(waste.streetId);
+  const [isReset, setIsReset] = useState(false);
   const renderSuggestions = useRenderSuggestions((item) => {
     if (item?.id) {
       setSelectedStreetId(item.id);
@@ -96,7 +99,6 @@ export const WasteCollectionScreen = ({ navigation }) => {
   const { setInputValue, setInputValueCity, setInputValueCitySelected } = renderSuggestions;
   const wasteTexts = { ...texts.wasteCalendar, ...wasteAddressesTexts };
   const [isRehydrating, setIsRehydrating] = useState(false);
-  const [selectedStreetId, setSelectedStreetId] = useState(waste.streetId);
   const [showCalendar, setShowCalendar] = useState(false);
   const [isDayOverlayVisible, setIsDayOverlayVisible] = useState(false);
   const [selectedDay, setSelectedDay] = useState('');
@@ -111,7 +113,6 @@ export const WasteCollectionScreen = ({ navigation }) => {
     selectedTypes: selectedTypes || typesData
   });
   const keyboardHeight = useKeyboardHeight();
-  const [isReset, setIsReset] = useState(false);
   const query = QUERY_TYPES.WASTE_STREET;
 
   const listItems = useMemo(() => {
@@ -130,29 +131,39 @@ export const WasteCollectionScreen = ({ navigation }) => {
 
       return item.listDate >= today && hasMatchesForItem;
     });
-  }, [markedDates, selectedTypes]);
+  }, [markedDates, query, selectedTypes]);
 
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => {
     if (
       !!selectedStreetId &&
       _isArray(streetData?.wasteAddresses) &&
       !streetData.wasteAddresses.length
     ) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelectedStreetId(undefined);
       setInputValue('');
       setInputValueCity('');
       setInputValueCitySelected(false);
     }
-  }, [selectedStreetId, streetData?.wasteAddresses]);
+  }, [
+    selectedStreetId,
+    setInputValue,
+    setInputValueCity,
+    setInputValueCitySelected,
+    streetData?.wasteAddresses
+  ]);
 
   // Initializes the `selectedTypes` state based on the available waste types (`usedTypes`)
   // and the user's previously selected type keys (`waste.selectedTypeKeys`).
   // If `selectedTypeKeys` is present, it maps the keys to the corresponding values in `usedTypes`.
   // Otherwise, it defaults to selecting all available types.
   // The effect triggers whenever `usedTypes` or `waste.selectedTypeKeys` change.
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => {
     if (!usedTypes) return;
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSelectedTypes(
       Object.fromEntries(
         (waste.selectedTypeKeys ? waste.selectedTypeKeys : Object.keys(usedTypes)).map(
@@ -186,6 +197,7 @@ export const WasteCollectionScreen = ({ navigation }) => {
       headerRight: () =>
         !!streetData && !!usedTypes ? (
           <WrapperRow itemsCenter>
+            <AccessibilityHeader style={styles.icon} />
             <HeaderLeft
               onPress={goToReminder}
               backImage={({ tintColor }) => (
@@ -198,7 +210,10 @@ export const WasteCollectionScreen = ({ navigation }) => {
             )}
           </WrapperRow>
         ) : navigationType === 'drawer' ? (
-          <DrawerHeader navigation={navigation} style={[styles.icon, styles.noPaddingLeft]} />
+          <WrapperRow itemsCenter>
+            <AccessibilityHeader style={styles.icon} />
+            <DrawerHeader navigation={navigation} style={[styles.icon, styles.noPaddingLeft]} />
+          </WrapperRow>
         ) : null
     });
 
@@ -225,7 +240,16 @@ export const WasteCollectionScreen = ({ navigation }) => {
         headerLeft: () => <HeaderLeft onPress={navigation.goBack} />
       });
     }
-  }, [goToReminder, showCalendar, streetData, usedTypes, isReset, waste.streetId]);
+  }, [
+    goToReminder,
+    isReset,
+    navigation,
+    navigationType,
+    showCalendar,
+    streetData,
+    usedTypes,
+    waste.streetId
+  ]);
 
   const resetSelectedStreetId = useCallback(async () => {
     setSelectedStreetId(undefined);
@@ -233,7 +257,7 @@ export const WasteCollectionScreen = ({ navigation }) => {
     setInputValueCity('');
     setInputValueCitySelected(false);
     setIsReset(true);
-  }, []);
+  }, [setInputValue, setInputValueCity, setInputValueCitySelected]);
 
   const wasteHeader = useCallback(() => {
     return <WasteHeader locationData={locationData} onPress={resetSelectedStreetId} />;
@@ -247,7 +271,7 @@ export const WasteCollectionScreen = ({ navigation }) => {
         selectedTypes={selectedTypes}
       />
     );
-  }, [selectedStreetId, listItems, wasteHeader, query, selectedTypes]);
+  }, [selectedStreetId, listItems, query, selectedTypes]);
 
   const onDayPress = useCallback((day) => {
     setSelectedDay(day.dateString);

--- a/src/types/Accessibility.ts
+++ b/src/types/Accessibility.ts
@@ -1,8 +1,50 @@
-export type Accessibility = {
+export type AccessibilitySystemState = {
   isBoldTextEnabled: boolean;
   isGrayscaleEnabled: boolean;
   isInvertColorsEnabled: boolean;
   isReduceMotionEnabled: boolean;
   isReduceTransparencyEnabled: boolean;
   isScreenReaderEnabled: boolean;
+};
+
+export type AccessibilityTogglePreferenceKey =
+  | 'highContrastEnabled'
+  | 'readAloudEnabled'
+  | 'reduceMotionEnabled'
+  | 'reduceTransparencyEnabled';
+
+export type AccessibilityPreferenceKey = AccessibilityTogglePreferenceKey | 'textScaleLevel';
+
+export type AccessibilityUserSettings = {
+  highContrastEnabled: boolean;
+  readAloudEnabled: boolean;
+  reduceMotionEnabled: boolean;
+  reduceTransparencyEnabled: boolean;
+  textScaleLevel: number;
+};
+
+export type AccessibilityFeatureKey =
+  | 'textScaling'
+  | 'boldText'
+  | 'highContrast'
+  | 'readAloud'
+  | 'reduceMotion'
+  | 'reduceTransparency'
+  | 'headerEntry'
+  | 'settingsEntry';
+
+export type AccessibilityFeatureAvailability = Record<AccessibilityFeatureKey, boolean>;
+
+export type AccessibilityContextValue = AccessibilitySystemState & {
+  defaults: AccessibilityUserSettings;
+  features: AccessibilityFeatureAvailability;
+  isHighContrastEnabled: boolean;
+  isReadAloudEnabled: boolean;
+  preferences: AccessibilityUserSettings;
+  resetPreferences: () => void;
+  setPreference: (key: AccessibilityTogglePreferenceKey, value?: boolean) => void;
+  setPreferences: (values: Partial<AccessibilityUserSettings>) => void;
+  setTextScaleLevel: (level: number) => void;
+  system: AccessibilitySystemState;
+  textScaleMultiplier: number;
 };


### PR DESCRIPTION
With this PR, accessibility features can now be controlled from within the app.

Accessibility features are currently enabled by default, but they can be controlled and toggled on or off via `globalSettings`.

```
{
  "settings": {
    "accessibility": {
      "enabledFeatures": {
        "settingsEntry": true,
        "headerEntry": true,
        "textScaling": true,
        "boldText": true,
        "highContrast": true,
        "reduceMotion": true,
        "reduceTransparency": true,
        "readAloud": true
      },
      "defaults": {
        "textScaleLevel": 2,
        "highContrastEnabled": false,
        "reduceMotionEnabled": false,
        "reduceTransparencyEnabled": false,
        "readAloudEnabled": false
      }
    }
  }
}
```

|HomeScreen with header accessibility settings|Accessibility Settings Modal|Accessibility SettingsScreen|
|--|--|--|
<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-06-01 at 13 58 50" src="https://github.com/user-attachments/assets/fe513feb-c711-4931-92ea-2592c8a8716b" />|<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-06-01 at 13 58 54" src="https://github.com/user-attachments/assets/1793fa45-3dc6-4653-9dbc-d6e02da1f27f" />|<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-06-01 at 13 59 02" src="https://github.com/user-attachments/assets/d1ea1331-9f71-4fa3-b2c1-ad38e4f04611" />


SVAK-190