### PR TITLE
feat: make `CircularProgress` responsive

### DIFF
--- a/src/components/vouchers/VoucherRedeem.tsx
+++ b/src/components/vouchers/VoucherRedeem.tsx
@@ -203,9 +203,11 @@ export const VoucherRedeem = ({
 
                   <CircularProgress
                     activeStrokeColor={colors.lighterPrimary}
+                    activeStrokeWidth={normalize(10)}
                     inActiveStrokeColor={colors.primary}
+                    inActiveStrokeWidth={normalize(10)}
                     maxValue={100}
-                    radius={120}
+                    radius={normalize(110)}
                     showProgressValue={false}
                     subtitle={texts.voucher.detailScreen.progressSubtitle}
                     subtitleColor={colors.surface}
@@ -215,7 +217,7 @@ export const VoucherRedeem = ({
                       '0'
                     )}`}
                     titleColor={colors.surface}
-                    titleFontSize={normalize(50)}
+                    titleFontSize={normalize(45)}
                     titleStyle={styles.progressTitle}
                     value={((defaultTime - remainingTime) / defaultTime) * 100}
                   />


### PR DESCRIPTION
This PR makes the coupon modal responsive

|before|after|
|--|--|
<img width="200" alt="gutschein-timer-iphone-mini-12" src="https://github.com/user-attachments/assets/788650e4-8c00-4c3e-868c-263de8bdfd83" />|<img width="200" alt="Simulator Screenshot - iPhone 13 mini - 2026-06-11 at 16 02 35" src="https://github.com/user-attachments/assets/71416a87-d060-4b46-a619-739f31d39e66" />


SVASD-584