### PR TITLE
fix(waste): stabilize keyboard handling in waste autocomplete

### DIFF
--- a/__tests__/components/wasteAutocompleteLayout.test.ts
+++ b/__tests__/components/wasteAutocompleteLayout.test.ts
@@ -1,10 +1,10 @@
 import {
   getAutocompleteKeyboardMarginBottom,
   getAutocompleteListContainerHeight,
-  getAutocompleteMaxKeyboardHeight
+  getAutocompleteMaxDropdownHeight
 } from '../../src/components/waste/autocompleteLayout';
 
-describe('getAutocompleteKeyboardMarginBottom', () => {
+describe('waste autocomplete layout helpers', () => {
   it('does not add keyboard margin on Android because the window is already resized', () => {
     expect(getAutocompleteKeyboardMarginBottom({ keyboardHeight: 320, platform: 'android' })).toBe(
       0
@@ -20,8 +20,7 @@ describe('getAutocompleteKeyboardMarginBottom', () => {
       getAutocompleteListContainerHeight({
         height: 600,
         keyboardHeight: 320,
-        maxKeyboardHeight: 300,
-        platform: 'android'
+        maxDropdownHeight: 300
       })
     ).toBe(300);
   });
@@ -31,8 +30,7 @@ describe('getAutocompleteKeyboardMarginBottom', () => {
       getAutocompleteListContainerHeight({
         height: 180,
         keyboardHeight: 320,
-        maxKeyboardHeight: 300,
-        platform: 'android'
+        maxDropdownHeight: 300
       })
     ).toBe(180);
   });
@@ -42,8 +40,7 @@ describe('getAutocompleteKeyboardMarginBottom', () => {
       getAutocompleteListContainerHeight({
         height: 600,
         keyboardHeight: 320,
-        maxKeyboardHeight: 300,
-        platform: 'ios'
+        maxDropdownHeight: 300
       })
     ).toBe(300);
   });
@@ -53,15 +50,14 @@ describe('getAutocompleteKeyboardMarginBottom', () => {
       getAutocompleteListContainerHeight({
         height: 600,
         keyboardHeight: 0,
-        maxKeyboardHeight: 300,
-        platform: 'ios'
+        maxDropdownHeight: 300
       })
     ).toBe(600);
   });
 
   it('uses a lower max dropdown height on iOS than on Android', () => {
     expect(
-      getAutocompleteMaxKeyboardHeight({
+      getAutocompleteMaxDropdownHeight({
         androidMaxHeight: 230,
         iosMaxHeight: 200,
         platform: 'ios'
@@ -69,7 +65,7 @@ describe('getAutocompleteKeyboardMarginBottom', () => {
     ).toBe(200);
 
     expect(
-      getAutocompleteMaxKeyboardHeight({
+      getAutocompleteMaxDropdownHeight({
         androidMaxHeight: 230,
         iosMaxHeight: 200,
         platform: 'android'

--- a/__tests__/components/wasteAutocompleteLayout.test.ts
+++ b/__tests__/components/wasteAutocompleteLayout.test.ts
@@ -1,0 +1,79 @@
+import {
+  getAutocompleteKeyboardMarginBottom,
+  getAutocompleteListContainerHeight,
+  getAutocompleteMaxKeyboardHeight
+} from '../../src/components/waste/autocompleteLayout';
+
+describe('getAutocompleteKeyboardMarginBottom', () => {
+  it('does not add keyboard margin on Android because the window is already resized', () => {
+    expect(getAutocompleteKeyboardMarginBottom({ keyboardHeight: 320, platform: 'android' })).toBe(
+      0
+    );
+  });
+
+  it('keeps the keyboard margin on iOS', () => {
+    expect(getAutocompleteKeyboardMarginBottom({ keyboardHeight: 320, platform: 'ios' })).toBe(320);
+  });
+
+  it('limits tall Android lists while the keyboard is visible', () => {
+    expect(
+      getAutocompleteListContainerHeight({
+        height: 600,
+        keyboardHeight: 320,
+        maxKeyboardHeight: 300,
+        platform: 'android'
+      })
+    ).toBe(300);
+  });
+
+  it('keeps short Android lists at their natural height while the keyboard is visible', () => {
+    expect(
+      getAutocompleteListContainerHeight({
+        height: 180,
+        keyboardHeight: 320,
+        maxKeyboardHeight: 300,
+        platform: 'android'
+      })
+    ).toBe(180);
+  });
+
+  it('limits tall iOS lists while the keyboard is visible', () => {
+    expect(
+      getAutocompleteListContainerHeight({
+        height: 600,
+        keyboardHeight: 320,
+        maxKeyboardHeight: 300,
+        platform: 'ios'
+      })
+    ).toBe(300);
+  });
+
+  it('keeps list height unchanged when the keyboard is hidden', () => {
+    expect(
+      getAutocompleteListContainerHeight({
+        height: 600,
+        keyboardHeight: 0,
+        maxKeyboardHeight: 300,
+        platform: 'ios'
+      })
+    ).toBe(600);
+  });
+
+  it('uses a lower max dropdown height on iOS than on Android', () => {
+    expect(
+      getAutocompleteMaxKeyboardHeight({
+        androidMaxHeight: 230,
+        iosMaxHeight: 200,
+        platform: 'ios'
+      })
+    ).toBe(200);
+
+    expect(
+      getAutocompleteMaxKeyboardHeight({
+        androidMaxHeight: 230,
+        iosMaxHeight: 200,
+        platform: 'android'
+      })
+    ).toBe(230);
+  });
+});

--- a/src/components/DefaultKeyboardAvoidingView.tsx
+++ b/src/components/DefaultKeyboardAvoidingView.tsx
@@ -4,12 +4,19 @@ import { KeyboardAvoidingView, StyleSheet } from 'react-native';
 
 import { device } from '../config';
 
-export const DefaultKeyboardAvoidingView = ({ children }: { children: React.ReactNode }) => {
+export const DefaultKeyboardAvoidingView = ({
+  children,
+  enabled
+}: {
+  children: React.ReactNode;
+  enabled?: boolean;
+}) => {
   const headerHeight = useHeaderHeight();
 
   return (
     <KeyboardAvoidingView
       behavior={device.platform === 'ios' ? 'padding' : 'height'}
+      enabled={enabled ?? true}
       keyboardVerticalOffset={headerHeight}
       style={styles.flex}
     >

--- a/src/components/waste/WasteCityInput.tsx
+++ b/src/components/waste/WasteCityInput.tsx
@@ -9,6 +9,12 @@ import { SettingsContext } from '../../SettingsProvider';
 import { Label } from '../Label';
 import { Wrapper } from '../Wrapper';
 
+import {
+  getAutocompleteKeyboardMarginBottom,
+  getAutocompleteListContainerHeight,
+  getAutocompleteMaxKeyboardHeight
+} from './autocompleteLayout';
+
 type Props = {
   isFocused: boolean;
   renderSuggestions: {
@@ -94,8 +100,22 @@ export const WasteCityInput = ({
         listContainerStyle={[
           styles.autoCompleteListContainer,
           {
-            height: inputValueCitySelected ? undefined : listContainerHeight,
-            marginBottom: keyboardHeight
+            height: inputValueCitySelected
+              ? undefined
+              : getAutocompleteListContainerHeight({
+                  height: listContainerHeight,
+                  keyboardHeight,
+                  maxKeyboardHeight: getAutocompleteMaxKeyboardHeight({
+                    androidMaxHeight: normalize(250),
+                    iosMaxHeight: normalize(220),
+                    platform: device.platform
+                  }),
+                  platform: device.platform
+                }),
+            marginBottom: getAutocompleteKeyboardMarginBottom({
+              keyboardHeight,
+              platform: device.platform
+            })
           }
         ]}
         onBlur={() => setIsFocused(false)}

--- a/src/components/waste/WasteCityInput.tsx
+++ b/src/components/waste/WasteCityInput.tsx
@@ -12,7 +12,7 @@ import { Wrapper } from '../Wrapper';
 import {
   getAutocompleteKeyboardMarginBottom,
   getAutocompleteListContainerHeight,
-  getAutocompleteMaxKeyboardHeight
+  getAutocompleteMaxDropdownHeight
 } from './autocompleteLayout';
 
 type Props = {
@@ -105,12 +105,11 @@ export const WasteCityInput = ({
               : getAutocompleteListContainerHeight({
                   height: listContainerHeight,
                   keyboardHeight,
-                  maxKeyboardHeight: getAutocompleteMaxKeyboardHeight({
+                  maxDropdownHeight: getAutocompleteMaxDropdownHeight({
                     androidMaxHeight: normalize(250),
                     iosMaxHeight: normalize(220),
                     platform: device.platform
-                  }),
-                  platform: device.platform
+                  })
                 }),
             marginBottom: getAutocompleteKeyboardMarginBottom({
               keyboardHeight,

--- a/src/components/waste/WasteStreetInput.tsx
+++ b/src/components/waste/WasteStreetInput.tsx
@@ -13,7 +13,7 @@ import { Wrapper } from '../Wrapper';
 import {
   getAutocompleteKeyboardMarginBottom,
   getAutocompleteListContainerHeight,
-  getAutocompleteMaxKeyboardHeight
+  getAutocompleteMaxDropdownHeight
 } from './autocompleteLayout';
 
 type Props = {
@@ -92,12 +92,11 @@ export const WasteStreetInput = ({ isFocused, renderSuggestions, setIsFocused }:
             height: getAutocompleteListContainerHeight({
               height: listContainerHeight,
               keyboardHeight,
-              maxKeyboardHeight: getAutocompleteMaxKeyboardHeight({
+              maxDropdownHeight: getAutocompleteMaxDropdownHeight({
                 androidMaxHeight: normalize(230),
                 iosMaxHeight: normalize(200),
                 platform: device.platform
-              }),
-              platform: device.platform
+              })
             }),
             marginBottom: getAutocompleteKeyboardMarginBottom({
               keyboardHeight,

--- a/src/components/waste/WasteStreetInput.tsx
+++ b/src/components/waste/WasteStreetInput.tsx
@@ -10,6 +10,12 @@ import { Label } from '../Label';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { Wrapper } from '../Wrapper';
 
+import {
+  getAutocompleteKeyboardMarginBottom,
+  getAutocompleteListContainerHeight,
+  getAutocompleteMaxKeyboardHeight
+} from './autocompleteLayout';
+
 type Props = {
   isFocused: boolean;
   renderSuggestions: {
@@ -82,7 +88,22 @@ export const WasteStreetInput = ({ isFocused, renderSuggestions, setIsFocused }:
         inputContainerStyle={styles.autoCompleteInputContainer}
         listContainerStyle={[
           styles.autoCompleteListContainer,
-          { height: listContainerHeight, marginBottom: keyboardHeight }
+          {
+            height: getAutocompleteListContainerHeight({
+              height: listContainerHeight,
+              keyboardHeight,
+              maxKeyboardHeight: getAutocompleteMaxKeyboardHeight({
+                androidMaxHeight: normalize(230),
+                iosMaxHeight: normalize(200),
+                platform: device.platform
+              }),
+              platform: device.platform
+            }),
+            marginBottom: getAutocompleteKeyboardMarginBottom({
+              keyboardHeight,
+              platform: device.platform
+            })
+          }
         ]}
         onBlur={() => setIsFocused(false)}
         onChangeText={(text) => setInputValue(text)}

--- a/src/components/waste/autocompleteLayout.ts
+++ b/src/components/waste/autocompleteLayout.ts
@@ -3,12 +3,13 @@ type AutocompleteKeyboardMarginBottomParams = {
   platform: string;
 };
 
-type AutocompleteListContainerHeightParams = AutocompleteKeyboardMarginBottomParams & {
+type AutocompleteListContainerHeightParams = {
   height: number | string;
-  maxKeyboardHeight: number;
+  keyboardHeight: number;
+  maxDropdownHeight: number;
 };
 
-type AutocompleteMaxKeyboardHeightParams = {
+type AutocompleteMaxDropdownHeightParams = {
   androidMaxHeight: number;
   iosMaxHeight: number;
   platform: string;
@@ -22,17 +23,17 @@ export const getAutocompleteKeyboardMarginBottom = ({
 export const getAutocompleteListContainerHeight = ({
   height,
   keyboardHeight,
-  maxKeyboardHeight
+  maxDropdownHeight
 }: AutocompleteListContainerHeightParams) => {
   if (!keyboardHeight || typeof height !== 'number') {
     return height;
   }
 
-  return Math.min(height, maxKeyboardHeight);
+  return Math.min(height, maxDropdownHeight);
 };
 
-export const getAutocompleteMaxKeyboardHeight = ({
+export const getAutocompleteMaxDropdownHeight = ({
   androidMaxHeight,
   iosMaxHeight,
   platform
-}: AutocompleteMaxKeyboardHeightParams) => (platform === 'ios' ? iosMaxHeight : androidMaxHeight);
+}: AutocompleteMaxDropdownHeightParams) => (platform === 'ios' ? iosMaxHeight : androidMaxHeight);

--- a/src/components/waste/autocompleteLayout.ts
+++ b/src/components/waste/autocompleteLayout.ts
@@ -1,0 +1,38 @@
+type AutocompleteKeyboardMarginBottomParams = {
+  keyboardHeight: number;
+  platform: string;
+};
+
+type AutocompleteListContainerHeightParams = AutocompleteKeyboardMarginBottomParams & {
+  height: number | string;
+  maxKeyboardHeight: number;
+};
+
+type AutocompleteMaxKeyboardHeightParams = {
+  androidMaxHeight: number;
+  iosMaxHeight: number;
+  platform: string;
+};
+
+export const getAutocompleteKeyboardMarginBottom = ({
+  keyboardHeight,
+  platform
+}: AutocompleteKeyboardMarginBottomParams) => (platform === 'android' ? 0 : keyboardHeight);
+
+export const getAutocompleteListContainerHeight = ({
+  height,
+  keyboardHeight,
+  maxKeyboardHeight
+}: AutocompleteListContainerHeightParams) => {
+  if (!keyboardHeight || typeof height !== 'number') {
+    return height;
+  }
+
+  return Math.min(height, maxKeyboardHeight);
+};
+
+export const getAutocompleteMaxKeyboardHeight = ({
+  androidMaxHeight,
+  iosMaxHeight,
+  platform
+}: AutocompleteMaxKeyboardHeightParams) => (platform === 'ios' ? iosMaxHeight : androidMaxHeight);

--- a/src/screens/WasteCollectionScreen.js
+++ b/src/screens/WasteCollectionScreen.js
@@ -262,7 +262,7 @@ export const WasteCollectionScreen = ({ navigation }) => {
     <SafeAreaViewFlex>
       {!hasHeaderSearchBarOption ? (
         !selectedStreetId ? (
-          <DefaultKeyboardAvoidingView>
+          <DefaultKeyboardAvoidingView enabled={device.platform === 'ios'}>
             <Wrapper>
               <RegularText small>
                 {hasWasteAddressesTwoStep ? wasteTexts.hintCityAndStreet : wasteTexts.hintStreet}


### PR DESCRIPTION
This PR fixes keyboard-related layout issues in the waste calendar autocomplete inputs on mobile.

## Changes

- disable `KeyboardAvoidingView` for the waste collection search state where it caused flickering during keyboard open/resize
- add shared autocomplete layout helpers in `src/components/waste/autocompleteLayout.ts`
- limit autocomplete dropdown height while the keyboard is visible
- use platform-specific dropdown height limits, with lower limits on iOS than on Android
- allow a slightly larger dropdown for the city input than for the street input
- add focused tests for the autocomplete layout helper behavior

## Why

The waste autocomplete had two conflicting problems:

- on Android, opening the keyboard caused visible flickering because the screen resized in multiple ways at once
- after removing that flicker, some suggestion items became hard to reach or the list could scroll too far and show too much empty space

This change makes the dropdown behavior stable and keeps the suggestion list usable on both platforms.

## Testing

- ran `yarn test __tests__/components/wasteAutocompleteLayout.test.ts --runInBand`
- ran `prettier --check` on the touched files

## Notes

- iOS uses lower dropdown height limits than Android
- the city input uses a slightly higher limit than the street input

SVASD-603