### PR TITLE
fix: refresh defect report categories on form load

### DIFF
--- a/__tests__/screens/DefectReportFormScreen.test.js
+++ b/__tests__/screens/DefectReportFormScreen.test.js
@@ -1,0 +1,78 @@
+/* eslint-disable @typescript-eslint/no-var-requires, react/prop-types */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+import { NetworkContext } from '../../src/NetworkProvider';
+import { DefectReportFormScreen } from '../../src/screens/DefectReport';
+import { SettingsContext, initialContext } from '../../src/SettingsProvider';
+
+const mockUseQuery = jest.fn();
+
+jest.mock('react-apollo', () => ({
+  useQuery: (...args) => mockUseQuery(...args)
+}));
+
+jest.mock('../../src/components/index.js', () => {
+  const { View } = require('react-native');
+
+  return {
+    DefaultKeyboardAvoidingView: ({ children }) => <View>{children}</View>,
+    DefectReportCreateForm: () => <View />,
+    DefectReportLocationForm: () => <View />,
+    HtmlView: () => <View />,
+    LoadingContainer: ({ children }) => <View>{children}</View>,
+    SafeAreaViewFlex: ({ children }) => <View>{children}</View>,
+    Wrapper: ({ children }) => <View>{children}</View>
+  };
+});
+
+jest.mock('../../src/hooks', () => ({
+  useStaticContent: jest.fn(() => ({
+    data: undefined,
+    loading: true,
+    refetch: jest.fn()
+  }))
+}));
+
+describe('DefectReportFormScreen', () => {
+  const navigation = { goBack: jest.fn(), navigate: jest.fn() };
+  const route = {};
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: true,
+      refetch: jest.fn()
+    });
+  });
+
+  it('fetches defect report categories from the network when opening the form', async () => {
+    const globalSettings = {
+      ...initialContext.globalSettings,
+      settings: {
+        defectReports: {
+          categoryId: 123
+        }
+      }
+    };
+
+    await act(async () => {
+      renderer.create(
+        <NetworkContext.Provider value={{ isConnected: true, isMainserverUp: true }}>
+          <SettingsContext.Provider value={{ ...initialContext, globalSettings }}>
+            <DefectReportFormScreen navigation={navigation} route={route} />
+          </SettingsContext.Provider>
+        </NetworkContext.Provider>
+      );
+    });
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        variables: { ids: [123] },
+        fetchPolicy: 'network-only',
+        skip: false
+      })
+    );
+  });
+});

--- a/src/screens/DefectReport/DefectReportFormScreen.tsx
+++ b/src/screens/DefectReport/DefectReportFormScreen.tsx
@@ -14,6 +14,7 @@ import {
   Wrapper
 } from '../../components';
 import { colors } from '../../config';
+import { graphqlFetchPolicy } from '../../helpers/graphqlHelper';
 import { useStaticContent } from '../../hooks';
 import { NetworkContext } from '../../NetworkProvider';
 import { GET_CATEGORIES } from '../../queries/categories';
@@ -24,10 +25,10 @@ export const DefectReportFormScreen = ({
   navigation,
   route
 }: {
-  navigation: StackNavigationProp<any>;
-  route: any;
+  navigation: StackNavigationProp<Record<string, object | undefined>>;
+  route: { params?: { consentForDataProcessingText?: string } };
 }) => {
-  const { isConnected } = useContext(NetworkContext);
+  const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const { globalSettings } = useContext(SettingsContext);
   const [refreshing, setRefreshing] = useState(false);
   const [isLocationSelect, setIsLocationSelect] = useState(true);
@@ -52,6 +53,7 @@ export const DefectReportFormScreen = ({
     refetch: refetchCategories
   } = useQuery(GET_CATEGORIES, {
     variables: { ids: [categoryId] },
+    fetchPolicy: graphqlFetchPolicy({ isConnected, isMainserverUp }),
     skip: !categoryId
   });
 
@@ -62,7 +64,7 @@ export const DefectReportFormScreen = ({
       await refetchCategories?.();
     }
     setRefreshing(false);
-  }, [isConnected, refetchHtml]);
+  }, [isConnected, refetchCategories, refetchHtml]);
 
   if (loadingHtml || loadingCategories) {
     return (


### PR DESCRIPTION
Fixes stale defect report categories in installed apps. The defect report form now fetches category dropdown data from the network when online, instead of relying indefinitely on persisted Apollo cache data. Offline fallback behavior remains unchanged. A regression test was added for the expected fetch policy.