### PR TITLE
feat: enhance `AddressSection` with title prop and improve navigation handling

### DIFF
--- a/src/components/infoCard/AddressSection.tsx
+++ b/src/components/infoCard/AddressSection.tsx
@@ -22,10 +22,15 @@ type Props = {
   address?: Address;
   addresses?: Address[];
   openWebScreen?: (link: string, specificTitle?: string) => void;
+  title?: string;
 };
 
-const addressOnPress = (address?: string, geoLocation?: LocationObjectCoords) => {
-  const mapsString = locationString(address);
+const addressOnPress = (
+  address?: string,
+  geoLocation?: LocationObjectCoords,
+  fallbackTitle?: string
+) => {
+  const mapsString = locationString(address || fallbackTitle);
   const mapsLink = locationLink(mapsString, geoLocation);
 
   openLink(mapsLink);
@@ -48,7 +53,7 @@ const getBBNaviUrl = (baseUrl: string, address: Address, currentPosition?: Locat
   return `${baseUrl}${currentParam}/${destinationParam}/`;
 };
 
-export const AddressSection = ({ address, addresses, openWebScreen }: Props) => {
+export const AddressSection = ({ address, addresses, openWebScreen, title }: Props) => {
   // @ts-expect-error global settings are not properly typed
   const bbNaviBaseUrl = useContext(SettingsContext).globalSettings?.settings?.['bbnavi'];
   const isAddress = address || addresses?.length;
@@ -70,34 +75,35 @@ export const AddressSection = ({ address, addresses, openWebScreen }: Props) => 
     <>
       {filteredAddresses.map((item, index) => {
         const filteredAddress = formatAddress(item);
+        const hasGeoCoordinates =
+          item.geoLocation?.latitude != null && item.geoLocation?.longitude != null;
+        const addressText =
+          filteredAddress ||
+          (hasGeoCoordinates ? texts.pointOfInterest.navigationWithoutAddress : '');
+        const isNavigationPressable = !!filteredAddress?.length || hasGeoCoordinates;
 
-        if (!filteredAddress?.length) return null;
-
-        const isPressable = item.city?.length || item.street?.length || item.zip?.length;
+        if (!addressText.length) return null;
 
         const innerComponent = (
           <WrapperVertical>
             <WrapperRow centerVertical style={styles.wrap}>
               <Icon.Flag style={styles.margin} />
-              <RegularText
-                accessibilityLabel={`${a11yText.address} (${filteredAddress}) ${a11yText.button} ${a11yText.mapHint}`}
-                primary
-              >
-                {filteredAddress}
-              </RegularText>
+              <RegularText primary>{addressText}</RegularText>
             </WrapperRow>
           </WrapperVertical>
         );
 
         return (
           <View key={index}>
-            {isPressable ? (
-              <TouchableOpacity onPress={() => addressOnPress(filteredAddress, item.geoLocation)}>
-                {innerComponent}
-              </TouchableOpacity>
-            ) : (
-              innerComponent
-            )}
+            <TouchableOpacity
+              accessibilityLabel={`${a11yText.address} (${addressText}) ${a11yText.button} ${a11yText.mapHint}`}
+              accessibilityRole="button"
+              accessibilityState={{ disabled: !isNavigationPressable }}
+              disabled={!isNavigationPressable}
+              onPress={() => addressOnPress(filteredAddress, item.geoLocation, title)}
+            >
+              {innerComponent}
+            </TouchableOpacity>
 
             <Divider style={styles.divider} />
 
@@ -110,6 +116,8 @@ export const AddressSection = ({ address, addresses, openWebScreen }: Props) => 
                     <WrapperRow centerVertical style={styles.wrap}>
                       <Icon.RoutePlanner color={colors.primary} style={styles.margin} />
                       <TouchableOpacity
+                        accessibilityLabel={texts.pointOfInterest.routePlanner}
+                        accessibilityRole="button"
                         onPress={() =>
                           openWebScreen(
                             getBBNaviUrl(bbNaviBaseUrl, item, position ?? lastKnownPosition),

--- a/src/components/infoCard/InfoCard.tsx
+++ b/src/components/infoCard/InfoCard.tsx
@@ -67,7 +67,12 @@ export const InfoCard = ({
 
     {showOpeningTimes && <OpenStatus openingHours={openingHours} />}
 
-    <AddressSection address={address} addresses={addresses} openWebScreen={openWebScreen} />
+    <AddressSection
+      address={address}
+      addresses={addresses}
+      openWebScreen={openWebScreen}
+      title={name}
+    />
 
     <ContactSection contact={contact} contacts={contacts} />
 

--- a/src/components/volunteer/VolunteerUser.tsx
+++ b/src/components/volunteer/VolunteerUser.tsx
@@ -138,7 +138,7 @@ export const VolunteerUser = ({
       <Wrapper>
         <ContactSection contact={contact} />
 
-        <AddressSection address={address} openWebScreen={openWebScreen} />
+        <AddressSection address={address} openWebScreen={openWebScreen} title={name} />
 
         <UrlSection openWebScreen={openWebScreen} webUrls={webUrls} />
       </Wrapper>

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -943,6 +943,7 @@ export const texts = {
     filterByOpeningTime: 'Nur aktuell geöffnete anzeigen',
     loadMoreVouchers: 'Mehr anzeigen',
     location: 'Karte',
+    navigationWithoutAddress: 'Navigation anzeigen',
     noAvailableVehicles: 'Im Moment ist kein Fahrzeug verfügbar',
     openingTime: 'Öffnungszeiten',
     operatingCompany: 'Anbieter',

--- a/src/helpers/mapHelper.js
+++ b/src/helpers/mapHelper.js
@@ -17,14 +17,21 @@ export function locationString(address) {
  */
 export function locationLink(mapsString, geoLocation) {
   const coords = geoLocation ? `${geoLocation.latitude},${geoLocation.longitude}` : undefined;
+  const query = mapsString || coords;
 
   switch (device.platform) {
     case 'ios':
-      return coords ? `maps:?q=${mapsString}&ll=${coords}` : `maps:?q=${mapsString}`;
+      return coords ? `maps:?q=${query}&ll=${coords}` : `maps:?q=${mapsString}`;
     case 'android':
-      return coords ? `geo:${coords}?q=${coords}(${mapsString})` : `geo:0,0?q=${mapsString}`;
+      if (coords) {
+        return mapsString
+          ? `geo:${coords}?q=${coords}(${mapsString})`
+          : `geo:${coords}?q=${coords}`;
+      }
+
+      return `geo:0,0?q=${mapsString}`;
     default:
-      return `https://maps.google.com/?q=${mapsString}`;
+      return `https://maps.google.com/?q=${query || mapsString}`;
   }
 }
 


### PR DESCRIPTION
With this PR, coordinate data has been added so that users are still redirected to the map app and navigation works even if no address data is available.

|before detail screen|after detail screen|maps|
|--|--|--|
<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-06-05 at 14 48 27" src="https://github.com/user-attachments/assets/169e8590-2415-4c98-a018-87885c94100f" />|<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-06-05 at 14 47 47" src="https://github.com/user-attachments/assets/09e81b0b-0988-4d0c-8ac5-75258b60616d" />|<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-06-05 at 14 47 56" src="https://github.com/user-attachments/assets/0cbc2a84-f191-4455-9644-7adfb959b182" />

SVA-1725