### PR TITLE
fix(volunteer): paginate calendar event fetching

### DIFF
--- a/__tests__/queries/volunteer/calendar.test.ts
+++ b/__tests__/queries/volunteer/calendar.test.ts
@@ -1,0 +1,87 @@
+jest.mock('../../../src/helpers/volunteerHelper', () => ({
+  volunteerApiV1Url: 'https://example.test/api/v1/',
+  volunteerApiV2Url: 'https://example.test/api/v2/',
+  volunteerAuthToken: jest.fn(async () => 'token-123')
+}));
+
+jest.mock('../../../src/config', () => ({
+  colors: {
+    darkText: '#111111',
+    primary: '#008000'
+  }
+}));
+
+import { calendarAll } from '../../../src/queries/volunteer/calendar';
+
+describe('calendarAll', () => {
+  beforeEach(() => {
+    globalThis.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('merges paginated results without forwarding the app date range', async () => {
+    (globalThis.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        json: async () => ({
+          total: 2,
+          page: 1,
+          pages: 2,
+          results: [{ id: 1, title: 'First event' }]
+        })
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({
+          total: 2,
+          page: 2,
+          pages: 2,
+          results: [{ id: 2, title: 'Second event' }]
+        })
+      });
+
+    const data = await calendarAll({
+      dateRange: ['2026-06-01', '2026-06-30']
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect((globalThis.fetch as jest.Mock).mock.calls[0][0]).toBe(
+      'https://example.test/api/v2/calendar'
+    );
+    expect((globalThis.fetch as jest.Mock).mock.calls[1][0]).toBe(
+      'https://example.test/api/v2/calendar?page=2'
+    );
+    expect((globalThis.fetch as jest.Mock).mock.calls[0][1]).toMatchObject({
+      headers: {
+        Accept: 'application/json',
+        Authorization: 'Bearer token-123'
+      },
+      method: 'GET'
+    });
+    expect(data.results).toEqual([
+      { id: 1, title: 'First event' },
+      { id: 2, title: 'Second event' }
+    ]);
+  });
+
+  it('uses the container endpoint when a content container id is provided', async () => {
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
+      json: async () => ({
+        total: 1,
+        page: 1,
+        pages: 1,
+        results: [{ id: 3, title: 'Container event' }]
+      })
+    });
+
+    await calendarAll({
+      contentContainerId: 157,
+      dateRange: ['2026-06-01', '2026-06-30']
+    });
+
+    expect((globalThis.fetch as jest.Mock).mock.calls[0][0]).toBe(
+      'https://example.test/api/v2/calendar/container/157'
+    );
+  });
+});

--- a/src/queries/volunteer/calendar.ts
+++ b/src/queries/volunteer/calendar.ts
@@ -2,7 +2,6 @@ import _isNumber from 'lodash/isNumber';
 
 import { colors } from '../../config';
 import { formatTime } from '../../helpers/formatHelper';
-import { momentFormat } from '../../helpers/momentHelper';
 import {
   volunteerApiV1Url,
   volunteerApiV2Url,
@@ -25,12 +24,42 @@ export const calendarAll = async (queryVariables?: {
   };
 
   const id = queryVariables?.contentContainerId;
+  const baseUrl =
+    id && _isNumber(id)
+      ? `${volunteerApiV2Url}calendar/container/${id}`
+      : `${volunteerApiV2Url}calendar`;
 
-  if (id && _isNumber(id)) {
-    return (await fetch(`${volunteerApiV2Url}calendar/container/${id}`, fetchObj)).json();
+  const fetchPage = async (page?: number) => {
+    const searchParams = new URLSearchParams();
+
+    if (page && page > 1) {
+      searchParams.append('page', String(page));
+    }
+
+    const queryString = searchParams.toString();
+    const requestUrl = queryString ? `${baseUrl}?${queryString}` : baseUrl;
+
+    return (await fetch(requestUrl, fetchObj)).json();
+  };
+
+  const firstPage = await fetchPage();
+  const totalPages = Number(firstPage?.pages) || 1;
+
+  if (totalPages <= 1) {
+    return firstPage;
   }
 
-  return (await fetch(`${volunteerApiV2Url}calendar`, fetchObj)).json();
+  const additionalPages = await Promise.all(
+    Array.from({ length: totalPages - 1 }, (_, index) => fetchPage(index + 2))
+  );
+
+  return {
+    ...firstPage,
+    results: [
+      ...(firstPage?.results || []),
+      ...additionalPages.flatMap((page) => page?.results || [])
+    ]
+  };
 };
 
 export const calendar = async ({ id }: { id: number }) => {
@@ -131,7 +160,7 @@ export const calendarNew = async ({
   ).json();
 };
 
-export const calendarDelete = async (entryId: any) => {
+export const calendarDelete = async (entryId: number | string) => {
   const authToken = await volunteerAuthToken();
 
   const fetchObj = {


### PR DESCRIPTION
This PR fixes missing volunteer calendar events in the app by handling HumHub `api/v2/calendar` pagination correctly. The query now loads all pages and merges the results, without forwarding the app `dateRange` to that endpoint.

It also adds focused tests for paginated `calendarAll` responses and `container` URL handling, so the bug stays covered.