### PR TITLE
fix: keep filter actions above Android navigation

### DIFF
--- a/src/components/filter/Filter.tsx
+++ b/src/components/filter/Filter.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from 'react';
 import { Modal, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import Collapsible from 'react-native-collapsible';
 import { Divider, Header } from 'react-native-elements';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { Icon, colors, consts, normalize, texts } from '../../config';
 import { momentFormat } from '../../helpers';
@@ -217,54 +218,56 @@ export const Filter = ({
               </Wrapper>
             </ScrollView>
 
-            <Wrapper style={styles.alignLeft} noPaddingTop>
-              <WrapperRow style={{ gap: normalize(16) }}>
-                <Button
-                  disabled={!!isNoFilterSet}
-                  invert
-                  notFullWidth
-                  onPress={resetFilters}
-                  title={texts.filter.resetFilter}
-                />
-                <Button
-                  disabled={!!isNoFilterSet}
-                  notFullWidth
-                  onPress={() => {
-                    let dateRange = filters.dateRange || null;
+            <SafeAreaView edges={['bottom']}>
+              <Wrapper style={styles.alignLeft} noPaddingTop>
+                <WrapperRow style={{ gap: normalize(16) }}>
+                  <Button
+                    disabled={!!isNoFilterSet}
+                    invert
+                    notFullWidth
+                    onPress={resetFilters}
+                    title={texts.filter.resetFilter}
+                  />
+                  <Button
+                    disabled={!!isNoFilterSet}
+                    notFullWidth
+                    onPress={() => {
+                      let dateRange = filters.dateRange || null;
 
-                    if (filters.start_date && filters.end_date) {
-                      dateRange = [
-                        momentFormat(filters.start_date, 'YYYY-MM-DD'),
-                        momentFormat(filters.end_date, 'YYYY-MM-DD')
-                      ];
-                    } else if (filters.start_date && !filters.end_date) {
-                      // because of the requirement to specify the start and end date of the `dateRange`,
-                      // if only `startDate` is selected, `endDate` is set to 31.12.9999
-                      dateRange = [momentFormat(filters.start_date, 'YYYY-MM-DD'), '9999-12-31'];
-                    } else if (!filters.start_date && filters.end_date) {
-                      // because of the requirement to specify the start and end date of the `dateRange`,
-                      // if only `endDate` is selected, `startDate` is set to today's date or if
-                      // `endDate` is in the past, it is set to the date of the `endDate`
-                      dateRange = [
-                        moment().isAfter(filters.end_date)
-                          ? momentFormat(filters.end_date, 'YYYY-MM-DD')
-                          : moment().format('YYYY-MM-DD'),
-                        momentFormat(filters.end_date, 'YYYY-MM-DD')
-                      ];
-                    }
+                      if (filters.start_date && filters.end_date) {
+                        dateRange = [
+                          momentFormat(filters.start_date, 'YYYY-MM-DD'),
+                          momentFormat(filters.end_date, 'YYYY-MM-DD')
+                        ];
+                      } else if (filters.start_date && !filters.end_date) {
+                        // because of the requirement to specify the start and end date of the `dateRange`,
+                        // if only `startDate` is selected, `endDate` is set to 31.12.9999
+                        dateRange = [momentFormat(filters.start_date, 'YYYY-MM-DD'), '9999-12-31'];
+                      } else if (!filters.start_date && filters.end_date) {
+                        // because of the requirement to specify the start and end date of the `dateRange`,
+                        // if only `endDate` is selected, `startDate` is set to today's date or if
+                        // `endDate` is in the past, it is set to the date of the `endDate`
+                        dateRange = [
+                          moment().isAfter(filters.end_date)
+                            ? momentFormat(filters.end_date, 'YYYY-MM-DD')
+                            : moment().format('YYYY-MM-DD'),
+                          momentFormat(filters.end_date, 'YYYY-MM-DD')
+                        ];
+                      }
 
-                    if (dateRange?.length) {
-                      setQueryVariables({ ...filters, dateRange });
-                    } else {
-                      setQueryVariables({ ...filters });
-                    }
+                      if (dateRange?.length) {
+                        setQueryVariables({ ...filters, dateRange });
+                      } else {
+                        setQueryVariables({ ...filters });
+                      }
 
-                    setIsCollapsed(!isCollapsed);
-                  }}
-                  title={texts.filter.filter}
-                />
-              </WrapperRow>
-            </Wrapper>
+                      setIsCollapsed(!isCollapsed);
+                    }}
+                    title={texts.filter.filter}
+                  />
+                </WrapperRow>
+              </Wrapper>
+            </SafeAreaView>
           </Modal>
         ) : (
           <Collapsible collapsed={isCollapsed}>

--- a/src/components/vouchers/VoucherRedeem.tsx
+++ b/src/components/vouchers/VoucherRedeem.tsx
@@ -13,6 +13,7 @@ import { REDEEM_QUOTA_OF_VOUCHER } from '../../queries/vouchers';
 import { TQuota, TVoucherDates } from '../../types';
 import { Button } from '../Button';
 import { Checkbox } from '../Checkbox';
+import { SafeAreaViewFlex } from '../SafeAreaViewFlex';
 import { BoldText, RegularText } from '../Text';
 import { Touchable } from '../Touchable';
 import { Wrapper, WrapperRow, WrapperVertical } from '../Wrapper';
@@ -156,7 +157,7 @@ export const VoucherRedeem = ({
         visible={isVisible}
         supportedOrientations={['landscape', 'portrait']}
       >
-        <View style={styles.sheetBackgroundContainer}>
+        <SafeAreaViewFlex edges={['bottom']} style={styles.sheetBackgroundContainer}>
           <View style={styles.sheetContainer}>
             {isExpiredVoucher ? (
               <WrapperVertical>
@@ -315,7 +316,7 @@ export const VoucherRedeem = ({
               </WrapperVertical>
             )}
           </View>
-        </View>
+        </SafeAreaViewFlex>
       </Modal>
     </>
   );


### PR DESCRIPTION
This PR resolves the issue where the filter buttons were hidden behind the Android navigation buttons

|before|after|
|--|--|
<img width="200" alt="1000000125" src="https://github.com/user-attachments/assets/94a3ae33-a580-478a-ba0e-c856fe0dd07a" />|<img width="200" alt="1000000131" src="https://github.com/user-attachments/assets/b00bdb8e-5cab-48c6-a0bd-852c41562974" />



SVASD-592