### PR TITLE
feat: add black white mode for accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "react-native-calendars": "^1.1313.0",
     "react-native-circular-progress-indicator": "^4.4.2",
     "react-native-collapsible": "1.6.1",
+    "react-native-color-matrix-image-filters": "8.0.2",
     "react-native-elements": "^3.4.3",
     "react-native-expo-image-cache": "4.1.0",
     "react-native-gesture-handler": "~2.28.0",

--- a/src/AccessibilityProvider.tsx
+++ b/src/AccessibilityProvider.tsx
@@ -28,6 +28,7 @@ const defaultSystemAccessibility: AccessibilitySystemState = {
 const defaultAccessibility: AccessibilityContextValue = {
   ...defaultSystemAccessibility,
   defaults: {
+    isGrayscaleEnabled: false,
     highContrastEnabled: false,
     readAloudEnabled: false,
     reduceMotionEnabled: false,
@@ -38,6 +39,7 @@ const defaultAccessibility: AccessibilityContextValue = {
     boldText: true,
     headerEntry: true,
     highContrast: true,
+    isGrayscaleEnabled: true,
     readAloud: true,
     reduceMotion: true,
     reduceTransparency: true,
@@ -47,6 +49,7 @@ const defaultAccessibility: AccessibilityContextValue = {
   isHighContrastEnabled: false,
   isReadAloudEnabled: false,
   preferences: {
+    isGrayscaleEnabled: false,
     highContrastEnabled: false,
     readAloudEnabled: false,
     reduceMotionEnabled: false,
@@ -215,6 +218,9 @@ export const AccessibilityProvider = ({ children }: { children?: React.ReactNode
 
   const accessibility = useMemo<AccessibilityContextValue>(() => {
     const isBoldTextEnabled = systemAccessibility.isBoldTextEnabled;
+    const isGrayscaleEnabled =
+      systemAccessibility.isGrayscaleEnabled ||
+      (features.isGrayscaleEnabled && preferences.isGrayscaleEnabled);
     const isReduceMotionEnabled =
       systemAccessibility.isReduceMotionEnabled ||
       (features.reduceMotion && preferences.reduceMotionEnabled);
@@ -230,6 +236,7 @@ export const AccessibilityProvider = ({ children }: { children?: React.ReactNode
       defaults,
       features,
       isBoldTextEnabled,
+      isGrayscaleEnabled,
       isHighContrastEnabled: features.highContrast && preferences.highContrastEnabled,
       isReadAloudEnabled: features.readAloud && preferences.readAloudEnabled,
       isReduceMotionEnabled,

--- a/src/RootView.tsx
+++ b/src/RootView.tsx
@@ -1,14 +1,17 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useFonts } from 'expo-font';
 import * as SplashScreen from 'expo-splash-screen';
-import React, { useCallback } from 'react';
+import React, { useCallback, useContext } from 'react';
 import { StyleSheet, View } from 'react-native';
 
+import { AccessibilityContext } from './AccessibilityProvider';
+import { AppWideGrayscaleFilter } from './components/AppWideGrayscaleFilter';
 import { fontConfig } from './config';
 import { SUE_REPORT_VALUES } from './screens';
 
 const RootView = ({ children }: { children: React.ReactNode }) => {
   const [isFontLoaded] = useFonts(fontConfig);
+  const { isGrayscaleEnabled } = useContext(AccessibilityContext);
 
   const onLayoutRootView = useCallback(async () => {
     if (isFontLoaded) {
@@ -28,7 +31,9 @@ const RootView = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <View style={styles.flex} onLayout={onLayoutRootView}>
-      {children}
+      <AppWideGrayscaleFilter isGrayscaleEnabled={isGrayscaleEnabled}>
+        {children}
+      </AppWideGrayscaleFilter>
     </View>
   );
 };

--- a/src/components/AppWideGrayscaleFilter.tsx
+++ b/src/components/AppWideGrayscaleFilter.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Platform, StyleSheet, View } from 'react-native';
+
+type AppWideGrayscaleFilterProps = {
+  children: React.ReactNode;
+  isGrayscaleEnabled: boolean;
+};
+
+export const AppWideGrayscaleFilter = ({
+  children,
+  isGrayscaleEnabled
+}: AppWideGrayscaleFilterProps) => {
+  if (!isGrayscaleEnabled) {
+    return <View style={styles.flex}>{children}</View>;
+  }
+
+  if (Platform.OS === 'android') {
+    return <View style={[styles.flex, styles.androidGrayscale]}>{children}</View>;
+  }
+
+  return (
+    <View style={[styles.flex, styles.isolationContext]}>
+      <View style={styles.flex}>{children}</View>
+      <View pointerEvents="none" style={styles.iosSaturationOverlay} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  androidGrayscale: {
+    filter: [{ grayscale: 1 }]
+  },
+  flex: {
+    flex: 1
+  },
+  iosSaturationOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: '#808080',
+    mixBlendMode: 'saturation'
+  },
+  isolationContext: {
+    isolation: 'isolate'
+  }
+});

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -1,7 +1,9 @@
 import { Image as ExpoImage } from 'expo-image';
+import { Grayscale } from 'react-native-color-matrix-image-filters';
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, StyleSheet, View } from 'react-native';
 
+import { AccessibilityContext } from '../AccessibilityProvider';
 import { ConfigurationsContext } from '../ConfigurationsProvider';
 import { SettingsContext } from '../SettingsProvider';
 import { colors, consts, device } from '../config';
@@ -57,6 +59,7 @@ export const Image = ({
   const [source, setSource] = useState(null);
   const [loading, setLoading] = useState(true);
 
+  const { isGrayscaleEnabled } = useContext(AccessibilityContext);
   const { globalSettings } = useContext(SettingsContext);
   const timestamp = useInterval(refreshInterval);
   const { sueConfig = {} } = useContext(ConfigurationsContext);
@@ -103,19 +106,23 @@ export const Image = ({
     [style, defaultImageStyle, borderRadius]
   );
 
+  const imageElement = (
+    <ExpoImage
+      source={source}
+      style={imageStyle}
+      contentFit={resizeMode}
+      accessible={!!sourceProp?.captionText}
+      accessibilityLabel={`${sourceProp?.captionText ? sourceProp.captionText : ''} ${
+        device.platform === 'ios' ? consts.a11yLabel.image : ''
+      }`}
+      onLoadStart={() => setLoading(true)}
+      onLoadEnd={() => setLoading(false)}
+    />
+  );
+
   return (
     <View style={[containerStyle, placeholderStyle]}>
-      <ExpoImage
-        source={source}
-        style={imageStyle}
-        contentFit={resizeMode}
-        accessible={!!sourceProp?.captionText}
-        accessibilityLabel={`${sourceProp?.captionText ? sourceProp.captionText : ''} ${
-          device.platform === 'ios' ? consts.a11yLabel.image : ''
-        }`}
-        onLoadStart={() => setLoading(true)}
-        onLoadEnd={() => setLoading(false)}
-      />
+      {isGrayscaleEnabled ? <Grayscale>{imageElement}</Grayscale> : imageElement}
 
       {(loading || showChildren) && (
         <View style={styles.overlayFill} pointerEvents="box-none">

--- a/src/components/settings/AccessibilitySettings.tsx
+++ b/src/components/settings/AccessibilitySettings.tsx
@@ -28,6 +28,12 @@ type Definition = {
 
 const SETTINGS_DEFINITIONS: Definition[] = [
   {
+    key: 'isGrayscaleEnabled',
+    featureKey: 'isGrayscaleEnabled',
+    title: texts.settingsContents.accessibility.isGrayscaleEnabled.title,
+    description: texts.settingsContents.accessibility.isGrayscaleEnabled.description
+  },
+  {
     key: 'highContrastEnabled',
     featureKey: 'highContrast',
     title: texts.settingsContents.accessibility.highContrast.title,

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -1251,6 +1251,10 @@ export const texts = {
         levelLargest: 'Extra groß',
         levelMaximum: 'Maximum'
       },
+      isGrayscaleEnabled: {
+        title: 'Graustufenmodus',
+        description: 'Stellt die App-Inhalte in Graustufen dar.'
+      },
       highContrast: {
         title: 'Höherer Kontrast',
         description: 'Reduziert kontrastarme Textfarben für bessere Lesbarkeit.'

--- a/src/helpers/accessibilitySettingsHelper.ts
+++ b/src/helpers/accessibilitySettingsHelper.ts
@@ -9,6 +9,7 @@ export const ACCESSIBILITY_FEATURE_BY_PREFERENCE: Record<
   AccessibilityTogglePreferenceKey,
   AccessibilityFeatureKey
 > = {
+  isGrayscaleEnabled: 'isGrayscaleEnabled',
   highContrastEnabled: 'highContrast',
   readAloudEnabled: 'readAloud',
   reduceMotionEnabled: 'reduceMotion',
@@ -22,6 +23,7 @@ export const DEFAULT_ACCESSIBILITY_FEATURES: AccessibilityFeatureAvailability = 
   boldText: true,
   headerEntry: true,
   highContrast: true,
+  isGrayscaleEnabled: true,
   readAloud: true,
   reduceMotion: true,
   reduceTransparency: true,
@@ -30,6 +32,7 @@ export const DEFAULT_ACCESSIBILITY_FEATURES: AccessibilityFeatureAvailability = 
 };
 
 export const DEFAULT_ACCESSIBILITY_USER_SETTINGS: AccessibilityUserSettings = {
+  isGrayscaleEnabled: false,
   highContrastEnabled: false,
   readAloudEnabled: false,
   reduceMotionEnabled: false,
@@ -112,6 +115,10 @@ export const resolveAccessibilityConfiguration = (
 
   const defaults: AccessibilityUserSettings = {
     ...DEFAULT_ACCESSIBILITY_USER_SETTINGS,
+    isGrayscaleEnabled:
+      typeof defaultSettings.isGrayscaleEnabled === 'boolean'
+        ? defaultSettings.isGrayscaleEnabled
+        : DEFAULT_ACCESSIBILITY_USER_SETTINGS.isGrayscaleEnabled,
     highContrastEnabled:
       typeof defaultSettings.highContrastEnabled === 'boolean'
         ? defaultSettings.highContrastEnabled

--- a/src/hooks/useAccessibilityPreferences.ts
+++ b/src/hooks/useAccessibilityPreferences.ts
@@ -8,6 +8,7 @@ export const useAccessibilityPreferences = () => {
   const {
     defaults,
     features,
+    isGrayscaleEnabled,
     preferences,
     resetPreferences,
     setPreference,
@@ -67,6 +68,7 @@ export const useAccessibilityPreferences = () => {
     availablePreferenceKeys,
     defaults,
     features,
+    isGrayscaleEnabled,
     isPreferenceAvailable,
     isTextScalingAvailable,
     preferences,

--- a/src/types/Accessibility.ts
+++ b/src/types/Accessibility.ts
@@ -8,6 +8,7 @@ export type AccessibilitySystemState = {
 };
 
 export type AccessibilityTogglePreferenceKey =
+  | 'isGrayscaleEnabled'
   | 'highContrastEnabled'
   | 'readAloudEnabled'
   | 'reduceMotionEnabled'
@@ -16,6 +17,7 @@ export type AccessibilityTogglePreferenceKey =
 export type AccessibilityPreferenceKey = AccessibilityTogglePreferenceKey | 'textScaleLevel';
 
 export type AccessibilityUserSettings = {
+  isGrayscaleEnabled: boolean;
   highContrastEnabled: boolean;
   readAloudEnabled: boolean;
   reduceMotionEnabled: boolean;
@@ -24,6 +26,7 @@ export type AccessibilityUserSettings = {
 };
 
 export type AccessibilityFeatureKey =
+  | 'isGrayscaleEnabled'
   | 'textScaling'
   | 'boldText'
   | 'highContrast'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4618,6 +4618,11 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz#0f79731eb8cfe1ec72acd4066efac9d61991b00d"
   integrity sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==
 
+clamp@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/clamp/-/clamp-1.0.1.tgz#66a0e64011816e37196828fdc8c8c147312c8634"
+  integrity sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA==
+
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
@@ -4794,6 +4799,13 @@ compression@^1.7.4:
     on-headers "~1.0.2"
     safe-buffer "5.2.1"
     vary "~1.1.2"
+
+concat-color-matrices@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/concat-color-matrices/-/concat-color-matrices-1.0.0.tgz#7d77baa4148264806d4318d9a2378e7dec4bc413"
+  integrity sha512-K0IMtl4m9LcHg4vVFb40Txmie/GwCJBkquGSn6wtA9yIcszzFZgGc6co4sSnjFdqeJAv+q2LrCHMUSb2GHAChA==
+  dependencies:
+    invariant "^2.2.4"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -10975,6 +10987,15 @@ react-native-collapsible@1.6.1:
   resolved "https://registry.yarnpkg.com/react-native-collapsible/-/react-native-collapsible-1.6.1.tgz#27e289831a6955aebde98abff2424a7710f36f02"
   integrity sha512-orF4BeiXd2hZW7fu9YcqIJXzN6TJcFcddY807D3MAOVktLuW9oQ+RIkrTJ5DR3v9ZOFfREkOjEmS79qeUTvkBQ==
 
+react-native-color-matrix-image-filters@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-color-matrix-image-filters/-/react-native-color-matrix-image-filters-8.0.2.tgz#24cc38deb459e03e54578964decde852ba150d19"
+  integrity sha512-RJoNJt5Mhi1ztsPdKB3kNDHMSbarrWdNkcY2gPb3G7N9Kx6TKq00hl/X90PWRk9p2lqgiD0YznD8NlxDgqgLPg==
+  dependencies:
+    concat-color-matrices "^1.0.0"
+    rn-color-matrices "^4.1.0"
+    ts-tiny-invariant "^2.0.5"
+
 react-native-communications@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-native-communications/-/react-native-communications-2.2.1.tgz#7883b56b20a002eeb790c113f8616ea8692ca795"
@@ -11692,6 +11713,13 @@ rimraf@^2.6.3:
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   dependencies:
     glob "^7.1.3"
+
+rn-color-matrices@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/rn-color-matrices/-/rn-color-matrices-4.1.0.tgz#9ac5ce3d7daaf33d336b877508649469cb39f8a5"
+  integrity sha512-a8++z3Zi4GhA0oWwKS3etdrVuVQ2q/ByTMh6lMxo+vaSv3SRSSg5SzpZk65GS0NCAqMhFT8WSvgSgNhO/F+xag==
+  dependencies:
+    clamp "^1.0.1"
 
 rsvp@^4.8.4:
   version "4.8.5"
@@ -12855,6 +12883,11 @@ ts-object-utils@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/ts-object-utils/-/ts-object-utils-0.0.5.tgz#95361cdecd7e52167cfc5e634c76345e90a26077"
   integrity sha512-iV0GvHqOmilbIKJsfyfJY9/dNHCs969z3so90dQWsO1eMMozvTpnB1MEaUbb3FYtZTGjv5sIy/xmslEz0Rg2TA==
+
+ts-tiny-invariant@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/ts-tiny-invariant/-/ts-tiny-invariant-2.0.5.tgz#20888046ede981edcddb77615a5f6e3c1ffb0901"
+  integrity sha512-NGQzWRLGLMjOUTpsxMSRj63fuFBC8HV8L4NUxzDVgU4MFeOt3qFI2534M5L+ch22x53oDEwPaRBPXgAfRjcXHA==
 
 ts-toolbelt@^6.15.1:
   version "6.15.5"


### PR DESCRIPTION
With this PR, a new accessibility feature is added that switches the entire app to black-and-white mode for users with visual impairments.

It is necessary to create a new build for testing.

|Accessibility Settings|HomeScreen|DetailScreen|
|--|--|--|
<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-06-01 at 14 09 33" src="https://github.com/user-attachments/assets/e76be039-1988-4b18-9870-d8dba8a7cdc3" />|<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-06-01 at 14 09 36" src="https://github.com/user-attachments/assets/c14d8908-e3be-4362-8f02-3b65f41e083a" />|<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-06-01 at 14 09 42" src="https://github.com/user-attachments/assets/1d878116-54dc-4004-9e59-acef44572f74" />


SVAK-190